### PR TITLE
Augment Validation runner to check Vendor's results dir for basic checks

### DIFF
--- a/runners/dmn-tck-validation/pom.xml
+++ b/runners/dmn-tck-validation/pom.xml
@@ -13,6 +13,13 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.7</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/runners/dmn-tck-validation/src/test/java/org/omg/dmn/tck/validation/TestTestResultsContent.java
+++ b/runners/dmn-tck-validation/src/test/java/org/omg/dmn/tck/validation/TestTestResultsContent.java
@@ -1,0 +1,70 @@
+
+package org.omg.dmn.tck.validation;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class TestTestResultsContent {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestTestResultsContent.class);
+    private final File vendorResultParentDir;
+    private final String vendorID;
+
+    public TestTestResultsContent(File vendorResultParentDir, String vendorID) {
+        this.vendorResultParentDir = vendorResultParentDir;
+        this.vendorID = vendorID;
+    }
+
+    @Parameters(name = "Vendor {1} results")
+    public static Iterable<Object[]> data() {
+        List<Object[]> vendorResults = new ArrayList<>();
+        File parentDir = new File("../../TestResults");
+        for (File vendorResultParentDir : parentDir.listFiles(File::isDirectory)) {
+            vendorResults.add(new Object[]{vendorResultParentDir, vendorResultParentDir.getName()});
+        }
+        return vendorResults;
+    }
+
+    @Test
+    public void checkVendorResultsDir() {
+        LOG.info("Checking Vendor results directory: {}", vendorResultParentDir);
+        
+        File[] versionDirs = vendorResultParentDir.listFiles(File::isDirectory);
+        assertEquals("Only 1 version per Vendor is allowed, please consider removing old versions.", 1, versionDirs.length);
+
+        File versionDir = versionDirs[0];
+        File[] files = versionDir.listFiles(File::isFile);
+
+        LOG.info("Checking {} version {} directory...", vendorID, versionDir.getName());
+
+        Optional<File> csvFile = Stream.of(files).filter(f -> f.getName().equals("tck_results.csv")).findFirst();
+        assertTrue("Cannot find tck_results.csv file inside: " + versionDir, csvFile.isPresent());
+
+        Optional<File> propFile = Stream.of(files).filter(f -> f.getName().equals("tck_results.properties")).findFirst();
+        assertTrue("Cannot find tck_results.properties file inside: " + versionDir, propFile.isPresent());
+        try {
+            new Properties().load(new FileReader(propFile.get()));
+        } catch (IOException e) {
+            LOG.error("Unable to read tck_results.properties file.", e);
+            fail("Unable to read tck_results.properties file.");
+        }
+    }
+}

--- a/runners/dmn-tck-validation/src/test/resources/log4j.properties
+++ b/runners/dmn-tck-validation/src/test/resources/log4j.properties
@@ -1,0 +1,13 @@
+log4j.rootLogger=INFO, A1
+
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d %-5p [%c] (%t) %m%n
+
+log4j.appender.A2=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.A2.File=dmn-demo.log
+log4j.appender.A2.DatePattern='.'yyyy-MM-dd
+log4j.appender.A2.layout=org.apache.log4j.PatternLayout
+log4j.appender.A2.layout.ConversionPattern=%d %-5p [%c] (%t) %m%n
+
+log4j.logger.org.omg.dmn.tck=INFO


### PR DESCRIPTION
For each Vendor results directory:

- check only 1 version subdirectory
- that subdirectory to contain the `tck_results.csv` and `tck_results.properties` files
- minimal check `.properties` file is consistent

Further content check of both files will be performed later by the reporter runner, given we will be moving to automate website generation anyway.

This should mitigate the need to perform manual corrections like it was needed with f2535d780cda54c8188700aa11ec3da334bc7f7d