### PR TITLE
Adding tests for FEEL constants

### DIFF
--- a/TestCases/compliance-level-2/0100-feel-constants/0100-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0100-feel-constants/0100-feel-constants-test-01.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.omg.org/spec/DMN/20160719/testcase ../../testCases.xsd">
+	<modelName>0100-feel-constants.dmn</modelName>
+	<labels>
+	    <label>Compliance Level 2</label>
+		<label>Literal Expression</label>
+	    <label>FEEL constants</label>
+	    <label>Data Type: Boolean</label>
+	</labels>
+	<testCase id="001"> 
+		<description>Tests FEEL boolean constants</description>
+		<resultNode name="Decision1" type="decision">
+			<expected>
+				<value>true</value>
+			</expected>
+		</resultNode>
+	    <resultNode name="Decision2" type="decision">
+	        <expected>
+	            <value>false</value>
+	        </expected>
+	    </resultNode>
+	</testCase>
+</testCases>

--- a/TestCases/compliance-level-2/0100-feel-constants/0100-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0100-feel-constants/0100-feel-constants-test-01.xml
@@ -6,7 +6,7 @@
 	<labels>
 	    <label>Compliance Level 2</label>
 		<label>Literal Expression</label>
-	    <label>FEEL constants</label>
+	    <label>FEEL Constants</label>
 	    <label>Data Type: Boolean</label>
 	</labels>
 	<testCase id="001"> 

--- a/TestCases/compliance-level-2/0100-feel-constants/0100-feel-constants.dmn
+++ b/TestCases/compliance-level-2/0100-feel-constants/0100-feel-constants.dmn
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_feel-constants" name="feel-constants"
+	namespace="https://github.com/dmn-tck/tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+	<decision name="Decision1" id="d_Decision1">
+		<variable name="Decision1" typeRef="feel:boolean"/>
+		<literalExpression>
+			<text>true</text>
+		</literalExpression>
+	</decision>
+    <decision name="Decision2" id="d_Decision2">
+        <variable name="Decision2" typeRef="feel:boolean"/>
+        <literalExpression>
+            <text>false</text>
+        </literalExpression>
+    </decision>
+</definitions>

--- a/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants-test-01.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.omg.org/spec/DMN/20160719/testcase ../../testCases.xsd">
+	<modelName>0101-feel-constants.dmn</modelName>
+	<labels>
+	    <label>Compliance Level 2</label>
+		<label>Literal Expression</label>
+	    <label>FEEL constants</label>
+	    <label>Data Type: Number</label>
+	</labels>
+	<testCase id="001"> 
+		<description>Tests FEEL number constants</description>
+		<resultNode name="Decision1" type="decision">
+			<expected>
+				<value>0.872</value>
+			</expected>
+		</resultNode>
+	    <resultNode name="Decision2" type="decision">
+	        <expected>
+	            <value>-0.872</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision3" type="decision">
+	        <expected>
+	            <value>0.872</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision4" type="decision">
+	        <expected>
+	            <value>50</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision5" type="decision">
+	        <expected>
+	            <value>-50</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision6" type="decision">
+	        <expected>
+	            <value>50</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision7" type="decision">
+	        <expected>
+	            <value>125.4321987654</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision8" type="decision">
+	        <expected>
+	            <value>-125.4321987654</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision9" type="decision">
+	        <expected>
+	            <value>125.4321987654</value>
+	        </expected>
+	    </resultNode>
+	</testCase>
+</testCases>

--- a/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants-test-01.xml
@@ -6,7 +6,7 @@
 	<labels>
 	    <label>Compliance Level 2</label>
 		<label>Literal Expression</label>
-	    <label>FEEL constants</label>
+	    <label>FEEL Constants</label>
 	    <label>Data Type: Number</label>
 	</labels>
 	<testCase id="001"> 

