### PR TITLE
Fix tck-runner-drools accordingly to modification in #119

### DIFF
--- a/runners/dmn-tck-runner-drools/src/test/java/org/omg/dmn/tck/runner/drools/DroolsTCKTest.java
+++ b/runners/dmn-tck-runner-drools/src/test/java/org/omg/dmn/tck/runner/drools/DroolsTCKTest.java
@@ -127,16 +127,15 @@ public class DroolsTCKTest
 
       DMNContext dmnctx = ctx.runtime.newContext();
       testCase.getInputNode().forEach(in -> {
-         if (in.getType() != null && "decision".equals(in.getType()))
-         {
-            DecisionNode decision = ctx.dmnmodel.getDecisionByName(in.getName());
-            dmnctx.set(in.getName(), parseValue(in, decision));
-         }
-         else
-         {
             InputDataNode input = ctx.dmnmodel.getInputByName(in.getName());
-            dmnctx.set(in.getName(), parseValue(in, input));
-         }
+            DecisionNode decision = ctx.dmnmodel.getDecisionByName(in.getName());
+            if (input != null) {
+                dmnctx.set(in.getName(), parseValue(in, input)); // normally data input from file, should be pointing at a InputData in the model
+            } else if (decision != null) {
+                dmnctx.set(in.getName(), parseValue(in, decision)); // the test case offers a pre-evaluated Decision 
+            } else {
+                throw new RuntimeException("Unable to locate InputData node or a Decision node for name: " + in.getName());
+            }
       });
 
       DMNContext resultctx = dmnctx;


### PR DESCRIPTION
Accordingly to this change:
https://github.com/dmn-tck/tck/commit/f47ef47ec947ba3ecff1e48b37aab20f91286d7b#diff-c8d71167e18a3144bd0b8ddd8d86eea7L24

the "type" attribute is no longer offered for the TCK InputNode.

This was used by tck-runner-drools here:
https://github.com/dmn-tck/tck/blob/4889b5a4ed8bbe9a1e86545ea4a3705a28e5db72/runners/dmn-tck-runner-drools/src/test/java/org/omg/dmn/tck/runner/drools/DroolsTCKTest.java#L130

This modifies the runner accordingly so that,
normally it expect the TCK InputNode name to match a DMN InputData node
of the model, for the most common case; otherwise it looks for a DMN
Decision node for the same name, for the case when a pre-evaluated
decision result is offered from the file. Finally if neither strategy
works, raise a RuntimeException to let the original producer of the TCK
test file aware of the potential issue.
.
/cc @etirelli 