### PR TITLE
Extended TestResult object with 'lines'

### DIFF
--- a/runners/dmn-tck-runner/pom.xml
+++ b/runners/dmn-tck-runner/pom.xml
@@ -23,6 +23,12 @@
       <artifactId>junit</artifactId>
       <version>4.12</version>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.8.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckRunner.java
+++ b/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckRunner.java
@@ -39,7 +39,7 @@ public class DmnTckRunner
     private static final Logger logger = LoggerFactory.getLogger( DmnTckRunner.class );
 
     // The description of the test suite
-    private final ConcurrentMap<TestCases.TestCase, Description> children = new ConcurrentHashMap<TestCases.TestCase, Description>();
+    private final ConcurrentMap<TestCases.TestCase, Description> children = new ConcurrentHashMap<>();
     private final DmnTckVendorTestSuite vendorSuite;
     private       Description           descr;
     private       TestSuiteContext      context;
@@ -80,7 +80,7 @@ public class DmnTckRunner
 
     @Override
     protected List<TestCases.TestCase> getChildren() {
-        return new ArrayList<TestCases.TestCase>( children.keySet() );
+        return new ArrayList<>( children.keySet() );
     }
 
     @Override
@@ -149,7 +149,7 @@ public class DmnTckRunner
                     runNotifier.fireTestIgnored( description );
                     break;
                 case ERROR:
-                    runNotifier.fireTestFailure( new Failure( description, new RuntimeException( result.getMsg() ) ) );
+				runNotifier.fireTestFailure(new Failure(description, new RuntimeException(result.toStringWithLines())));
                     break;
             }
             resultFile.append( String.format( "%s,%s,%s,%s\n", folder, description.getClassName(), description.getMethodName(), result.getResult().toString() ) );

--- a/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/TestResult.java
+++ b/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/TestResult.java
@@ -14,52 +14,172 @@
 
 package org.omg.dmn.tck.runner.junit4;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * A class to return a test result.
+ * <p>
+ * Allows to add nested lines for fine-grained reporting of TestResults. For
+ * example to capture a report on comparison errors.
+ * </p>
  */
 public class TestResult {
 
-    /**
-     * An enum for the possible test
-     * result.
-     */
-    public static enum Result {
-        SUCCESS, ERROR, IGNORED;
-    }
+	/**
+	 * An enum for the possible test result.
+	 */
+	public enum Result {
+		SUCCESS, ERROR, IGNORED;
+	}
 
-    private Result result;
-    private String msg;
+	private Result result;
+	private String msg;
+	private List<TestResult> lines = new ArrayList<>();
 
-    public TestResult(Result result) {
-        this.result = result;
-    }
+	public TestResult(Result result) {
+		this(result, null);
+	}
 
-    public TestResult(Result result, String msg) {
-        this.result = result;
-        this.msg = msg;
-    }
+	public TestResult(Result result, String msg) {
+		this.result = result;
+		this.msg = msg;
+	}
 
-    public Result getResult() {
-        return result;
-    }
+	/**
+	 * Factory method to create TestResult with {@link Result#ERROR}.
+	 * 
+	 * @param msg
+	 *            the msg for this TestResult
+	 * @return the newly created error TestResult
+	 */
+	public static TestResult error( String msg ) {
+		return new TestResult(Result.ERROR, msg);
+	}
 
-    public void setResult(Result result) {
-        this.result = result;
-    }
+	/**
+	 * Factory method to create TestResult with {@link Result#SUCCESS}.
+	 * 
+	 * @param msg
+	 *            the msg for this TestResult
+	 * @return the newly created success TestResult
+	 */
+	public static TestResult success( String msg ) {
+		return new TestResult(Result.SUCCESS, msg);
+	}
 
-    public String getMsg() {
-        return msg;
-    }
+	/**
+	 * Factory method to create TestResult with {@link Result#IGNORED}.
+	 * 
+	 * @param msg
+	 *            the msg for this TestResult
+	 * @return the newly created TestResult with status ignored
+	 */
+	public static TestResult ignore( String msg ) {
+		return new TestResult(Result.IGNORED, msg);
+	}
 
-    public void setMsg(String msg) {
-        this.msg = msg;
-    }
+	public Result getResult() {
+		return result;
+	}
 
-    @Override
-    public String toString() {
-        return "TestResult{" +
-               "result=" + result +
-               ", msg='" + msg + '\'' +
-               '}';
-    }
+	public void setResult( Result result ) {
+		this.result = result;
+	}
+
+	public String getMsg() {
+		return msg;
+	}
+
+	public void setMsg( String msg ) {
+		this.msg = msg;
+	}
+
+	/**
+	 * Adds a line to this TestResult. 
+	 * 
+	 * <p>
+	 *  Lines are useful to provide detailed feedback or additional information on the 'overall' 
+	 *  result and message. 
+	 *  For example one could add detailed information about errors during node execution or 
+	 *  for failed comparisons. 
+	 * </p> 
+	 * @param line the line to add
+	 * @return this TestResult for method concatenation
+	 */
+	public TestResult addLine( TestResult line ) {
+		this.lines.add(line);
+		return this;
+	}
+
+	/**
+	 * Adds lines to this TestResult.
+	 * 
+	 * @see #addLine(TestResult)
+	 * @param lines
+	 *            the lines to add
+	 * @return this TestResult for method concatenation
+	 */
+	public TestResult addLines( Iterable<TestResult> lines ) {
+		lines.forEach(this.lines::add);
+		return this;
+	}
+
+	/**
+	 * @see #addLine(TestResult)
+	 * @return true in case this TestResult has lines. false otherwise.
+	 */
+	public boolean hasLines() {
+		return !lines.isEmpty();
+	}
+
+	@Override
+	public String toString() {
+		return "TestResult{" + "result=" + result + ", msg='" + msg + '\'' + '}';
+	}
+
+	/**
+	 * @return a stream representation of this TestResult containing this TestResult
+	 *         as first element followed by its lines.
+	 */
+	public Stream<TestResult> toStream() {
+		return Stream.concat(Stream.of(this), this.lines.stream().flatMap(TestResult::toStream));
+	}
+
+	/**
+	 * Prints this TestResult to a string
+	 * 
+	 * @return a string representation of this TestResult including lines
+	 */
+	public String toStringWithLines() {
+		return string(this) + (hasLines() ? "\n Lines: \n" + linesToString(l -> true) : "");
+	}
+
+	/**
+	 * Returns the lines as string with a line break after each line. Nested lines
+	 * are flattened. Example:
+	 * 
+	 * <pre>
+	 * 	IGNORED: my message
+	 * 	ERROR: something failed
+	 * </pre>
+	 * 
+	 * @see #addLine(TestResult)
+	 * @return this TestResults' lines as string representation
+	 */
+	public String linesToString( Predicate<TestResult> filter ) {
+		if (lines.isEmpty()) {
+			return "";
+		}
+		return lines.stream().filter(filter).flatMap(TestResult::toStream).map(this::string)
+				.collect(Collectors.joining("\n"));
+	}
+
+	String string(TestResult l){
+		return (l.getResult() != null ? l.getResult() : "TestResult")
+				+ (l.getMsg() != null ? ": " + l.getMsg() : ": <no message>");
+	}
 }

