### PR TITLE
Split test cases of FEEL functions, constants and math (for better reporting)

### DIFF
--- a/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants-test-01.xml
@@ -14,26 +14,41 @@
 				<value>0.872</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="002">
+	    <description>Tests FEEL number constants</description>
 	    <resultNode name="Decision2" type="decision">
 	        <expected>
 	            <value>-0.872</value>
 	        </expected>
 	    </resultNode>
+	</testCase>
+	<testCase id="004">
+	    <description>Tests FEEL number constants</description>
 	    <resultNode name="Decision4" type="decision">
 	        <expected>
 	            <value>50</value>
 	        </expected>
 	    </resultNode>
+	</testCase>
+	<testCase id="005">
+	    <description>Tests FEEL number constants</description>
 	    <resultNode name="Decision5" type="decision">
 	        <expected>
 	            <value>-50</value>
 	        </expected>
 	    </resultNode>
+	</testCase>
+	<testCase id="007">
+	    <description>Tests FEEL number constants</description>
 	    <resultNode name="Decision7" type="decision">
 	        <expected>
 	            <value>125.4321987654</value>
 	        </expected>
 	    </resultNode>
+	</testCase>
+	<testCase id="008">
+	    <description>Tests FEEL number constants</description>
 	    <resultNode name="Decision8" type="decision">
 	        <expected>
 	            <value>-125.4321987654</value>

--- a/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0101-feel-constants/0101-feel-constants-test-01.xml
@@ -8,7 +8,7 @@
 		<label>Data Type: Number</label>
 	</labels>
 	<testCase id="001">
-		<description>Tests FEEL number constants</description>
+		<description>Tests FEEL decimal number constant</description>
 		<resultNode name="Decision1" type="decision">
 			<expected>
 				<value>0.872</value>
@@ -16,7 +16,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="002">
-	    <description>Tests FEEL number constants</description>
+	    <description>Tests FEEL negative decimal number constant</description>
 	    <resultNode name="Decision2" type="decision">
 	        <expected>
 	            <value>-0.872</value>
@@ -24,7 +24,7 @@
 	    </resultNode>
 	</testCase>
 	<testCase id="004">
-	    <description>Tests FEEL number constants</description>
+	    <description>Tests FEEL number constant</description>
 	    <resultNode name="Decision4" type="decision">
 	        <expected>
 	            <value>50</value>
@@ -32,7 +32,7 @@
 	    </resultNode>
 	</testCase>
 	<testCase id="005">
-	    <description>Tests FEEL number constants</description>
+	    <description>Tests FEEL negative number constant</description>
 	    <resultNode name="Decision5" type="decision">
 	        <expected>
 	            <value>-50</value>
@@ -40,7 +40,7 @@
 	    </resultNode>
 	</testCase>
 	<testCase id="007">
-	    <description>Tests FEEL number constants</description>
+	    <description>Tests FEEL decimal number constant</description>
 	    <resultNode name="Decision7" type="decision">
 	        <expected>
 	            <value>125.4321987654</value>
@@ -48,7 +48,7 @@
 	    </resultNode>
 	</testCase>
 	<testCase id="008">
-	    <description>Tests FEEL number constants</description>
+	    <description>Tests FEEL negative decimal number constant</description>
 	    <resultNode name="Decision8" type="decision">
 	        <expected>
 	            <value>-125.4321987654</value>

--- a/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants-test-01.xml
@@ -15,16 +15,25 @@
 				<value>foo bar</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="002">
+		<description>Tests FEEL string constants</description>
 		<resultNode name="Decision2" type="decision">
 			<expected>
 				<value>šomeÚnicodeŠtriňg</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="003">
+		<description>Tests FEEL string constants</description>
 		<resultNode name="Decision3" type="decision">
 			<expected>
 				<value>横綱</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="004">
+		<description>Tests FEEL string constants</description>
 		<resultNode name="Decision4" type="decision">
 			<expected>
 				<value>thisIsSomeLongStringThatMustBeProcessedSoHopefullyThisTestPassWithItAndIMustWriteSomethingMoreSoItIsLongerAndLongerAndLongerAndLongerAndLongerTillItIsReallyLong</value>

