### PR TITLE
Remove 1121-feel-years-and-months-duration-function tests 31 and 32

### DIFF
--- a/TestCases/compliance-level-3/1121-feel-years-and-months-duration-function/1121-feel-years-and-months-duration-function-test-01.xml
+++ b/TestCases/compliance-level-3/1121-feel-years-and-months-duration-function/1121-feel-years-and-months-duration-function-test-01.xml
@@ -216,20 +216,6 @@
             </expected>
         </resultNode>
     </testCase>
-    <testCase id="031">
-        <resultNode errorResult="true" name="feel-years-and-months-duration-function_ErrorCase_31" type="decision">
-            <expected>
-                <value xsi:nil="true"/>
-            </expected>
-        </resultNode>
-    </testCase>
-    <testCase id="032">
-        <resultNode errorResult="true" name="feel-years-and-months-duration-function_ErrorCase_32" type="decision">
-            <expected>
-                <value xsi:nil="true"/>
-            </expected>
-        </resultNode>
-    </testCase>
     <testCase id="033">
         <resultNode name="feel-years-and-months-duration-function_33" type="decision">
             <expected>

--- a/TestCases/compliance-level-3/1121-feel-years-and-months-duration-function/1121-feel-years-and-months-duration-function.dmn
+++ b/TestCases/compliance-level-3/1121-feel-years-and-months-duration-function/1121-feel-years-and-months-duration-function.dmn
@@ -69,8 +69,6 @@
   <dmn:itemDefinition id="_JUp148lGEeeAGbzZrHaKcQ" name="tfeel-years-and-months-duration-function_28_Result"/>
   <dmn:itemDefinition id="_JUrEA8lGEeeAGbzZrHaKcQ" name="tfeel-years-and-months-duration-function_29_Result"/>
   <dmn:itemDefinition id="_JUrrE8lGEeeAGbzZrHaKcQ" name="tfeel-years-and-months-duration-function_30_Result"/>
-  <dmn:itemDefinition id="_JUsSI8lGEeeAGbzZrHaKcQ" name="tfeel-years-and-months-duration-function_31_Result"/>
-  <dmn:itemDefinition id="_JUuHU8lGEeeAGbzZrHaKcQ" name="tfeel-years-and-months-duration-function_32_Result"/>
   <dmn:itemDefinition id="_JUv8gclGEeeAGbzZrHaKcQ" name="tfeel-years-and-months-duration-function_33_Result">
     <dmn:typeRef>feel:yearMonthDuration</dmn:typeRef>
   </dmn:itemDefinition>
@@ -351,24 +349,6 @@
     <dmn:variable id="_JUsSIslGEeeAGbzZrHaKcQ" name="feel-years-and-months-duration-function_ErrorCase_30" typeRef="ns1:tfeel-years-and-months-duration-function_30_Result"/>
     <dmn:literalExpression id="_JUsSIMlGEeeAGbzZrHaKcQ">
       <dmn:text>years and months duration([],[])</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_JUuHUclGEeeAGbzZrHaKcQ" name="feel-years-and-months-duration-function_ErrorCase_31">
-    <dmn:description>Tests FEEL expression: 'years and months duration(date(&quot;2013-08-24&quot;), date and time(&quot;2017-12-15T00:59:59&quot;))' and expects result: 'null (null)'</dmn:description>
-    <dmn:question>Result of FEEL expression 'years and months duration(date(&quot;2013-08-24&quot;), date and time(&quot;2017-12-15T00:59:59&quot;))'?</dmn:question>
-    <dmn:allowedAnswers>null (null)</dmn:allowedAnswers>
-    <dmn:variable id="_JUuHUslGEeeAGbzZrHaKcQ" name="feel-years-and-months-duration-function_ErrorCase_31" typeRef="ns1:tfeel-years-and-months-duration-function_31_Result"/>
-    <dmn:literalExpression id="_JUuHUMlGEeeAGbzZrHaKcQ">
-      <dmn:text>years and months duration(date(&quot;2013-08-24&quot;), date and time(&quot;2017-12-15T00:59:59&quot;))</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_JUvVcclGEeeAGbzZrHaKcQ" name="feel-years-and-months-duration-function_ErrorCase_32">
-    <dmn:description>Tests FEEL expression: 'years and months duration(date and time(&quot;2017-02-28T23:59:59&quot;), date(&quot;2019-07-23&quot;) )' and expects result: 'null (null)'</dmn:description>
-    <dmn:question>Result of FEEL expression 'years and months duration(date and time(&quot;2017-02-28T23:59:59&quot;), date(&quot;2019-07-23&quot;) )'?</dmn:question>
-    <dmn:allowedAnswers>null (null)</dmn:allowedAnswers>
-    <dmn:variable id="_JUv8gMlGEeeAGbzZrHaKcQ" name="feel-years-and-months-duration-function_ErrorCase_32" typeRef="ns1:tfeel-years-and-months-duration-function_32_Result"/>
-    <dmn:literalExpression id="_JUvVcMlGEeeAGbzZrHaKcQ">
-      <dmn:text>years and months duration(date and time(&quot;2017-02-28T23:59:59&quot;), date(&quot;2019-07-23&quot;) )</dmn:text>
     </dmn:literalExpression>
   </dmn:decision>
   <dmn:decision id="_JUxKoclGEeeAGbzZrHaKcQ" name="feel-years-and-months-duration-function_33">

--- a/TestCases/compliance-level-3/1121-feel-years-and-months-duration-function/Readme.md
+++ b/TestCases/compliance-level-3/1121-feel-years-and-months-duration-function/Readme.md
@@ -42,8 +42,6 @@ DMN Model [1121-feel-years-and-months-duration-function.dmn](./1121-feel-years-a
 |feel-years-and-months-duration-function_ErrorCase_28|years and months duration(2017)|null (null)|
 |feel-years-and-months-duration-function_ErrorCase_29|years and months duration("2012T-12-2511:00:00Z")|null (null)|
 |feel-years-and-months-duration-function_ErrorCase_30|years and months duration([],[])|null (null)|
-|feel-years-and-months-duration-function_ErrorCase_31|years and months duration(date("2013-08-24"), date and time("2017-12-15T00:59:59"))|null (null)|
-|feel-years-and-months-duration-function_ErrorCase_32|years and months duration(date and time("2017-02-28T23:59:59"), date("2019-07-23") )|null (null)|
 |feel-years-and-months-duration-function_33|years and months duration(from:date and time("2016-12-31T00:00:01"),to:date and time("2017-12-31T23:59:59"))|P1Y (years and months duration)|
 |feel-years-and-months-duration-function_34|years and months duration(from:date and time("2014-12-31T23:59:59"),to:date and time("2016-12-31T00:00:01"))|P2Y (years and months duration)|
 |feel-years-and-months-duration-function_35|years and months duration(from:date("2011-12-22"),to:date("2013-08-24"))|P1Y8M (years and months duration)|


### PR DESCRIPTION
As per DMN spec, date function can be used in place of date and time