### PR TITLE
Configurable name for result.csv

### DIFF
--- a/runners/dmn-tck-runner-drools/pom.xml
+++ b/runners/dmn-tck-runner-drools/pom.xml
@@ -7,7 +7,7 @@
   <name>DMN :: TCK :: jUnit Runner :: Drools</name>
 
   <properties>
-    <drools.version>7.1.0-SNAPSHOT</drools.version>
+    <drools.version>7.1.0.Final</drools.version>
   </properties>
 
   <dependencies>

--- a/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckRunner.java
+++ b/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckRunner.java
@@ -91,7 +91,12 @@ public class DmnTckRunner
     @Override
     public void run(RunNotifier notifier) {
         try {
-            resultFile = new FileWriter( "result.csv", true );
+			String resultFilePath = vendorSuite.getResultFileName();
+			if (resultFilePath != null) {
+				resultFile = new FileWriter(resultFilePath, true);
+			} else {
+				logger.error("Result file path is null. Skipping result file generation.");
+			}
             try {
                 context = vendorSuite.createContext();
             } catch ( Throwable e ) {
@@ -152,7 +157,9 @@ public class DmnTckRunner
                     runNotifier.fireTestFailure( new Failure( description, new RuntimeException( result.getMsg() ) ) );
                     break;
             }
+			if (resultFile != null) {
             resultFile.append( String.format( "%s,%s,%s,%s\n", folder, description.getClassName(), description.getMethodName(), result.getResult().toString() ) );
+			}
         } catch ( IOException e ) {
             e.printStackTrace();
         } finally {

--- a/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckVendorTestSuite.java
+++ b/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckVendorTestSuite.java
@@ -115,4 +115,16 @@ public interface DmnTckVendorTestSuite {
      */
     void afterTestCase( TestSuiteContext context, TestCases testCases );
 
+	/**
+	 * Defines the filename where tck results are written to. Defaults to
+	 * 'result.csv'. Override to customize the file name or path. If a path is
+	 * returned, the directories must exist.
+	 * 
+	 * @return the result path. Defaults to 'result.csv'. Return {@code null} to
+	 *         disable result file creation.
+	 */
+	default String getResultFileName() {
+		return "result.csv";
+	}
+
 }


### PR DESCRIPTION
* Result filename is configurable by overriding
'DmnTckVendorTestSuite.getResultFileName()'
* Defaults to result.csv
* Returning null disables result file creation 

Background: We would like to integrate the tck testsuite as part of our
unit tests and test our dmn engine with different settings against the
tck.  

For that, we would like to have result file name to be customizable (so
that multiple files can be written and placed into target folder) and
also a way to disable it.


* Updated drools to release version 7.1.0.Final so that artifacts can be fetched from maven central