--- a/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants-test-01.xml
+++ b/TestCases/compliance-level-2/0102-feel-constants/0102-feel-constants-test-01.xml
@@ -17,7 +17,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="002">
-		<description>Tests FEEL string constants</description>
+		<description>Tests FEEL unicode string constant</description>
 		<resultNode name="Decision2" type="decision">
 			<expected>
 				<value>šomeÚnicodeŠtriňg</value>
@@ -25,7 +25,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="003">
-		<description>Tests FEEL string constants</description>
+		<description>Tests FEEL unicode string constant</description>
 		<resultNode name="Decision3" type="decision">
 			<expected>
 				<value>横綱</value>
@@ -33,7 +33,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="004">
-		<description>Tests FEEL string constants</description>
+		<description>Tests FEEL long string constant</description>
 		<resultNode name="Decision4" type="decision">
 			<expected>
 				<value>thisIsSomeLongStringThatMustBeProcessedSoHopefullyThisTestPassWithItAndIMustWriteSomethingMoreSoItIsLongerAndLongerAndLongerAndLongerAndLongerTillItIsReallyLong</value>

--- a/TestCases/compliance-level-2/0105-feel-math/0105-feel-math-test-01.xml
+++ b/TestCases/compliance-level-2/0105-feel-math/0105-feel-math-test-01.xml
@@ -15,170 +15,266 @@
 				<value>15</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="002">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision2" type="decision">
 			<expected>
 				<value>-15</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="003">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision3" type="decision">
 			<expected>
 				<value>-15</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="004">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision4" type="decision">
 			<expected>
 				<value>5</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="005">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision5" type="decision">
 			<expected>
 				<value>-5</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="006">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision6" type="decision">
 			<expected>
 				<value>-5</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="007">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision7" type="decision">
 			<expected>
 				<value>32</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="008">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision8" type="decision">
 			<expected>
 				<value>50</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="009">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision9" type="decision">
 			<expected>
 				<value>50</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="010">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision10" type="decision">
 			<expected>
 				<value>50</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="011">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision11" type="decision">
 			<expected>
 				<value>-225</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="012">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision12" type="decision">
 			<expected>
 				<value>2</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="013">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision13" type="decision">
 			<expected>
 				<value>2</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="014">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision14" type="decision">
 			<expected>
 				<value>2</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="015">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision15" type="decision">
 			<expected>
 				<value>-2</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="016">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision16" type="decision">
 			<expected>
 				<!-- null -->
 				<value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="017">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision17" type="decision">
 			<expected>
 				<value>100000</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="018">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision18" type="decision">
 			<expected>
 				<value>0.00001</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="019">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision19" type="decision">
 			<expected>
 				<value>16807</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="020">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision20" type="decision">
 			<expected>
 				<value>37</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="021">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision21" type="decision">
 			<expected>
 				<value>40</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="022">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision22" type="decision">
 			<expected>
 				<value>261</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="023">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision23" type="decision">
 			<expected>
 				<!-- null -->
 			    <value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="024">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision24" type="decision">
 			<expected>
 				<!-- null -->
 			    <value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="025">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision25" type="decision">
 			<expected>
 				<!-- null -->
 			    <value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="026">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision26" type="decision">
 			<expected>
 				<!-- null -->
 			    <value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="027">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision27" type="decision">
 			<expected>
 				<!-- null -->
 			    <value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="028">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision28" type="decision">
 			<expected>
 				<!-- null -->
 			    <value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="029">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision29" type="decision">
 			<expected>
 				<!-- null -->
 			    <value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="030">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision30" type="decision">
 			<expected>
 				<!-- null -->
 			    <value xsi:nil="true"/>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="031">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision31" type="decision">
 			<expected>
 				<value>3</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="032">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision32" type="decision">
 			<expected>
 				<value>7.5</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="033">
+		<description>Tests FEEL simple arithmetics with constants</description>
 		<resultNode name="Decision33" type="decision">
 			<expected>
 				<value>1200</value>