--- a/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants.dmn
+++ b/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants.dmn
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_feel-constants" name="feel-constants"
+	namespace="https://github.com/dmn-tck/tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+	<decision name="Decision1" id="d_Decision1">
+		<variable name="Decision1" typeRef="feel:number"/>
+		<literalExpression>
+			<text>.872</text>
+		</literalExpression>
+	</decision>
+    <decision name="Decision2" id="d_Decision2">
+        <variable name="Decision2" typeRef="feel:number"/>
+        <literalExpression>
+            <text>-.872</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision3" id="d_Decision3">
+        <variable name="Decision3" typeRef="feel:number"/>
+        <literalExpression>
+            <text>+.872</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision4" id="d_Decision4">
+        <variable name="Decision4" typeRef="feel:number"/>
+        <literalExpression>
+            <text>50</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision5" id="d_Decision5">
+        <variable name="Decision5" typeRef="feel:number"/>
+        <literalExpression>
+            <text>-50</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision6" id="d_Decision6">
+        <variable name="Decision6" typeRef="feel:number"/>
+        <literalExpression>
+            <text>+50</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision7" id="d_Decision7">
+        <variable name="Decision7" typeRef="feel:number"/>
+        <literalExpression>
+            <text>125.4321987654</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision8" id="d_Decision8">
+        <variable name="Decision8" typeRef="feel:number"/>
+        <literalExpression>
+            <text>-125.4321987654</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision9" id="d_Decision9">
+        <variable name="Decision9" typeRef="feel:number"/>
+        <literalExpression>
+            <text>+125.4321987654</text>
+        </literalExpression>
+    </decision>
+</definitions>

--- a/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants-test-01.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.omg.org/spec/DMN/20160719/testcase ../../testCases.xsd">
+	<modelName>0102-feel-constants.dmn</modelName>
+	<labels>
+	    <label>Compliance Level 2</label>
+		<label>Literal Expression</label>
+	    <label>FEEL constants</label>
+	    <label>Data Type: String</label>
+	</labels>
+	<testCase id="001"> 
+		<description>Tests FEEL string constants</description>
+		<resultNode name="Decision1" type="decision">
+			<expected>
+				<value>foo bar</value>
+			</expected>
+		</resultNode>
+	    <resultNode name="Decision2" type="decision">
+	        <expected>
+	            <value>šomeÚnicodeŠtriňg</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision3" type="decision">
+	        <expected>
+	            <value>横綱</value>
+	        </expected>
+	    </resultNode>
+	    <resultNode name="Decision4" type="decision">
+	        <expected>
+	            <value>thisIsSomeLongStringThatMustBeProcessedSoHopefullyThisTestPassWithItAndIMustWriteSomethingMoreSoItIsLongerAndLongerAndLongerAndLongerAndLongerTillItIsReallyLong</value>
+	        </expected>
+	    </resultNode>
+	</testCase>
+</testCases>

--- a/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants-test-01.xml
@@ -6,7 +6,7 @@
 	<labels>
 	    <label>Compliance Level 2</label>
 		<label>Literal Expression</label>
-	    <label>FEEL constants</label>
+	    <label>FEEL Constants</label>
 	    <label>Data Type: String</label>
 	</labels>
 	<testCase id="001"> 

--- a/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants.dmn
+++ b/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants.dmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_feel-constants" name="feel-constants"
+	namespace="https://github.com/dmn-tck/tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+	<decision name="Decision1" id="d_Decision1">
+		<variable name="Decision1" typeRef="feel:string"/>
+		<literalExpression>
+			<text>"foo bar"</text>
+		</literalExpression>
+	</decision>
+    <decision name="Decision2" id="d_Decision2">
+        <variable name="Decision2" typeRef="feel:string"/>
+        <literalExpression>
+            <text>"šomeÚnicodeŠtriňg"</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision3" id="d_Decision3">
+        <variable name="Decision3" typeRef="feel:string"/>
+        <literalExpression>
+            <text>"横綱"</text>
+        </literalExpression>
+    </decision>
+    <decision name="Decision4" id="d_Decision4">
+        <variable name="Decision4" typeRef="feel:string"/>
+        <literalExpression>
+            <text>"thisIsSomeLongStringThatMustBeProcessedSoHopefullyThisTestPassWithItAndIMustWriteSomethingMoreSoItIsLongerAndLongerAndLongerAndLongerAndLongerTillItIsReallyLong"</text>
+        </literalExpression>
+    </decision>
+</definitions>


### PR DESCRIPTION
I am proposing we use tests numbers starting with 0100 and up for our extensive FEEL tests. We can leave the lower numbers to use with more adhoc tests as we've been doing.

In any case, test numbers are only really used to make sure we have unique IDs for the tests. All the reporting is done by labels.