### PR TITLE
Address com.fasterxml.jackson.core:jackson-databind vulnerabilities

### DIFF
--- a/runners/dmn-tck-marshaller/pom.xml
+++ b/runners/dmn-tck-marshaller/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tck.schema.basedir>../../TestCases</tck.schema.basedir>
-    <jackson.version>2.4.0</jackson.version>
+    <jackson.version>2.8.11.1</jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
	GitHub opened this alert 27 days ago

3 com.fasterxml.jackson.core:jackson-databind vulnerabilities found in
…/dmn-tck-marshaller/pom.xml 27 days ago
Remediation
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.8.11.1
or later. For example:

<dependency>
  <groupId>com.fasterxml.jackson.core</groupId>
  <artifactId>jackson-databind</artifactId>
  <version>[2.8.11.1,)</version>
</dependency>