### PR TITLE
Extended schema to provide marker for error results

### DIFF
--- a/TestCases/testCases.xsd
+++ b/TestCases/testCases.xsd
@@ -27,12 +27,13 @@
 									</xs:complexContent>
 								</xs:complexType>
 							</xs:element>
-							<xs:element name="resultNode" minOccurs="0" maxOccurs="unbounded">
+							<xs:element name="resultNode" minOccurs="0" maxOccurs="unbounded">		
 								<xs:complexType>
 									<xs:sequence>
 										<xs:element name="computed" type="valueType" minOccurs="0"/>
 										<xs:element name="expected" type="valueType" minOccurs="0"/>
 									</xs:sequence>
+								    <xs:attribute name="errorResult" type="xs:boolean" default="false" />
 									<xs:attribute name="name" use="required"/>
 									<xs:attribute name="type" type="xs:string"/>
 									<xs:attribute name="cast" type="xs:string"/>


### PR DESCRIPTION
Extended schema to add errorResult flag to ResultNode to indicate null-value as a result of an error situations