### PR TITLE
Enable DMN engines TCK Runners during Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,16 @@
 language: java
-script: cd runners && mvn verify -B -Pvalidation
+
+jdk:
+  - openjdk8
+
+env:
+  - RUNNERS=validation
+  - RUNNERS=camunda
+  - RUNNERS=drools
+
+script: cd runners && mvn verify -B -P$RUNNERS
+
+matrix:
+  allow_failures:
+    - env: RUNNERS=camunda
+    - env: RUNNERS=drools


### PR DESCRIPTION
As per issue https://github.com/dmn-tck/tck/issues/157

Summary:

- **Option A** was chosen during tck meeting: the green/red mark will be affected just and ONLY based on validation. Result of engine runners will NOT affect the green/red mark on github pr page.

- Camunda runner was included following [this comment](https://github.com/dmn-tck/tck/issues/157#issuecomment-406737566)

/cc @etirelli kindly double-check for merge, please?