--- a/TestCases/compliance-level-2/0105-feel-math/0105-feel-math-test-01.xml
+++ b/TestCases/compliance-level-2/0105-feel-math/0105-feel-math-test-01.xml
@@ -9,7 +9,7 @@
 		<label>FEEL Arithmetic</label>
 	</labels>
 	<testCase id="001">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition of number literals</description>
 		<resultNode name="Decision1" type="decision">
 			<expected>
 				<value>15</value>
@@ -17,7 +17,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="002">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition of negative number literals</description>
 		<resultNode name="Decision2" type="decision">
 			<expected>
 				<value>-15</value>
@@ -25,7 +25,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="003">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition of negative number literals with brakets</description>
 		<resultNode name="Decision3" type="decision">
 			<expected>
 				<value>-15</value>
@@ -33,7 +33,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="004">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL subtraction of number literals</description>
 		<resultNode name="Decision4" type="decision">
 			<expected>
 				<value>5</value>
@@ -41,7 +41,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="005">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL subtraction of negative number literals</description>
 		<resultNode name="Decision5" type="decision">
 			<expected>
 				<value>-5</value>
@@ -49,7 +49,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="006">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL subtraction of negative number literals with brakets</description>
 		<resultNode name="Decision6" type="decision">
 			<expected>
 				<value>-5</value>
@@ -57,7 +57,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="007">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition and subtraction of number literals with brakets</description>
 		<resultNode name="Decision7" type="decision">
 			<expected>
 				<value>32</value>
@@ -65,7 +65,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="008">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL multiplication of number literals</description>
 		<resultNode name="Decision8" type="decision">
 			<expected>
 				<value>50</value>
@@ -73,7 +73,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="009">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL multiplication of negative number literals</description>
 		<resultNode name="Decision9" type="decision">
 			<expected>
 				<value>50</value>
@@ -81,7 +81,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="010">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL multiplication of negative number literals with brakets</description>
 		<resultNode name="Decision10" type="decision">
 			<expected>
 				<value>50</value>
@@ -89,7 +89,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="011">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition and multiplication of number literals with brakets</description>
 		<resultNode name="Decision11" type="decision">
 			<expected>
 				<value>-225</value>
@@ -97,7 +97,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="012">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL division of number literals</description>
 		<resultNode name="Decision12" type="decision">
 			<expected>
 				<value>2</value>
@@ -105,7 +105,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="013">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL division of negative number literals</description>
 		<resultNode name="Decision13" type="decision">
 			<expected>
 				<value>2</value>
@@ -113,7 +113,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="014">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL division of negative number literals with brakets</description>
 		<resultNode name="Decision14" type="decision">
 			<expected>
 				<value>2</value>
@@ -121,7 +121,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="015">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition and division of number literals with brakets</description>
 		<resultNode name="Decision15" type="decision">
 			<expected>
 				<value>-2</value>
@@ -129,7 +129,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="016">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL division by zero</description>
 		<resultNode name="Decision16" type="decision">
 			<expected>
 				<!-- null -->
@@ -138,7 +138,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="017">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL potency of number literal</description>
 		<resultNode name="Decision17" type="decision">
 			<expected>
 				<value>100000</value>
@@ -146,7 +146,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="018">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL negative potency of number literal</description>
 		<resultNode name="Decision18" type="decision">
 			<expected>
 				<value>0.00001</value>
@@ -154,7 +154,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="019">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL potency of number literal with brakets</description>
 		<resultNode name="Decision19" type="decision">
 			<expected>
 				<value>16807</value>
@@ -162,7 +162,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="020">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition and potency of number literals</description>
 		<resultNode name="Decision20" type="decision">
 			<expected>
 				<value>37</value>
@@ -170,7 +170,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="021">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition and potency of number literals</description>
 		<resultNode name="Decision21" type="decision">
 			<expected>
 				<value>40</value>
@@ -178,7 +178,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="022">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition and potency of number literals with brakets</description>
 		<resultNode name="Decision22" type="decision">
 			<expected>
 				<value>261</value>
@@ -186,7 +186,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="023">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition with null</description>
 		<resultNode name="Decision23" type="decision">
 			<expected>
 				<!-- null -->
