### PR TITLE
Added target BKM Test

### DIFF
--- a/TestCases/testCases.xsd
+++ b/TestCases/testCases.xsd
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by Bruce Silver (private) -->
 <xs:schema xmlns="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.omg.org/spec/DMN/20160719/testcase" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:simpleType name="testCaseType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="decision"/>
+			<xs:enumeration value="bkm"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:element name="testCases">
 		<xs:complexType>
 			<xs:sequence>
@@ -41,6 +47,7 @@
 							</xs:element>
 						</xs:sequence>
 						<xs:attribute name="id" type="xs:string"/>
+						<xs:attribute name="type" type="testCaseType" default="decision"/>
 					</xs:complexType>
 				</xs:element>
 			</xs:sequence>


### PR DESCRIPTION
My contribution to issue #89 

Essentially, i'm proposing adding a targetBKM attribute to the existing testCase definition. This would hold the name of a BKM in the model.

You can then use inputNodes/resultNodes as you would normally, the only caveat is that there would be a single resultNode with the BKM name.

For instance the testcase 0001 would become if we would change the logic of _Greating Message_ to a BKM:

	<testCase id="001" **targetBKM="Greeting Message"**>
		<description>Testing valid input</description>
		<inputNode name="Full Name">
			<value>John Doe</value>
		</inputNode>
		<resultNode name="Greeting Message" **type="bkm"**>
			<expected>
				<value>Hello John Doe</value>
			</expected>
		</resultNode>
	</testCase>

I've always considered the resultNode attribute _type_ to be optional and we don't use it in our runner but I think i could be set to bkm in this case.