--- a/runners/dmn-tck-runner/src/test/java/org/omg/dmn/tck/runner/junit4/TestResultTest.java
+++ b/runners/dmn-tck-runner/src/test/java/org/omg/dmn/tck/runner/junit4/TestResultTest.java
@@ -1,0 +1,81 @@
+package org.omg.dmn.tck.runner.junit4;
+
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.omg.dmn.tck.runner.junit4.TestResult.Result;
+
+public class TestResultTest {
+
+	@Test
+	public void testToString() {
+
+		TestResult testResult = new TestResult(Result.ERROR).addLine(new TestResult(Result.ERROR, "My Message"));
+		Assertions.assertThat(testResult.toStringWithLines()).contains("ERROR: <no message>");
+		Assertions.assertThat(testResult.toStringWithLines()).contains("Lines: ");
+		Assertions.assertThat(testResult.toStringWithLines()).contains("ERROR: My Message");
+	}
+
+	@Test
+	public void testToStringNull() {
+		// Expect no exception
+		TestResult result = new TestResult(null).addLine(new TestResult(null, null));
+		result.toStringWithLines();
+	}
+
+	@Test
+	public void testToStringWithLinesWithNoLines() {
+		// Expect no exception
+		TestResult result = TestResult.error("error");
+		Assertions.assertThat(result.toStringWithLines()).isEqualTo("ERROR: error");
+	}
+
+	@Test
+	public void testToStream() {
+		// GIVEN
+		TestResult r = TestResult.error("uh oh - something went wrong :-(").addLine(TestResult.error("this went wrong"))
+				.addLine(TestResult.success("this was good"));
+
+		// WHEN
+		Stream<TestResult> stream = r.toStream();
+		// THEN
+		Assertions.assertThat(stream).extracting(TestResult::getMsg)
+				.containsExactly(
+						"uh oh - something went wrong :-(",
+						"this went wrong",
+						"this was good");
+	}
+
+	@Test
+	public void testToStreamFlatMapped() {
+		// GIVEN
+		TestResult r = TestResult.error("uh oh - something went wrong :-(")
+				.addLine(TestResult.error("this went wrong").addLine(TestResult.ignore("nestedLine")))
+				.addLine(TestResult.success("this was good"));
+
+		// WHEN
+		Stream<TestResult> stream = r.toStream();
+		// THEN
+		Assertions.assertThat(stream).extracting(TestResult::getMsg)
+				.containsExactly(
+						"uh oh - something went wrong :-(",
+						"this went wrong",
+						"nestedLine",
+						"this was good");
+	}
+
+	@Test
+	public void testToStringWithLinesNested() {
+		// GIVEN
+		TestResult r = TestResult.error("uh oh - something went wrong :-(")
+				.addLine(TestResult.error("this went wrong").addLine(TestResult.ignore("nestedLine")))
+				.addLine(TestResult.success("this was good"));
+
+		// WHEN
+		String s = r.toStringWithLines();
+		// THEN
+		Assertions.assertThat(s).contains("IGNORED: nestedLine");
+	}
+
+}


### PR DESCRIPTION
'Lines' can now be added to TestResult, so that a more detailed result
can produced and printed, showing in detail why a test failed. For
example, one line for each failed comparison of expected and actual
result.