@@ -195,7 +195,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="024">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL addition with null</description>
 		<resultNode name="Decision24" type="decision">
 			<expected>
 				<!-- null -->
@@ -204,7 +204,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="025">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL subtraction with null</description>
 		<resultNode name="Decision25" type="decision">
 			<expected>
 				<!-- null -->
@@ -213,7 +213,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="026">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL subtraction with null</description>
 		<resultNode name="Decision26" type="decision">
 			<expected>
 				<!-- null -->
@@ -222,7 +222,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="027">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL multiplication with null</description>
 		<resultNode name="Decision27" type="decision">
 			<expected>
 				<!-- null -->
@@ -231,7 +231,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="028">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL multiplication with null</description>
 		<resultNode name="Decision28" type="decision">
 			<expected>
 				<!-- null -->
@@ -240,7 +240,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="029">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL division with null</description>
 		<resultNode name="Decision29" type="decision">
 			<expected>
 				<!-- null -->
@@ -249,7 +249,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="030">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL division with null</description>
 		<resultNode name="Decision30" type="decision">
 			<expected>
 				<!-- null -->
@@ -258,7 +258,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="031">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL arithmetics with spaces between number literals</description>
 		<resultNode name="Decision31" type="decision">
 			<expected>
 				<value>3</value>
@@ -266,7 +266,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="032">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL arithmetics with spaces between number literals and brakets</description>
 		<resultNode name="Decision32" type="decision">
 			<expected>
 				<value>7.5</value>
@@ -274,7 +274,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="033">
-		<description>Tests FEEL simple arithmetics with constants</description>
+		<description>Tests FEEL arithmetics with decimal number literals</description>
 		<resultNode name="Decision33" type="decision">
 			<expected>
 				<value>1200</value>

--- a/TestCases/compliance-level-3/0002-string-functions/0002-string-functions-test-01.xml
+++ b/TestCases/compliance-level-3/0002-string-functions/0002-string-functions-test-01.xml
@@ -17,6 +17,7 @@
 		<label>Data Type: Structure</label>
 	</labels>
 	<testCase id="001">
+		<description>Tests FEEL built-in functions on string literals (starts_with, ends_with, contains, substring, string_length, upper_case, lower_case, substring_before, substring_after)</description>
 		<inputNode name="A">
 			<value>banana</value>
 		</inputNode>
@@ -68,11 +69,9 @@
 		</resultNode>
 	</testCase>
 	<testCase id="002">
+		<description>Tests FEEL built-in function for regular expresssion matching (matches)</description>
 		<inputNode name="A">
 			<value>banana</value>
-		</inputNode>
-		<inputNode name="B">
-			<value>a</value>
 		</inputNode>
 		<resultNode name="Matches" type="decision">
 			<expected>
@@ -81,11 +80,9 @@
 		</resultNode>
 	</testCase>
 	<testCase id="003">
+		<description>Tests FEEL built-in function 'replace' on string literals</description>
 		<inputNode name="A">
 			<value>banana</value>
-		</inputNode>
-		<inputNode name="B">
-			<value>a</value>
 		</inputNode>
 		<resultNode name="Replace" type="decision">
 			<expected>
@@ -102,6 +99,7 @@
 		</resultNode>
 	</testCase>
 	<testCase id="004">
+		<description>Tests FEEL built-in function for converting a number to a string</description>
 		<inputNode name="NumC">
 			<value>2</value>
 		</inputNode>

--- a/TestCases/compliance-level-3/0002-string-functions/0002-string-functions-test-01.xml
+++ b/TestCases/compliance-level-3/0002-string-functions/0002-string-functions-test-01.xml
@@ -66,11 +66,27 @@
 				</component>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="002">
+		<inputNode name="A">
+			<value>banana</value>
+		</inputNode>
+		<inputNode name="B">
+			<value>a</value>
+		</inputNode>
 		<resultNode name="Matches" type="decision">
 			<expected>
 				<value>true</value>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="003">
+		<inputNode name="A">
+			<value>banana</value>
+		</inputNode>
+		<inputNode name="B">
+			<value>a</value>
+		</inputNode>
 		<resultNode name="Replace" type="decision">
 			<expected>
 				<component name="Aao">
