### PR TITLE
Proposal for an optional Validation module checking Schema

### DIFF
--- a/runners/dmn-tck-validation/pom.xml
+++ b/runners/dmn-tck-validation/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.omg.dmn</groupId>
+    <artifactId>dmn-tck-runners</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>tck-validation</artifactId>
+  <name>DMN :: TCK :: Validation</name>
+  <description>Validate testCase xml files for both DMN model and test case definition.</description>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/runners/dmn-tck-validation/src/test/java/org/omg/dmn/tck/validation/TestCasesFiles.java
+++ b/runners/dmn-tck-validation/src/test/java/org/omg/dmn/tck/validation/TestCasesFiles.java
@@ -1,0 +1,71 @@
+
+package org.omg.dmn.tck.validation;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.xml.sax.SAXException;
+
+@RunWith(Parameterized.class)
+public class TestCasesFiles {
+
+    static Schema dmnSchema;
+    static Schema testCasesSchema;
+    static {
+        try {
+            dmnSchema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(new File("../../TestCases/dmn.xsd"));
+            testCasesSchema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(new File("../../TestCases/testCases.xsd"));
+        } catch (SAXException e) {
+            throw new RuntimeException("Unable to initialize correctly.", e);
+        }
+    }
+
+    @Parameters(name = "TestCase {0}")
+    public static Iterable<Object[]> data() {
+        List<Object[]> testCases = new ArrayList<>();
+        File cl2parent = new File("../../TestCases/compliance-level-2");
+        FileFilter filenameFilter = pathname -> pathname.isDirectory();
+        for (File file : cl2parent.listFiles(filenameFilter)) {
+            testCases.add(new Object[]{file.getName(), file});
+        }
+        File cl3parent = new File("../../TestCases/compliance-level-3");
+        for (File file : cl3parent.listFiles(filenameFilter)) {
+            testCases.add(new Object[]{file.getName(), file});
+        }
+        return testCases;
+    }
+
+    private String testCaseID;
+
+    private File basedir;
+
+    public TestCasesFiles(String testCaseID, File basedir) {
+        this.testCaseID = testCaseID;
+        this.basedir = basedir;
+    }
+
+    @Test
+    public void testDMNFileIsValid() throws Exception {
+        for (File dmnFile : basedir.listFiles((dir, name) -> name.matches(".*\\.dmn$"))) {
+            dmnSchema.newValidator().validate(new StreamSource(dmnFile));
+        }
+    }
+
+    @Test
+    public void testCaseFileIsValid() throws Exception {
+        for (File dmnFile : basedir.listFiles((dir, name) -> name.matches(".*\\.xml$"))) {
+            testCasesSchema.newValidator().validate(new StreamSource(dmnFile));
+        }
+    }
+}

--- a/runners/pom.xml
+++ b/runners/pom.xml
@@ -20,6 +20,14 @@
 
   <profiles>
     <profile>
+      <id>validation</id>
+      <modules>
+        <module>dmn-tck-validation</module>
+      </modules>
+    </profile>
+    
+    <!-- Vendor's runners Profiles: -->
+    <profile>
       <id>drools</id>
       <activation>
         <file>


### PR DESCRIPTION
..for both DMN model xml files and TestCase xml files.

We could have this under continuous integration automatically on the master branch and on proposed PRs, using Travis CI for this GitHub repo (dmn-tck/tck).

This should mitigate against the issue discussed during last TCK call (an xml file in this repo is not consistent with its Schema) and check all files are consistent with their _expected_ Schema. This is a Maven module guarded under a specific Maven Profile, so it would run only if explicitly activated and in order to NOT prevent site generation or vendor runners from executing despite some problems are detected.