### PR TITLE
Add missing call.

### DIFF
--- a/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckRunner.java
+++ b/runners/dmn-tck-runner/src/main/java/org/omg/dmn/tck/runner/junit4/DmnTckRunner.java
@@ -157,7 +157,7 @@ public class DmnTckRunner
                     runNotifier.fireTestIgnored( description );
                     break;
                 case ERROR:
-				runNotifier.fireTestFailure(new Failure(description, new RuntimeException(result.toStringWithLines())));
+				    runNotifier.fireTestFailure(new Failure(description, new RuntimeException(result.toStringWithLines())));
                     break;
             }
 			if (resultFile != null) {
@@ -169,6 +169,7 @@ public class DmnTckRunner
             e.printStackTrace();
         } finally {
             vendorSuite.afterTest( description, context, testCase );
+            runNotifier.fireTestFinished(description);
         }
     }
 


### PR DESCRIPTION
Missing call is required to resume testing after one test case fails.