@@ -84,6 +100,11 @@
 				</component>
 			</expected>
 		</resultNode>
+	</testCase>
+	<testCase id="004">
+		<inputNode name="NumC">
+			<value>2</value>
+		</inputNode>
 		<resultNode name="Constructor" type="decision">
 			<expected>
 				<value xsi:type="xsd:string">2</value>

--- a/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.dmn
+++ b/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.dmn
@@ -149,9 +149,6 @@
 		<informationRequirement>
 			<requiredInput href="#_0923ed0c-3674-4476-b84c-f9ad5e5e8048"/>
 		</informationRequirement>
-		<informationRequirement>
-			<requiredInput href="#_1df2ad51-3334-4098-b55f-df885fb0e412"/>
-		</informationRequirement>
 		<literalExpression>
 			<text>matches(A,"[a-z]{3}")</text>
 		</literalExpression>
@@ -160,9 +157,6 @@
 		<variable name="Replace" typeRef="tns:tReplace"/>
 		<informationRequirement>
 			<requiredInput href="#_0923ed0c-3674-4476-b84c-f9ad5e5e8048"/>
-		</informationRequirement>
-		<informationRequirement>
-			<requiredInput href="#_1df2ad51-3334-4098-b55f-df885fb0e412"/>
 		</informationRequirement>
 		<context>
 			<contextEntry>

--- a/TestResults/Camunda/7.7.0/tck_results.csv
+++ b/TestResults/Camunda/7.7.0/tck_results.csv
@@ -67,7 +67,10 @@ compliance-level-2/0105-feel-math,0105-feel-math-test-01,031,SUCCESS,
 compliance-level-2/0105-feel-math,0105-feel-math-test-01,032,SUCCESS,
 compliance-level-2/0105-feel-math,0105-feel-math-test-01,033,SUCCESS,
 compliance-level-3/0001-filter,0001-filter-test-01,001,SUCCESS,
-compliance-level-3/0002-string-functions,0002-string-functions-test-01,001,IGNORED,The element 'context' is not supported.
+compliance-level-3/0002-string-functions,0002-string-functions-test-01,001,SUCCESS,
+compliance-level-3/0002-string-functions,0002-string-functions-test-01,002,SUCCESS,
+compliance-level-3/0002-string-functions,0002-string-functions-test-01,003,SUCCESS,
+compliance-level-3/0002-string-functions,0002-string-functions-test-01,004,SUCCESS,
 compliance-level-3/0003-iteration,0003-iteration-test-01,001,IGNORED,The element 'businessKnowledgeModel' is not supported.
 compliance-level-3/0004-lending,0004-lending-test-01,001,IGNORED,The element 'businessKnowledgeModel' is not supported.
 compliance-level-3/0005-literal-invocation,0005-literal-invocation-test-01,002,IGNORED,The element 'businessKnowledgeModel' is not supported.

--- a/TestResults/Camunda/7.7.0/tck_results.csv
+++ b/TestResults/Camunda/7.7.0/tck_results.csv
@@ -22,6 +22,50 @@ compliance-level-2/0009-invocation-arithmetic,0009-invocation-arithmetic-test-01
 compliance-level-2/0010-multi-output-U,0010-multi-output-U-test-01,001,SUCCESS,
 compliance-level-2/0010-multi-output-U,0010-multi-output-U-test-01,003,SUCCESS,
 compliance-level-2/0010-multi-output-U,0010-multi-output-U-test-01,002,SUCCESS,
