### PR TITLE
Additional fix for expected empty context

### DIFF
--- a/TestCases/testCases.xsd
+++ b/TestCases/testCases.xsd
@@ -54,7 +54,7 @@
 	<xs:complexType name="valueType">
 		<xs:choice>
 			<xs:element name="value" type="xs:anySimpleType" nillable="true"/>
-			<xs:element name="component" nillable="true" maxOccurs="unbounded">
+			<xs:element name="component" nillable="true" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:complexContent>
 						<xs:extension base="valueType">


### PR DESCRIPTION
In order to support an empty context as testcase result there was already a fix that removed the required attribute for the name. But this was not sufficient. We also have to specify that inside a component no nested component is needed. Added minOccurs="0" to component.