### PR TITLE
Match result file name with reporter expectations

### DIFF
--- a/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckVendorTestSuite.java
+++ b/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckVendorTestSuite.java
@@ -124,7 +124,7 @@ public interface DmnTckVendorTestSuite {
 	 *         disable result file creation.
 	 */
 	default String getResultFileName() {
-		return "result.csv";
+		return "tck_results.csv";
 	}
 
 }


### PR DESCRIPTION
Our test reporter expects a file called 'tck_results.csv'. Let's make that the default in order to ease submissions.