+compliance-level-2/0100-feel-constants,0100-feel-constants-test-01,001,SUCCESS,
+compliance-level-2/0101-feel-constants,0101-feel-constants-test-01,001,SUCCESS,
+compliance-level-2/0101-feel-constants,0101-feel-constants-test-01,002,SUCCESS,
+compliance-level-2/0101-feel-constants,0101-feel-constants-test-01,004,SUCCESS,
+compliance-level-2/0101-feel-constants,0101-feel-constants-test-01,005,SUCCESS,
+compliance-level-2/0101-feel-constants,0101-feel-constants-test-01,007,SUCCESS,
+compliance-level-2/0101-feel-constants,0101-feel-constants-test-01,008,SUCCESS,
+compliance-level-2/0102-feel-constants,0102-feel-constants-test-01,001,SUCCESS,
+compliance-level-2/0102-feel-constants,0102-feel-constants-test-01,002,SUCCESS,
+compliance-level-2/0102-feel-constants,0102-feel-constants-test-01,003,SUCCESS,
+compliance-level-2/0102-feel-constants,0102-feel-constants-test-01,004,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,001,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,002,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,003,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,004,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,005,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,006,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,007,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,008,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,009,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,010,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,011,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,012,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,013,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,014,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,015,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,016,ERROR,FAILURE: ArithmeticException: Division by zero
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,017,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,018,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,019,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,020,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,021,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,022,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,023,ERROR,FAILURE: DmnEvaluationException: DMN-01002 Unable to evaluate expression for language 'feel': '10+null' – Caused by: ScriptException: failed to evaluate expression '10+null': expected Number but found 'ValNull'
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,024,ERROR,FAILURE: DmnEvaluationException: DMN-01002 Unable to evaluate expression for language 'feel': 'null + 10' – Caused by: ScriptException: failed to evaluate expression 'null + 10': expected Number; String; Date; Time or Duration but found 'ValNull'
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,025,ERROR,FAILURE: DmnEvaluationException: DMN-01002 Unable to evaluate expression for language 'feel': '10 - null' – Caused by: ScriptException: failed to evaluate expression '10 - null': expected Number but found 'ValNull'
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,026,ERROR,FAILURE: DmnEvaluationException: DMN-01002 Unable to evaluate expression for language 'feel': 'null - 10' – Caused by: ScriptException: failed to evaluate expression 'null - 10': expected Number; Date; Time or Duration but found 'ValNull'
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,027,ERROR,FAILURE: DmnEvaluationException: DMN-01002 Unable to evaluate expression for language 'feel': '10 * null' – Caused by: ScriptException: failed to evaluate expression '10 * null': expect Number; or Year-Month-/Day-Time-Duration but found '10'
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,028,ERROR,FAILURE: DmnEvaluationException: DMN-01002 Unable to evaluate expression for language 'feel': 'null * 10' – Caused by: ScriptException: failed to evaluate expression 'null * 10': expected Number; or Duration but found 'ValNull'
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,029,ERROR,FAILURE: DmnEvaluationException: DMN-01002 Unable to evaluate expression for language 'feel': '10 / null' – Caused by: ScriptException: failed to evaluate expression '10 / null': expected Number but found 'ValNull'
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,030,ERROR,FAILURE: DmnEvaluationException: DMN-01002 Unable to evaluate expression for language 'feel': 'null / 10' – Caused by: ScriptException: failed to evaluate expression 'null / 10': expected Number; or Duration but found 'ValNull'
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,031,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,032,SUCCESS,
+compliance-level-2/0105-feel-math,0105-feel-math-test-01,033,SUCCESS,
 compliance-level-3/0001-filter,0001-filter-test-01,001,SUCCESS,
 compliance-level-3/0002-string-functions,0002-string-functions-test-01,001,IGNORED,The element 'context' is not supported.
 compliance-level-3/0003-iteration,0003-iteration-test-01,001,IGNORED,The element 'businessKnowledgeModel' is not supported.


### PR DESCRIPTION
Currently, we have four test cases that combine many tests for different FEEL functions, arithmetics, and constant literals. If an implementation has issues in these areas, the current report does not show any details and it is really hard to even know which decision or FEEL feature caused a problem.

In order to make it easier for users to see which FEEL features are supported, we suggest a small split in the test case XML files. Each expected result of a decision should be distinguished as a separate test case and therefore gets reported separately. This also helps developers from software vendors to identify and fix issues in their tools.

This proposal keeps changes to a minimum and does not require the DMN files or the Test XML files to be split or duplicated.

Have a look at the [updated Camunda CSV file](https://github.com/falko/dmn-tck/blob/a4070f17c28b8d4a060cf1c26a64a638222f23b6/TestResults/Camunda/7.7.0/tck_results.csv) to see the effect.