### PR TITLE
Fix case 57 for 1117-feel-date-and-time-function-test-01

### DIFF
--- a/TestCases/compliance-level-3/1117-feel-date-and-time-function/1117-feel-date-and-time-function-test-01.xml
+++ b/TestCases/compliance-level-3/1117-feel-date-and-time-function/1117-feel-date-and-time-function-test-01.xml
@@ -400,9 +400,9 @@
         </resultNode>
     </testCase>
     <testCase id="057">
-        <resultNode errorResult="true" name="feel-date-and-time-function_ErrorCase_57" type="decision">
+        <resultNode name="feel-date-and-time-function_57" type="decision">
             <expected>
-                <value xsi:nil="true"/>
+                <value xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:dateTime">2012-12-24T00:00:00</value>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/1117-feel-date-and-time-function/1117-feel-date-and-time-function.dmn
+++ b/TestCases/compliance-level-3/1117-feel-date-and-time-function/1117-feel-date-and-time-function.dmn
@@ -151,7 +151,9 @@
   <dmn:itemDefinition id="_JR4OsclGEeeAGbzZrHaKcQ" name="tfeel-date-and-time-function_54_Result"/>
   <dmn:itemDefinition id="_JR41wclGEeeAGbzZrHaKcQ" name="tfeel-date-and-time-function_55_Result"/>
   <dmn:itemDefinition id="_JR5c0clGEeeAGbzZrHaKcQ" name="tfeel-date-and-time-function_56_Result"/>
-  <dmn:itemDefinition id="_JR6D4clGEeeAGbzZrHaKcQ" name="tfeel-date-and-time-function_57_Result"/>
+  <dmn:itemDefinition id="_JR6D4clGEeeAGbzZrHaKcQ" name="tfeel-date-and-time-function_57_Result">
+    <dmn:typeRef>feel:dateTime</dmn:typeRef>
+  </dmn:itemDefinition>
   <dmn:itemDefinition id="_JR6D5clGEeeAGbzZrHaKcQ" name="tfeel-date-and-time-function_58_Result"/>
   <dmn:itemDefinition id="_JR6q88lGEeeAGbzZrHaKcQ" name="tfeel-date-and-time-function_59_Result"/>
   <dmn:itemDefinition id="_JR7SA8lGEeeAGbzZrHaKcQ" name="tfeel-date-and-time-function_60_Result"/>
@@ -687,11 +689,11 @@
       <dmn:text>date and time(&quot;&quot;)</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
-  <dmn:decision id="_JR6D48lGEeeAGbzZrHaKcQ" name="feel-date-and-time-function_ErrorCase_57">
-    <dmn:description>Tests FEEL expression: 'date and time(&quot;2012-12-24&quot;)' and expects result: 'null (null)'</dmn:description>
+  <dmn:decision id="_JR6D48lGEeeAGbzZrHaKcQ" name="feel-date-and-time-function_57">
+    <dmn:description>Tests FEEL expression: 'date and time(&quot;2012-12-24&quot;)' and expects result: '2012-12-24T00:00:00 (date and time)'</dmn:description>
     <dmn:question>Result of FEEL expression 'date and time(&quot;2012-12-24&quot;)'?</dmn:question>
-    <dmn:allowedAnswers>null (null)</dmn:allowedAnswers>
-    <dmn:variable id="_JR6D5MlGEeeAGbzZrHaKcQ" name="feel-date-and-time-function_ErrorCase_57" typeRef="ns1:tfeel-date-and-time-function_57_Result"/>
+    <dmn:allowedAnswers>2012-12-24T00:00:00 (date and time)</dmn:allowedAnswers>
+    <dmn:variable id="_JR6D5MlGEeeAGbzZrHaKcQ" name="feel-date-and-time-function_57" typeRef="ns1:tfeel-date-and-time-function_57_Result"/>
     <dmn:literalExpression id="_JR6D4slGEeeAGbzZrHaKcQ">
       <dmn:text>date and time(&quot;2012-12-24&quot;)</dmn:text>
     </dmn:literalExpression>

--- a/TestCases/compliance-level-3/1117-feel-date-and-time-function/Readme.md
+++ b/TestCases/compliance-level-3/1117-feel-date-and-time-function/Readme.md
@@ -68,7 +68,7 @@ DMN Model [1117-feel-date-and-time-function.dmn](./1117-feel-date-and-time-funct
 |feel-date-and-time-function_ErrorCase_54|date and time(2017)|null (null)|
 |feel-date-and-time-function_ErrorCase_55|date and time([])|null (null)|
 |feel-date-and-time-function_ErrorCase_56|date and time("")|null (null)|
-|feel-date-and-time-function_ErrorCase_57|date and time("2012-12-24")|null (null)|
+|feel-date-and-time-function_57|date and time("2012-12-24")|2012-12-24T00:00:00 (date and time)|
 |feel-date-and-time-function_ErrorCase_58|date and time("11:00:00")|null (null)|
 |feel-date-and-time-function_ErrorCase_59|date and time("2011-12-0310:15:30")|null (null)|
 |feel-date-and-time-function_ErrorCase_60|date and time("2011-12-03T10:15:30+01:00@Europe/Paris")|null (null)|


### PR DESCRIPTION
1117-feel-date-and-time-function-test-01
for
case 57 : date and time("2012-12-24")

CURRENT expected: an error
SHOULD ACTUALLY expect: 2012-12-24T00:00:00 (date and time)

Should not be an error.

Accordingly to the spec `date and time` function can receive
just the date part,
FEEL spec printed page 131 " date time string – a string value
consisting of a date string value, as specified above, optionally
followed by the character "T" followed by a time string value
as specified above "