### PR TITLE
A few test DMN model still used spurious typeRef prefixes

### DIFF
--- a/TestCases/compliance-level-2/0003-input-data-string-allowed-values/0003-input-data-string-allowed-values.dmn
+++ b/TestCases/compliance-level-2/0003-input-data-string-allowed-values/0003-input-data-string-allowed-values.dmn
@@ -16,7 +16,7 @@
         </literalExpression>
     </decision>
     <inputData name="Employment Status" id="i_EmploymentStatus">
-        <variable typeRef="tck:tEmploymentStatus" name="Employment Status"/>
+        <variable typeRef="tEmploymentStatus" name="Employment Status"/>
     </inputData>
     <dmndi:DMNDI>
         <dmndi:DMNDiagram id="_0003-input-data-string-allowed-values_D1">

--- a/TestCases/compliance-level-2/0008-LX-arithmetic/0008-LX-arithmetic.dmn
+++ b/TestCases/compliance-level-2/0008-LX-arithmetic/0008-LX-arithmetic.dmn
@@ -21,7 +21,7 @@
         </literalExpression>
     </decision>
     <inputData name="loan" id="_1f4ae444-2e4e-4d26-b1f7-87a645c3f50a">
-        <variable typeRef="tns:tLoan" name="loan"/>
+        <variable typeRef="tLoan" name="loan"/>
     </inputData>
     <dmndi:DMNDI>
         <dmndi:DMNDiagram id="_1fedf2c0-0f4a-470c-bc66-a15528e8a49a_D1">

--- a/TestCases/compliance-level-2/0009-invocation-arithmetic/0009-invocation-arithmetic.dmn
+++ b/TestCases/compliance-level-2/0009-invocation-arithmetic/0009-invocation-arithmetic.dmn
@@ -38,7 +38,7 @@
         </encapsulatedLogic>
     </businessKnowledgeModel>
     <inputData name="Loan" id="i_Loan">
-        <variable typeRef="tns:tLoan" name="Loan"/>
+        <variable typeRef="tLoan" name="Loan"/>
     </inputData>
     <inputData name="fee" id="i_fee">
         <variable typeRef="number" name="fee"/>

--- a/TestCases/compliance-level-2/0010-multi-output-U/0010-multi-output-U.dmn
+++ b/TestCases/compliance-level-2/0010-multi-output-U/0010-multi-output-U.dmn
@@ -9,7 +9,7 @@
         </itemComponent>
     </itemDefinition>
     <decision name="Approval" id="_3b2953a3-745f-4d2e-b55d-75c8c5ae653c">
-        <variable typeRef="tns:tApproval" name="Approval"/>
+        <variable typeRef="tApproval" name="Approval"/>
         <informationRequirement id="_4f470469-654d-4e9d-9627-c44816c253a3">
             <requiredInput href="#_5a4bdb64-f0ef-4978-9e03-6f1ae64a1f17"/>
         </informationRequirement>

--- a/TestCases/compliance-level-3/0001-filter/0001-filter.dmn
+++ b/TestCases/compliance-level-3/0001-filter/0001-filter.dmn
@@ -15,7 +15,7 @@
         <typeRef>string</typeRef>
     </itemDefinition>
     <decision name="filter01" id="_4a786da5-5cd2-4c3a-ba4d-dcb3051c1812">
-        <variable typeRef="tns:tNameList" name="filter01"/>
+        <variable typeRef="tNameList" name="filter01"/>
         <informationRequirement id="_1d1d61df-e3c2-4363-8182-b97e0d96ffb8">
             <requiredInput href="#_17c8d488-19be-481b-b341-85043176a25c"/>
         </informationRequirement>
@@ -24,7 +24,7 @@
         </literalExpression>
     </decision>
     <inputData name="Employees" id="_17c8d488-19be-481b-b341-85043176a25c">
-        <variable typeRef="tns:tEmployees" name="Employees"/>
+        <variable typeRef="tEmployees" name="Employees"/>
     </inputData>
     <dmndi:DMNDI>
         <dmndi:DMNDiagram id="_f52ca843-504b-4c3b-a6bc-4d377bffef7a_D1">

--- a/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.dmn
+++ b/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.dmn
@@ -59,7 +59,7 @@
         <variable typeRef="number" name="NumC"/>
     </inputData>
     <decision name="Basic" id="_de5529b1-ed4c-4b39-9e36-e0e056aec20c">
-        <variable typeRef="tns:tBasic" name="Basic"/>
+        <variable typeRef="tBasic" name="Basic"/>
         <informationRequirement id="_17e8658a-1553-481b-872a-ea3ff99a3f30">
             <requiredInput href="#_0923ed0c-3674-4476-b84c-f9ad5e5e8048"/>
         </informationRequirement>
@@ -154,7 +154,7 @@
         </literalExpression>
     </decision>
     <decision name="Replace" id="_cc368e53-961d-4399-ad91-df00446b49d8">
-        <variable typeRef="tns:tReplace" name="Replace"/>
+        <variable typeRef="tReplace" name="Replace"/>
         <informationRequirement id="c43c1999-2a2f-419a-8816-a16d42932298">
             <requiredInput href="#_0923ed0c-3674-4476-b84c-f9ad5e5e8048"/>
         </informationRequirement>

--- a/TestCases/compliance-level-3/0004-lending/0004-lending.dmn
+++ b/TestCases/compliance-level-3/0004-lending/0004-lending.dmn
@@ -96,7 +96,7 @@
         </itemComponent>
     </itemDefinition>
     <decision name="BureauCallType" id="d_BureauCallType">
-        <variable typeRef="tns:tBureauCallType" name="BureauCallType"/>
+        <variable typeRef="tBureauCallType" name="BureauCallType"/>
         <informationRequirement id="_77738833-38e6-4520-8774-d907958edb38">
             <requiredDecision href="#d_Pre-bureauRiskCategory"/>
         </informationRequirement>
@@ -118,7 +118,7 @@
     <decision name="Strategy" id="d_Strategy">
         <question>Is credit bureau call required?</question>
         <allowedAnswers>Yes (BUREAU) or No (DECLINE, THROUGH)</allowedAnswers>
-        <variable typeRef="tns:tStrategy" name="Strategy"/>
+        <variable typeRef="tStrategy" name="Strategy"/>
         <informationRequirement id="a451ac15-800a-4021-bad0-7371ceaf77a8">
             <requiredDecision href="#d_BureauCallType"/>
         </informationRequirement>
@@ -183,7 +183,7 @@
         </decisionTable>
     </decision>
     <decision name="Eligibility" id="d_Eligibility">
-        <variable typeRef="tns:tEligibility" name="Eligibility"/>
+        <variable typeRef="tEligibility" name="Eligibility"/>
         <informationRequirement id="_53bb075b-376a-4062-b5c1-df7d3e5f55ca">
             <requiredDecision href="#d_Pre-bureauAffordability"/>
         </informationRequirement>
@@ -221,7 +221,7 @@
         </invocation>
     </decision>
     <decision name="Pre-bureauRiskCategory" id="d_Pre-bureauRiskCategory">
-        <variable typeRef="tns:tRiskCategory" name="Pre-bureauRiskCategory"/>
+        <variable typeRef="tRiskCategory" name="Pre-bureauRiskCategory"/>
         <informationRequirement id="_03407f4c-6cb9-41c4-96e5-5b55b16b2b9e">
             <requiredDecision href="#d_ApplicationRiskScore"/>
         </informationRequirement>
@@ -250,7 +250,7 @@
         </invocation>
     </decision>
     <decision name="Post-bureauRiskCategory" id="d_Post-bureauRiskCategory">
-        <variable typeRef="tns:tRiskCategory" name="Post-bureauRiskCategory"/>
+        <variable typeRef="tRiskCategory" name="Post-bureauRiskCategory"/>
         <informationRequirement id="a0a68746-9fcb-424d-82d8-a7ddfca8ef09">
             <requiredDecision href="#d_ApplicationRiskScore"/>
         </informationRequirement>
@@ -458,7 +458,7 @@
         </invocation>
     </decision>
     <decision name="Routing" id="d_Routing">
-        <variable typeRef="tns:tRouting" name="Routing"/>
+        <variable typeRef="tRouting" name="Routing"/>
         <informationRequirement id="_215e8649-6226-457c-83cc-1a3470dee477">
             <requiredDecision href="#d_Post-bureauAffordability"/>
         </informationRequirement>
@@ -502,7 +502,7 @@
         </invocation>
     </decision>
     <decision name="Adjudication" id="d_Adjudication">
-        <variable typeRef="tns:tAdjudication" name="Adjudication"/>
+        <variable typeRef="tAdjudication" name="Adjudication"/>
         <informationRequirement id="b6a62c51-d7e3-423b-b81b-f9d3c889cc7f">
             <requiredInput href="#i_BureauData"/>
         </informationRequirement>
@@ -522,7 +522,7 @@
             <formalParameter typeRef="number" name="MonthlyIncome"/>
             <formalParameter typeRef="number" name="MonthlyRepayments"/>
             <formalParameter typeRef="number" name="MonthlyExpenses"/>
-            <formalParameter typeRef="tns:tRiskCategory" name="RiskCategory"/>
+            <formalParameter typeRef="tRiskCategory" name="RiskCategory"/>
             <formalParameter typeRef="number" name="RequiredMonthlyInstallment"/>
             <context>
                 <contextEntry>
@@ -565,7 +565,7 @@
     <businessKnowledgeModel name="CreditContingencyFactorTable" id="b_CreditContingencyFactorTable">
         <variable name="CreditContingencyFactorTable"/>
         <encapsulatedLogic>
-            <formalParameter typeRef="tns:tRiskCategory" name="RiskCategory"/>
+            <formalParameter typeRef="tRiskCategory" name="RiskCategory"/>
             <decisionTable hitPolicy="UNIQUE" outputLabel="CreditContingencyFactorTable" preferredOrientation="Rule-as-Row">
                 <input id="_7cdd3950-9a45-41f0-bef0-dc54240fe4c2" label="RiskCategory">
                     <inputExpression typeRef="string">
@@ -606,7 +606,7 @@
     <businessKnowledgeModel name="EligibilityRules" id="b_EligibilityRules">
         <variable name="EligibilityRules"/>
         <encapsulatedLogic>
-            <formalParameter typeRef="tns:tRiskCategory" name="Pre-bureauRiskCategory"/>
+            <formalParameter typeRef="tRiskCategory" name="Pre-bureauRiskCategory"/>
             <formalParameter typeRef="boolean" name="Pre-bureauAffordability"/>
             <formalParameter typeRef="number" name="Age"/>
             <decisionTable hitPolicy="PRIORITY" outputLabel="EligibilityRules" preferredOrientation="Rule-as-Row">
@@ -692,7 +692,7 @@
     <businessKnowledgeModel name="BureauCallTypeTable" id="b_BureauCallTypeTable">
         <variable name="BureauCallTypeTable"/>
         <encapsulatedLogic>
-            <formalParameter typeRef="tns:tRiskCategory" name="Pre-bureauRiskCategory"/>
+            <formalParameter typeRef="tRiskCategory" name="Pre-bureauRiskCategory"/>
             <decisionTable hitPolicy="UNIQUE" outputLabel="BureauCallTypeTable" preferredOrientation="Rule-as-Row">
                 <input id="_fcd1287d-7572-4523-ab27-33eff68d965b" label="Pre-bureauRiskCategory">
                     <inputExpression typeRef="string">
@@ -1263,7 +1263,7 @@
     <businessKnowledgeModel name="RoutingRules" id="b_RoutingRules">
         <variable name="RoutingRules"/>
         <encapsulatedLogic>
-            <formalParameter typeRef="tns:tRiskCategory" name="Post-bureauRiskCategory"/>
+            <formalParameter typeRef="tRiskCategory" name="Post-bureauRiskCategory"/>
             <formalParameter typeRef="boolean" name="Post-bureauAffordability"/>
             <formalParameter typeRef="boolean" name="Bankrupt"/>
             <formalParameter typeRef="number" name="CreditScore"/>
@@ -1382,13 +1382,13 @@
         </encapsulatedLogic>
     </businessKnowledgeModel>
     <inputData name="ApplicantData" id="i_ApplicantData">
-        <variable typeRef="tns:tApplicantData" name="ApplicantData"/>
+        <variable typeRef="tApplicantData" name="ApplicantData"/>
     </inputData>
     <inputData name="BureauData" id="i_BureauData">
-        <variable typeRef="tns:tBureauData" name="BureauData"/>
+        <variable typeRef="tBureauData" name="BureauData"/>
     </inputData>
     <inputData name="RequestedProduct" id="i_RequestedProduct">
-        <variable typeRef="tns:tRequestedProduct" name="RequestedProduct"/>
+        <variable typeRef="tRequestedProduct" name="RequestedProduct"/>
     </inputData>
     <inputData name="SupportingDocuments" id="i_SupportingDocuments">
         <variable typeRef="string" name="SupportingDocuments"/>

--- a/TestCases/compliance-level-3/0005-literal-invocation/0005-literal-invocation.dmn
+++ b/TestCases/compliance-level-3/0005-literal-invocation/0005-literal-invocation.dmn
@@ -38,7 +38,7 @@
         </encapsulatedLogic>
     </businessKnowledgeModel>
     <inputData name="Loan" id="i_Loan">
-        <variable typeRef="tns:tLoan" name="Loan"/>
+        <variable typeRef="tLoan" name="Loan"/>
     </inputData>
     <inputData name="fee" id="i_fee">
         <variable typeRef="number" name="fee"/>

--- a/TestCases/compliance-level-3/0006-join/0006-join.dmn
+++ b/TestCases/compliance-level-3/0006-join/0006-join.dmn
@@ -38,10 +38,10 @@
         </literalExpression>
     </decision>
     <inputData name="EmployeeTable" id="_7985579c-554c-4d98-aad6-c9dbacff726b">
-        <variable typeRef="tns:tEmployeeTable" name="EmployeeTable"/>
+        <variable typeRef="tEmployeeTable" name="EmployeeTable"/>
     </inputData>
     <inputData name="DeptTable" id="_35b4f57c-e574-4963-a149-83cc0030e809">
-        <variable typeRef="tns:tDeptTable" name="DeptTable"/>
+        <variable typeRef="tDeptTable" name="DeptTable"/>
     </inputData>
     <inputData name="LastName" id="_7b08bda2-fcf4-44e8-8022-08d9043e1dee">
         <variable typeRef="string" name="LastName"/>

--- a/TestCases/compliance-level-3/0007-date-time/0007-date-time.dmn
+++ b/TestCases/compliance-level-3/0007-date-time/0007-date-time.dmn
@@ -38,7 +38,7 @@
         <variable typeRef="string" name="timeString"/>
     </inputData>
     <decision name="Date" id="_bd547a08-c157-47ca-84d4-ac6f3d5bdeda">
-        <variable typeRef="tns:tDateVariants" name="Date"/>
+        <variable typeRef="tDateVariants" name="Date"/>
         <informationRequirement id="_5ed07807-110d-4dd1-b721-c2a1965196ac">
             <requiredInput href="#_74a9c3ad-a813-444e-88ee-8a91096ee233"/>
         </informationRequirement>

--- a/TestCases/compliance-level-3/0008-listGen/0008-listGen.dmn
+++ b/TestCases/compliance-level-3/0008-listGen/0008-listGen.dmn
@@ -4,7 +4,7 @@
         <typeRef>string</typeRef>
     </itemDefinition>
     <decision name="listGen1" id="_102c003f-ec24-47a9-bfa1-36d05f1452f6">
-        <variable typeRef="tns:tStringList" name="listGen1"/>
+        <variable typeRef="tStringList" name="listGen1"/>
         <literalExpression>
             <text>["a","b","c"]</text>
         </literalExpression>
@@ -19,7 +19,7 @@
         <variable typeRef="string" name="c"/>
     </inputData>
     <decision name="listGen2" id="_2504224f-d1c3-43cb-9216-8f9d4ffdfd72">
-        <variable typeRef="tns:tStringList" name="listGen2"/>
+        <variable typeRef="tStringList" name="listGen2"/>
         <informationRequirement id="_5320d4d9-c2f9-4fb1-9fd4-fa2f267bb101">
             <requiredInput href="#_018d53fc-1aef-4e1b-b418-c0fb7c36753b"/>
         </informationRequirement>
@@ -34,7 +34,7 @@
         </literalExpression>
     </decision>
     <decision name="listGen3" id="_5786c8b8-bea1-4b1f-9f7b-71be3f4ffbcc">
-        <variable typeRef="tns:tStringList" name="listGen3"/>
+        <variable typeRef="tStringList" name="listGen3"/>
         <informationRequirement id="a18bbcfe-f486-4f37-87c5-fa5268f856d2">
             <requiredInput href="#_7cd90c11-7224-41eb-95b0-109c0d5930c3"/>
         </informationRequirement>
@@ -46,7 +46,7 @@
         </literalExpression>
     </decision>
     <decision name="listGen4" id="_ca299168-4590-4040-bb10-beb7d1a6932b">
-        <variable typeRef="tns:tStringList" name="listGen4"/>
+        <variable typeRef="tStringList" name="listGen4"/>
         <informationRequirement id="_52fb84a1-a1e7-43fa-8b31-832e9870df55">
             <requiredInput href="#_2b11df48-aba7-435d-a2ea-e10da78fb70e"/>
         </informationRequirement>
@@ -84,7 +84,7 @@
         </decisionTable>
     </decision>
     <decision name="listGen5" id="_4a428274-6c5f-4c4c-ac86-1e81df943704">
-        <variable typeRef="tns:tStringList" name="listGen5"/>
+        <variable typeRef="tStringList" name="listGen5"/>
         <informationRequirement id="_0c6fad9d-246d-4da2-8278-3f85f74aabfe">
             <requiredInput href="#_018d53fc-1aef-4e1b-b418-c0fb7c36753b"/>
         </informationRequirement>
@@ -156,16 +156,16 @@
         </decisionTable>
     </decision>
     <inputData name="wx" id="_c51e77a1-30a4-4f23-9054-6c359bf80e9f">
-        <variable typeRef="tns:tStringList" name="wx"/>
+        <variable typeRef="tStringList" name="wx"/>
     </inputData>
     <decision name="listGen6" id="_50554bc6-d4e1-468b-a620-db2d35da5a0b">
-        <variable typeRef="tns:tStringList" name="listGen6"/>
+        <variable typeRef="tStringList" name="listGen6"/>
         <literalExpression>
             <text>flatten([["w","x"],"y","z"])</text>
         </literalExpression>
     </decision>
     <decision name="listGen7" id="_6d3062b2-55d4-4299-aeb2-a5e97e03daec">
-        <variable typeRef="tns:tStringList" name="listGen7"/>
+        <variable typeRef="tStringList" name="listGen7"/>
         <informationRequirement id="_5fa9d354-9df3-4ec4-af40-98d2aefdb031">
             <requiredInput href="#_c51e77a1-30a4-4f23-9054-6c359bf80e9f"/>
         </informationRequirement>
@@ -174,7 +174,7 @@
         </literalExpression>
     </decision>
     <decision name="listGen8" id="_bd8b0287-1ff4-4c13-b0ef-68cff151cabd">
-        <variable typeRef="tns:tStringList" name="listGen8"/>
+        <variable typeRef="tStringList" name="listGen8"/>
         <informationRequirement id="f5178a85-b0e5-4e39-86ab-ec1c0bf635d9">
             <requiredInput href="#_018d53fc-1aef-4e1b-b418-c0fb7c36753b"/>
         </informationRequirement>
@@ -189,7 +189,7 @@
         </literalExpression>
     </decision>
     <decision name="listGen9" id="_64ccac33-c22b-454d-b763-5a77ffd38678">
-        <variable typeRef="tns:tStringList" name="listGen9"/>
+        <variable typeRef="tStringList" name="listGen9"/>
         <informationRequirement id="a7acf200-5451-429d-9e7b-8bc3e3715fb7">
             <requiredInput href="#_018d53fc-1aef-4e1b-b418-c0fb7c36753b"/>
         </informationRequirement>
@@ -204,7 +204,7 @@
         </literalExpression>
     </decision>
     <decision name="listGen10" id="_9d464a01-5230-4270-88b6-f8e08d03e10b">
-        <variable typeRef="tns:tStringList" name="listGen10"/>
+        <variable typeRef="tStringList" name="listGen10"/>
         <informationRequirement id="eb713f78-1f6a-4fd2-a650-26afed5ae718">
             <requiredDecision href="#_6d3062b2-55d4-4299-aeb2-a5e97e03daec"/>
         </informationRequirement>

--- a/TestCases/compliance-level-3/0013-sort/0013-sort.dmn
+++ b/TestCases/compliance-level-3/0013-sort/0013-sort.dmn
@@ -18,19 +18,19 @@
         </itemComponent>
     </itemDefinition>
     <itemDefinition isCollection="true" name="tTable" id="tTable">
-        <typeRef>tns:tRow</typeRef>
+        <typeRef>tRow</typeRef>
     </itemDefinition>
     <itemDefinition isCollection="true" name="tStringList" id="tStringList">
         <typeRef>string</typeRef>
     </itemDefinition>
     <inputData name="listA" id="_d8747cda-26be-46c8-98ee-78f64efbf730">
-        <variable typeRef="tns:tNumList" name="listA"/>
+        <variable typeRef="tNumList" name="listA"/>
     </inputData>
     <inputData name="tableB" id="_f8197899-44af-4ec5-9453-26da073a2be3">
-        <variable typeRef="tns:tTable" name="tableB"/>
+        <variable typeRef="tTable" name="tableB"/>
     </inputData>
     <decision name="sort1" id="_c6416c42-328a-410c-a083-859b82771690">
-        <variable typeRef="tns:tNumList" name="sort1"/>
+        <variable typeRef="tNumList" name="sort1"/>
         <informationRequirement id="_5fec54dd-e626-4936-9086-06568a444ea9">
             <requiredInput href="#_d8747cda-26be-46c8-98ee-78f64efbf730"/>
         </informationRequirement>
@@ -39,7 +39,7 @@
         </literalExpression>
     </decision>
     <decision name="sort2" id="_d8ef1de9-9387-4389-ab83-cbf9dafc419b">
-        <variable typeRef="tns:tTable" name="sort2"/>
+        <variable typeRef="tTable" name="sort2"/>
         <informationRequirement id="_39f538b5-afe3-49ba-a3c5-dd419baa11c4">
             <requiredInput href="#_f8197899-44af-4ec5-9453-26da073a2be3"/>
         </informationRequirement>
@@ -48,10 +48,10 @@
         </literalExpression>
     </decision>
     <inputData name="stringList" id="_7471008b-e8c7-4205-8e17-586ff41e7205">
-        <variable typeRef="tns:tStringList" name="stringList"/>
+        <variable typeRef="tStringList" name="stringList"/>
     </inputData>
     <decision name="sort3" id="_4ff4b8ff-4379-477a-a016-f7d1741d2036">
-        <variable typeRef="tns:tStringList" name="sort3"/>
+        <variable typeRef="tStringList" name="sort3"/>
         <informationRequirement id="_6ce95c21-4d3d-4405-a285-284441ee45e5">
             <requiredInput href="#_7471008b-e8c7-4205-8e17-586ff41e7205"/>
         </informationRequirement>

--- a/TestCases/compliance-level-3/0017-tableTests/0017-tableTests.dmn
+++ b/TestCases/compliance-level-3/0017-tableTests/0017-tableTests.dmn
@@ -15,7 +15,7 @@
         <typeRef>string</typeRef>
     </itemDefinition>
     <inputData name="structA" id="_18b9d486-1ec0-436d-af4b-3e4567e8bca9">
-        <variable typeRef="tns:tA" name="structA"/>
+        <variable typeRef="tA" name="structA"/>
     </inputData>
     <inputData name="numB" id="_3b175722-5f96-49e4-a50d-0bf9588c901c">
         <variable typeRef="number" name="numB"/>

--- a/TestCases/compliance-level-3/0021-singleton-list/0021-singleton-list.dmn
+++ b/TestCases/compliance-level-3/0021-singleton-list/0021-singleton-list.dmn
@@ -4,10 +4,10 @@
         <typeRef>string</typeRef>
     </itemDefinition>
     <inputData name="Employees" id="_Employees">
-        <variable typeRef="tns:tStringList" name="Employees"/>
+        <variable typeRef="tStringList" name="Employees"/>
     </inputData>
     <decision name="decision1" id="decision1">
-        <variable typeRef="tns:tStringList" name="decision1"/>
+        <variable typeRef="tStringList" name="decision1"/>
         <informationRequirement id="_14c133f4-3127-4c16-97b6-e0e1b76d2c07">
             <requiredInput href="#_Employees"/>
         </informationRequirement>
@@ -25,7 +25,7 @@
         </literalExpression>
     </decision>
     <decision name="decision3" id="decision3">
-        <variable typeRef="tns:tStringList" name="decision3"/>
+        <variable typeRef="tStringList" name="decision3"/>
         <informationRequirement id="_8643a0b7-f6a9-45fe-9fa1-3550c6b289c4">
             <requiredInput href="#_Employees"/>
         </informationRequirement>

--- a/TestCases/compliance-level-3/0031-user-defined-functions/0031-user-defined-functions.dmn
+++ b/TestCases/compliance-level-3/0031-user-defined-functions/0031-user-defined-functions.dmn
@@ -43,7 +43,7 @@
         </itemComponent>
     </itemDefinition>
     <decision name="fn library" id="_q2qzIH6LEeePe9Zmt-encA">
-        <variable typeRef="ns1:tFnLibrary" name="fn library" id="_mRL98YDJEee-MeWXoLgrYg"/>
+        <variable typeRef="tFnLibrary" name="fn library" id="_mRL98YDJEee-MeWXoLgrYg"/>
         <context id="_zl1isH6LEeePe9Zmt-encA">
             <contextEntry>
                 <variable name="sumFn" id="_tc5HIH6OEeePe9Zmt-encA"/>
@@ -76,7 +76,7 @@
         </context>
     </decision>
     <decision name="fn invocation positional parameters" id="_AfhOEH6QEeePe9Zmt-encA">
-        <variable typeRef="ns1:tFnInvocationPositionalResult" name="fn invocation positional parameters" id="_rwrh8YDIEee-MeWXoLgrYg"/>
+        <variable typeRef="tFnInvocationPositionalResult" name="fn invocation positional parameters" id="_rwrh8YDIEee-MeWXoLgrYg"/>
         <informationRequirement id="f1a77547-c863-4c5c-8c40-c7118c9c56a7">
             <requiredDecision href="#_q2qzIH6LEeePe9Zmt-encA"/>
         </informationRequirement>
@@ -86,7 +86,7 @@
         <informationRequirement id="_1080c15e-bc84-4473-99f3-1b8ea7d12e61">
             <requiredInput href="#_5eBhQH6PEeePe9Zmt-encA"/>
         </informationRequirement>
-        <context typeRef="ns1:tFnInvocationResult" id="_JvSJQX6QEeePe9Zmt-encA">
+        <context typeRef="tFnInvocationResult" id="_JvSJQX6QEeePe9Zmt-encA">
             <contextEntry>
                 <variable name="sumResult" id="_TEHYYH6VEeePe9Zmt-encA"/>
                 <literalExpression id="_TEHYYX6VEeePe9Zmt-encA">
@@ -108,7 +108,7 @@
         </context>
     </decision>
     <decision name="fn invocation named parameters" id="_yHl3UIDhEee-MeWXoLgrYg">
-        <variable typeRef="ns1:tFnInvocationNamedResult" name="fn invocation named parameters" id="_eApsUYDjEee-MeWXoLgrYg"/>
+        <variable typeRef="tFnInvocationNamedResult" name="fn invocation named parameters" id="_eApsUYDjEee-MeWXoLgrYg"/>
         <informationRequirement id="_821bbeda-972a-489b-9467-9bdefd14b793">
             <requiredInput href="#_5eBhQH6PEeePe9Zmt-encA"/>
         </informationRequirement>
@@ -146,7 +146,7 @@
         </context>
     </decision>
     <decision name="fn invocation complex parameters" id="_b-gD0IDiEee-MeWXoLgrYg">
-        <variable typeRef="ns1:tFnInvocationComplexParamsResult" name="fn invocation complex parameters" id="_vU2_EYDjEee-MeWXoLgrYg"/>
+        <variable typeRef="tFnInvocationComplexParamsResult" name="fn invocation complex parameters" id="_vU2_EYDjEee-MeWXoLgrYg"/>
         <informationRequirement id="_9c0d7e05-550b-4b5d-a99f-455c098509f5">
             <requiredInput href="#_48BAYH6PEeePe9Zmt-encA"/>
         </informationRequirement>
@@ -159,7 +159,7 @@
         <knowledgeRequirement id="_548a994a-9a94-4df4-8245-eaefde56cb58">
             <requiredKnowledge href="#_8xmTAIDNEee-MeWXoLgrYg"/>
         </knowledgeRequirement>
-        <context typeRef="ns1:tFnInvocationResult" id="_eA6AcYDiEee-MeWXoLgrYg">
+        <context typeRef="tFnInvocationResult" id="_eA6AcYDiEee-MeWXoLgrYg">
             <contextEntry>
                 <variable name="functionInvocationInParameter" id="_eA6Aj4DiEee-MeWXoLgrYg"/>
                 <literalExpression id="_eA6AkYDiEee-MeWXoLgrYg">

--- a/TestCases/compliance-level-3/1100-feel-decimal-function/1100-feel-decimal-function.dmn
+++ b/TestCases/compliance-level-3/1100-feel-decimal-function/1100-feel-decimal-function.dmn
@@ -35,7 +35,7 @@
         <description>Tests FEEL expression: 'decimal(1/3, 2)' and expects result: '0.33 (number)'</description>
         <question>Result of FEEL expression 'decimal(1/3, 2)'?</question>
         <allowedAnswers>0.33 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_001_af177e63fc_Result" name="feel-decimal-function_001_af177e63fc" id="_i7fQhPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_001_af177e63fc_Result" name="feel-decimal-function_001_af177e63fc" id="_i7fQhPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQgvUUEeesLuP4RHs4vA">
             <text>decimal(1/3, 2)</text>
         </literalExpression>
@@ -44,7 +44,7 @@
         <description>Tests FEEL expression: 'decimal(1/3, 2.5)' and expects result: '0.33 (number)'</description>
         <question>Result of FEEL expression 'decimal(1/3, 2.5)'?</question>
         <allowedAnswers>0.33 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_002_f4ed9cd487_Result" name="feel-decimal-function_002_f4ed9cd487" id="_i7fQiPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_002_f4ed9cd487_Result" name="feel-decimal-function_002_f4ed9cd487" id="_i7fQiPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQhvUUEeesLuP4RHs4vA">
             <text>decimal(1/3, 2.5)</text>
         </literalExpression>
@@ -53,7 +53,7 @@
         <description>Tests FEEL expression: 'decimal(1.5, 0)' and expects result: '2 (number)'</description>
         <question>Result of FEEL expression 'decimal(1.5, 0)'?</question>
         <allowedAnswers>2 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_003_2d50ec7ffc_Result" name="feel-decimal-function_003_2d50ec7ffc" id="_i7fQjPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_003_2d50ec7ffc_Result" name="feel-decimal-function_003_2d50ec7ffc" id="_i7fQjPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQivUUEeesLuP4RHs4vA">
             <text>decimal(1.5, 0)</text>
         </literalExpression>
@@ -62,7 +62,7 @@
         <description>Tests FEEL expression: 'decimal(2.5, 0)' and expects result: '2 (number)'</description>
         <question>Result of FEEL expression 'decimal(2.5, 0)'?</question>
         <allowedAnswers>2 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_004_bb6f445d2c_Result" name="feel-decimal-function_004_bb6f445d2c" id="_i7fQkPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_004_bb6f445d2c_Result" name="feel-decimal-function_004_bb6f445d2c" id="_i7fQkPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQjvUUEeesLuP4RHs4vA">
             <text>decimal(2.5, 0)</text>
         </literalExpression>
@@ -71,7 +71,7 @@
         <description>Tests FEEL expression: 'decimal(0, 0)' and expects result: '0 (number)'</description>
         <question>Result of FEEL expression 'decimal(0, 0)'?</question>
         <allowedAnswers>0 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_005_55d33eadf6_Result" name="feel-decimal-function_005_55d33eadf6" id="_i7fQlPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_005_55d33eadf6_Result" name="feel-decimal-function_005_55d33eadf6" id="_i7fQlPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQkvUUEeesLuP4RHs4vA">
             <text>decimal(0, 0)</text>
         </literalExpression>
@@ -80,7 +80,7 @@
         <description>Tests FEEL expression: 'decimal(0.0, 1)' and expects result: '0.0 (number)'</description>
         <question>Result of FEEL expression 'decimal(0.0, 1)'?</question>
         <allowedAnswers>0.0 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_006_d9661e1d45_Result" name="feel-decimal-function_006_d9661e1d45" id="_i7fQmPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_006_d9661e1d45_Result" name="feel-decimal-function_006_d9661e1d45" id="_i7fQmPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQlvUUEeesLuP4RHs4vA">
             <text>decimal(0.0, 1)</text>
         </literalExpression>
@@ -89,7 +89,7 @@
         <description>Tests FEEL expression: 'decimal(0.515, 2)' and expects result: '0.52 (number)'</description>
         <question>Result of FEEL expression 'decimal(0.515, 2)'?</question>
         <allowedAnswers>0.52 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_007_49f7a22058_Result" name="feel-decimal-function_007_49f7a22058" id="_i7fQnPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_007_49f7a22058_Result" name="feel-decimal-function_007_49f7a22058" id="_i7fQnPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQmvUUEeesLuP4RHs4vA">
             <text>decimal(0.515, 2)</text>
         </literalExpression>
@@ -98,7 +98,7 @@
         <description>Tests FEEL expression: 'decimal(65.123456, 6)' and expects result: '65.123456 (number)'</description>
         <question>Result of FEEL expression 'decimal(65.123456, 6)'?</question>
         <allowedAnswers>65.123456 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_008_73e4f1c8b9_Result" name="feel-decimal-function_008_73e4f1c8b9" id="_i7fQoPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_008_73e4f1c8b9_Result" name="feel-decimal-function_008_73e4f1c8b9" id="_i7fQoPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQnvUUEeesLuP4RHs4vA">
             <text>decimal(65.123456, 6)</text>
         </literalExpression>
@@ -107,7 +107,7 @@
         <description>Tests FEEL expression: 'decimal(n:15/7,scale:3)' and expects result: '2.143 (number)'</description>
         <question>Result of FEEL expression 'decimal(n:15/7,scale:3)'?</question>
         <allowedAnswers>2.143 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_009_398b94286e_Result" name="feel-decimal-function_009_398b94286e" id="_i7fQpPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_009_398b94286e_Result" name="feel-decimal-function_009_398b94286e" id="_i7fQpPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQovUUEeesLuP4RHs4vA">
             <text>decimal(n:15/7,scale:3)</text>
         </literalExpression>
@@ -116,7 +116,7 @@
         <description>Tests FEEL expression: 'decimal(n:15/78*2,scale:3)' and expects result: '0.385 (number)'</description>
         <question>Result of FEEL expression 'decimal(n:15/78*2,scale:3)'?</question>
         <allowedAnswers>0.385 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-decimal-function_010_4b46e59c8b_Result" name="feel-decimal-function_010_4b46e59c8b" id="_i7fQqPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-decimal-function_010_4b46e59c8b_Result" name="feel-decimal-function_010_4b46e59c8b" id="_i7fQqPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i7fQpvUUEeesLuP4RHs4vA">
             <text>decimal(n:15/78*2,scale:3)</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1101-feel-floor-function/1101-feel-floor-function.dmn
+++ b/TestCases/compliance-level-3/1101-feel-floor-function/1101-feel-floor-function.dmn
@@ -23,7 +23,7 @@
         <description>Tests FEEL expression: 'floor(1.5)' and expects result: '1 (number)'</description>
         <question>Result of FEEL expression 'floor(1.5)'?</question>
         <allowedAnswers>1 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-floor-function_001_75592d0dee_Result" name="feel-floor-function_001_75592d0dee" id="_i9gCtPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-floor-function_001_75592d0dee_Result" name="feel-floor-function_001_75592d0dee" id="_i9gCtPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i9gCsvUUEeesLuP4RHs4vA">
             <text>floor(1.5)</text>
         </literalExpression>
@@ -32,7 +32,7 @@
         <description>Tests FEEL expression: 'floor(-1.5)' and expects result: '-2 (number)'</description>
         <question>Result of FEEL expression 'floor(-1.5)'?</question>
         <allowedAnswers>-2 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-floor-function_002_6fea586853_Result" name="feel-floor-function_002_6fea586853" id="_i9gCuPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-floor-function_002_6fea586853_Result" name="feel-floor-function_002_6fea586853" id="_i9gCuPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i9gCtvUUEeesLuP4RHs4vA">
             <text>floor(-1.5)</text>
         </literalExpression>
@@ -41,7 +41,7 @@
         <description>Tests FEEL expression: 'floor(--1)' and expects result: '1 (number)'</description>
         <question>Result of FEEL expression 'floor(--1)'?</question>
         <allowedAnswers>1 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-floor-function_003_cbae05445d_Result" name="feel-floor-function_003_cbae05445d" id="_i9gpwPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-floor-function_003_cbae05445d_Result" name="feel-floor-function_003_cbae05445d" id="_i9gpwPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i9gCuvUUEeesLuP4RHs4vA">
             <text>floor(--1)</text>
         </literalExpression>
@@ -50,7 +50,7 @@
         <description>Tests FEEL expression: 'floor(-5/2.3*5)' and expects result: '-11 (number)'</description>
         <question>Result of FEEL expression 'floor(-5/2.3*5)'?</question>
         <allowedAnswers>-11 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-floor-function_004_30f6d26798_Result" name="feel-floor-function_004_30f6d26798" id="_i9gpxPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-floor-function_004_30f6d26798_Result" name="feel-floor-function_004_30f6d26798" id="_i9gpxPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i9gpwvUUEeesLuP4RHs4vA">
             <text>floor(-5/2.3*5)</text>
         </literalExpression>
@@ -59,7 +59,7 @@
         <description>Tests FEEL expression: 'floor(n:5.777)' and expects result: '5 (number)'</description>
         <question>Result of FEEL expression 'floor(n:5.777)'?</question>
         <allowedAnswers>5 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-floor-function_005_dd970ad275_Result" name="feel-floor-function_005_dd970ad275" id="_i9hQ0PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-floor-function_005_dd970ad275_Result" name="feel-floor-function_005_dd970ad275" id="_i9hQ0PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i9gpxvUUEeesLuP4RHs4vA">
             <text>floor(n:5.777)</text>
         </literalExpression>
@@ -68,7 +68,7 @@
         <description>Tests FEEL expression: 'floor(n:-.33333)' and expects result: '-1 (number)'</description>
         <question>Result of FEEL expression 'floor(n:-.33333)'?</question>
         <allowedAnswers>-1 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-floor-function_006_1223620d9c_Result" name="feel-floor-function_006_1223620d9c" id="_i9hQ1PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-floor-function_006_1223620d9c_Result" name="feel-floor-function_006_1223620d9c" id="_i9hQ1PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i9hQ0vUUEeesLuP4RHs4vA">
             <text>floor(n:-.33333)</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1102-feel-ceiling-function/1102-feel-ceiling-function.dmn
+++ b/TestCases/compliance-level-3/1102-feel-ceiling-function/1102-feel-ceiling-function.dmn
@@ -23,7 +23,7 @@
         <description>Tests FEEL expression: 'ceiling(1.5)' and expects result: '2 (number)'</description>
         <question>Result of FEEL expression 'ceiling(1.5)'?</question>
         <allowedAnswers>2 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-ceiling-function_001_3df249d9c6_Result" name="feel-ceiling-function_001_3df249d9c6" id="_i-UiFfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-ceiling-function_001_3df249d9c6_Result" name="feel-ceiling-function_001_3df249d9c6" id="_i-UiFfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-UiE_UUEeesLuP4RHs4vA">
             <text>ceiling(1.5)</text>
         </literalExpression>
@@ -32,7 +32,7 @@
         <description>Tests FEEL expression: 'ceiling(-1.5)' and expects result: '-1 (number)'</description>
         <question>Result of FEEL expression 'ceiling(-1.5)'?</question>
         <allowedAnswers>-1 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-ceiling-function_002_1052993cd8_Result" name="feel-ceiling-function_002_1052993cd8" id="_i-UiGfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-ceiling-function_002_1052993cd8_Result" name="feel-ceiling-function_002_1052993cd8" id="_i-UiGfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-UiF_UUEeesLuP4RHs4vA">
             <text>ceiling(-1.5)</text>
         </literalExpression>
@@ -41,7 +41,7 @@
         <description>Tests FEEL expression: 'ceiling(--1)' and expects result: '1 (number)'</description>
         <question>Result of FEEL expression 'ceiling(--1)'?</question>
         <allowedAnswers>1 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-ceiling-function_003_ca33989df5_Result" name="feel-ceiling-function_003_ca33989df5" id="_i-UiHfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-ceiling-function_003_ca33989df5_Result" name="feel-ceiling-function_003_ca33989df5" id="_i-UiHfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-UiG_UUEeesLuP4RHs4vA">
             <text>ceiling(--1)</text>
         </literalExpression>
@@ -50,7 +50,7 @@
         <description>Tests FEEL expression: 'ceiling(-5/2.3*5)' and expects result: '-10 (number)'</description>
         <question>Result of FEEL expression 'ceiling(-5/2.3*5)'?</question>
         <allowedAnswers>-10 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-ceiling-function_004_be4a3e809c_Result" name="feel-ceiling-function_004_be4a3e809c" id="_i-UiIfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-ceiling-function_004_be4a3e809c_Result" name="feel-ceiling-function_004_be4a3e809c" id="_i-UiIfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-UiH_UUEeesLuP4RHs4vA">
             <text>ceiling(-5/2.3*5)</text>
         </literalExpression>
@@ -59,7 +59,7 @@
         <description>Tests FEEL expression: 'ceiling(n:5.777)' and expects result: '6 (number)'</description>
         <question>Result of FEEL expression 'ceiling(n:5.777)'?</question>
         <allowedAnswers>6 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-ceiling-function_005_cc56ed5373_Result" name="feel-ceiling-function_005_cc56ed5373" id="_i-UiJfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-ceiling-function_005_cc56ed5373_Result" name="feel-ceiling-function_005_cc56ed5373" id="_i-UiJfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-UiI_UUEeesLuP4RHs4vA">
             <text>ceiling(n:5.777)</text>
         </literalExpression>
@@ -68,7 +68,7 @@
         <description>Tests FEEL expression: 'ceiling(n:-.33333)' and expects result: '0 (number)'</description>
         <question>Result of FEEL expression 'ceiling(n:-.33333)'?</question>
         <allowedAnswers>0 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-ceiling-function_006_bbdf3bf8d7_Result" name="feel-ceiling-function_006_bbdf3bf8d7" id="_i-UiKfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-ceiling-function_006_bbdf3bf8d7_Result" name="feel-ceiling-function_006_bbdf3bf8d7" id="_i-UiKfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-UiJ_UUEeesLuP4RHs4vA">
             <text>ceiling(n:-.33333)</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1103-feel-substring-function/1103-feel-substring-function.dmn
+++ b/TestCases/compliance-level-3/1103-feel-substring-function/1103-feel-substring-function.dmn
@@ -38,7 +38,7 @@
         <description>Tests FEEL expression: 'substring("f",1)' and expects result: '"f" (string)'</description>
         <question>Result of FEEL expression 'substring("f",1)'?</question>
         <allowedAnswers>"f" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_001_53051b5628_Result" name="feel-substring-function_001_53051b5628" id="_i-6X8_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_001_53051b5628_Result" name="feel-substring-function_001_53051b5628" id="_i-6X8_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6X8fUUEeesLuP4RHs4vA">
             <text>substring("f",1)</text>
         </literalExpression>
@@ -47,7 +47,7 @@
         <description>Tests FEEL expression: 'substring("f",1,1)' and expects result: '"f" (string)'</description>
         <question>Result of FEEL expression 'substring("f",1,1)'?</question>
         <allowedAnswers>"f" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_002_03d12b93f0_Result" name="feel-substring-function_002_03d12b93f0" id="_i-6X9_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_002_03d12b93f0_Result" name="feel-substring-function_002_03d12b93f0" id="_i-6X9_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6X9fUUEeesLuP4RHs4vA">
             <text>substring("f",1,1)</text>
         </literalExpression>
@@ -56,7 +56,7 @@
         <description>Tests FEEL expression: 'substring("foobar",6)' and expects result: '"r" (string)'</description>
         <question>Result of FEEL expression 'substring("foobar",6)'?</question>
         <allowedAnswers>"r" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_003_6d06b1d2ec_Result" name="feel-substring-function_003_6d06b1d2ec" id="_i-6X-_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_003_6d06b1d2ec_Result" name="feel-substring-function_003_6d06b1d2ec" id="_i-6X-_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6X-fUUEeesLuP4RHs4vA">
             <text>substring("foobar",6)</text>
         </literalExpression>
@@ -65,7 +65,7 @@
         <description>Tests FEEL expression: 'substring("foobar",1,6)' and expects result: '"foobar" (string)'</description>
         <question>Result of FEEL expression 'substring("foobar",1,6)'?</question>
         <allowedAnswers>"foobar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_004_938a24e7af_Result" name="feel-substring-function_004_938a24e7af" id="_i-6X__UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_004_938a24e7af_Result" name="feel-substring-function_004_938a24e7af" id="_i-6X__UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6X_fUUEeesLuP4RHs4vA">
             <text>substring("foobar",1,6)</text>
         </literalExpression>
@@ -74,7 +74,7 @@
         <description>Tests FEEL expression: 'substring("foobar",3)' and expects result: '"obar" (string)'</description>
         <question>Result of FEEL expression 'substring("foobar",3)'?</question>
         <allowedAnswers>"obar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_005_21fcca286c_Result" name="feel-substring-function_005_21fcca286c" id="_i-6YA_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_005_21fcca286c_Result" name="feel-substring-function_005_21fcca286c" id="_i-6YA_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6YAfUUEeesLuP4RHs4vA">
             <text>substring("foobar",3)</text>
         </literalExpression>
@@ -83,7 +83,7 @@
         <description>Tests FEEL expression: 'substring("foobar",3,3)' and expects result: '"oba" (string)'</description>
         <question>Result of FEEL expression 'substring("foobar",3,3)'?</question>
         <allowedAnswers>"oba" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_006_253e533bc6_Result" name="feel-substring-function_006_253e533bc6" id="_i-6YB_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_006_253e533bc6_Result" name="feel-substring-function_006_253e533bc6" id="_i-6YB_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6YBfUUEeesLuP4RHs4vA">
             <text>substring("foobar",3,3)</text>
         </literalExpression>
@@ -92,7 +92,7 @@
         <description>Tests FEEL expression: 'substring("foobar",-2,1)' and expects result: '"a" (string)'</description>
         <question>Result of FEEL expression 'substring("foobar",-2,1)'?</question>
         <allowedAnswers>"a" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_007_3e021f33a8_Result" name="feel-substring-function_007_3e021f33a8" id="_i-6YC_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_007_3e021f33a8_Result" name="feel-substring-function_007_3e021f33a8" id="_i-6YC_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6YCfUUEeesLuP4RHs4vA">
             <text>substring("foobar",-2,1)</text>
         </literalExpression>
@@ -101,7 +101,7 @@
         <description>Tests FEEL expression: 'substring("foob r",-2,1)' and expects result: '" " (string)'</description>
         <question>Result of FEEL expression 'substring("foob r",-2,1)'?</question>
         <allowedAnswers>" " (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_008_ddeffdc93e_Result" name="feel-substring-function_008_ddeffdc93e" id="_i-6YD_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_008_ddeffdc93e_Result" name="feel-substring-function_008_ddeffdc93e" id="_i-6YD_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6YDfUUEeesLuP4RHs4vA">
             <text>substring("foob r",-2,1)</text>
         </literalExpression>
@@ -110,7 +110,7 @@
         <description>Tests FEEL expression: 'substring("foobar",-6,6)' and expects result: '"foobar" (string)'</description>
         <question>Result of FEEL expression 'substring("foobar",-6,6)'?</question>
         <allowedAnswers>"foobar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_009_b52405c384_Result" name="feel-substring-function_009_b52405c384" id="_i-6YE_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_009_b52405c384_Result" name="feel-substring-function_009_b52405c384" id="_i-6YE_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6YEfUUEeesLuP4RHs4vA">
             <text>substring("foobar",-6,6)</text>
         </literalExpression>
@@ -119,7 +119,7 @@
         <description>Tests FEEL expression: 'substring("foobar",3,3.8)' and expects result: '"oba" (string)'</description>
         <question>Result of FEEL expression 'substring("foobar",3,3.8)'?</question>
         <allowedAnswers>"oba" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_010_fbf9a89fde_Result" name="feel-substring-function_010_fbf9a89fde" id="_i-6YF_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_010_fbf9a89fde_Result" name="feel-substring-function_010_fbf9a89fde" id="_i-6YF_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6YFfUUEeesLuP4RHs4vA">
             <text>substring("foobar",3,3.8)</text>
         </literalExpression>
@@ -128,7 +128,7 @@
         <description>Tests FEEL expression: 'substring(string:"foobar",start position :3)' and expects result: '"obar" (string)'</description>
         <question>Result of FEEL expression 'substring(string:"foobar",start position :3)'?</question>
         <allowedAnswers>"obar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-function_011_a559ce6410_Result" name="feel-substring-function_011_a559ce6410" id="_i-6YG_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-function_011_a559ce6410_Result" name="feel-substring-function_011_a559ce6410" id="_i-6YG_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_i-6YGfUUEeesLuP4RHs4vA">
             <text>substring(string:"foobar",start position :3)</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1104-feel-string-length-function/1104-feel-string-length-function.dmn
+++ b/TestCases/compliance-level-3/1104-feel-string-length-function/1104-feel-string-length-function.dmn
@@ -23,7 +23,7 @@
         <description>Tests FEEL expression: 'string length("")' and expects result: '0 (number)'</description>
         <question>Result of FEEL expression 'string length("")'?</question>
         <allowedAnswers>0 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-string-length-function_001_1afe6930d1_Result" name="feel-string-length-function_001_1afe6930d1" id="_i_XD5fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-string-length-function_001_1afe6930d1_Result" name="feel-string-length-function_001_1afe6930d1" id="_i_XD5fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_XD4_UUEeesLuP4RHs4vA">
             <text>string length("")</text>
         </literalExpression>
@@ -32,7 +32,7 @@
         <description>Tests FEEL expression: 'string length("a")' and expects result: '1 (number)'</description>
         <question>Result of FEEL expression 'string length("a")'?</question>
         <allowedAnswers>1 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-string-length-function_002_249c23050d_Result" name="feel-string-length-function_002_249c23050d" id="_i_XD6fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-string-length-function_002_249c23050d_Result" name="feel-string-length-function_002_249c23050d" id="_i_XD6fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_XD5_UUEeesLuP4RHs4vA">
             <text>string length("a")</text>
         </literalExpression>
@@ -41,7 +41,7 @@
         <description>Tests FEEL expression: 'string length("abc")' and expects result: '3 (number)'</description>
         <question>Result of FEEL expression 'string length("abc")'?</question>
         <allowedAnswers>3 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-string-length-function_003_e1df507dee_Result" name="feel-string-length-function_003_e1df507dee" id="_i_XD7fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-string-length-function_003_e1df507dee_Result" name="feel-string-length-function_003_e1df507dee" id="_i_XD7fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_XD6_UUEeesLuP4RHs4vA">
             <text>string length("abc")</text>
         </literalExpression>
@@ -50,7 +50,7 @@
         <description>Tests FEEL expression: 'string length(string:"xyz123")' and expects result: '6 (number)'</description>
         <question>Result of FEEL expression 'string length(string:"xyz123")'?</question>
         <allowedAnswers>6 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-string-length-function_004_f4c02fac3d_Result" name="feel-string-length-function_004_f4c02fac3d" id="_i_XD8fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-string-length-function_004_f4c02fac3d_Result" name="feel-string-length-function_004_f4c02fac3d" id="_i_XD8fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_XD7_UUEeesLuP4RHs4vA">
             <text>string length(string:"xyz123")</text>
         </literalExpression>
@@ -59,7 +59,7 @@
         <description>Tests FEEL expression: 'string length(string:"aaaaa dddd")' and expects result: '10 (number)'</description>
         <question>Result of FEEL expression 'string length(string:"aaaaa dddd")'?</question>
         <allowedAnswers>10 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-string-length-function_005_ca834dabac_Result" name="feel-string-length-function_005_ca834dabac" id="_i_XD9fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-string-length-function_005_ca834dabac_Result" name="feel-string-length-function_005_ca834dabac" id="_i_XD9fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_XD8_UUEeesLuP4RHs4vA">
             <text>string length(string:"aaaaa dddd")</text>
         </literalExpression>
@@ -68,7 +68,7 @@
         <description>Tests FEEL expression: 'string length(string:"aaaaa dddd ")' and expects result: '11 (number)'</description>
         <question>Result of FEEL expression 'string length(string:"aaaaa dddd ")'?</question>
         <allowedAnswers>11 (number)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-string-length-function_006_6c4930a0eb_Result" name="feel-string-length-function_006_6c4930a0eb" id="_i_XD-fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-string-length-function_006_6c4930a0eb_Result" name="feel-string-length-function_006_6c4930a0eb" id="_i_XD-fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_XD9_UUEeesLuP4RHs4vA">
             <text>string length(string:"aaaaa dddd ")</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1105-feel-upper-case-function/1105-feel-upper-case-function.dmn
+++ b/TestCases/compliance-level-3/1105-feel-upper-case-function/1105-feel-upper-case-function.dmn
@@ -29,7 +29,7 @@
         <description>Tests FEEL expression: 'upper case("a")' and expects result: '"A" (string)'</description>
         <question>Result of FEEL expression 'upper case("a")'?</question>
         <allowedAnswers>"A" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-upper-case-function_001_2395aaad55_Result" name="feel-upper-case-function_001_2395aaad55" id="_i_zv1fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-upper-case-function_001_2395aaad55_Result" name="feel-upper-case-function_001_2395aaad55" id="_i_zv1fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_zv0_UUEeesLuP4RHs4vA">
             <text>upper case("a")</text>
         </literalExpression>
@@ -38,7 +38,7 @@
         <description>Tests FEEL expression: 'upper case("abc")' and expects result: '"ABC" (string)'</description>
         <question>Result of FEEL expression 'upper case("abc")'?</question>
         <allowedAnswers>"ABC" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-upper-case-function_002_991789dded_Result" name="feel-upper-case-function_002_991789dded" id="_i_zv2fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-upper-case-function_002_991789dded_Result" name="feel-upper-case-function_002_991789dded" id="_i_zv2fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_zv1_UUEeesLuP4RHs4vA">
             <text>upper case("abc")</text>
         </literalExpression>
@@ -47,7 +47,7 @@
         <description>Tests FEEL expression: 'upper case("")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'upper case("")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-upper-case-function_003_d8306d8d00_Result" name="feel-upper-case-function_003_d8306d8d00" id="_i_zv3fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-upper-case-function_003_d8306d8d00_Result" name="feel-upper-case-function_003_d8306d8d00" id="_i_zv3fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_zv2_UUEeesLuP4RHs4vA">
             <text>upper case("")</text>
         </literalExpression>
@@ -56,7 +56,7 @@
         <description>Tests FEEL expression: 'upper case("1")' and expects result: '"1" (string)'</description>
         <question>Result of FEEL expression 'upper case("1")'?</question>
         <allowedAnswers>"1" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-upper-case-function_004_310caf7262_Result" name="feel-upper-case-function_004_310caf7262" id="_i_zv4fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-upper-case-function_004_310caf7262_Result" name="feel-upper-case-function_004_310caf7262" id="_i_zv4fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_zv3_UUEeesLuP4RHs4vA">
             <text>upper case("1")</text>
         </literalExpression>
@@ -65,7 +65,7 @@
         <description>Tests FEEL expression: 'upper case("?@{")' and expects result: '"?@{" (string)'</description>
         <question>Result of FEEL expression 'upper case("?@{")'?</question>
         <allowedAnswers>"?@{" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-upper-case-function_005_b316d773ac_Result" name="feel-upper-case-function_005_b316d773ac" id="_i_zv5fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-upper-case-function_005_b316d773ac_Result" name="feel-upper-case-function_005_b316d773ac" id="_i_zv5fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_zv4_UUEeesLuP4RHs4vA">
             <text>upper case("?@{")</text>
         </literalExpression>
@@ -74,7 +74,7 @@
         <description>Tests FEEL expression: 'upper case(string:"AbDcF")' and expects result: '"ABDCF" (string)'</description>
         <question>Result of FEEL expression 'upper case(string:"AbDcF")'?</question>
         <allowedAnswers>"ABDCF" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-upper-case-function_006_d9bd3c14bc_Result" name="feel-upper-case-function_006_d9bd3c14bc" id="_i_zv6fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-upper-case-function_006_d9bd3c14bc_Result" name="feel-upper-case-function_006_d9bd3c14bc" id="_i_zv6fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_zv5_UUEeesLuP4RHs4vA">
             <text>upper case(string:"AbDcF")</text>
         </literalExpression>
@@ -83,7 +83,7 @@
         <description>Tests FEEL expression: 'upper case(string:"xyZ ")' and expects result: '"XYZ " (string)'</description>
         <question>Result of FEEL expression 'upper case(string:"xyZ ")'?</question>
         <allowedAnswers>"XYZ " (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-upper-case-function_007_31fc6c1967_Result" name="feel-upper-case-function_007_31fc6c1967" id="_i_zv7fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-upper-case-function_007_31fc6c1967_Result" name="feel-upper-case-function_007_31fc6c1967" id="_i_zv7fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_zv6_UUEeesLuP4RHs4vA">
             <text>upper case(string:"xyZ ")</text>
         </literalExpression>
@@ -92,7 +92,7 @@
         <description>Tests FEEL expression: 'upper case(string:"123ABC")' and expects result: '"123ABC" (string)'</description>
         <question>Result of FEEL expression 'upper case(string:"123ABC")'?</question>
         <allowedAnswers>"123ABC" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-upper-case-function_008_26e369a9d9_Result" name="feel-upper-case-function_008_26e369a9d9" id="_i_9g0PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-upper-case-function_008_26e369a9d9_Result" name="feel-upper-case-function_008_26e369a9d9" id="_i_9g0PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_i_zv7_UUEeesLuP4RHs4vA">
             <text>upper case(string:"123ABC")</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1106-feel-lower-case-function/1106-feel-lower-case-function.dmn
+++ b/TestCases/compliance-level-3/1106-feel-lower-case-function/1106-feel-lower-case-function.dmn
@@ -32,7 +32,7 @@
         <description>Tests FEEL expression: 'lower case("A")' and expects result: '"a" (string)'</description>
         <question>Result of FEEL expression 'lower case("A")'?</question>
         <allowedAnswers>"a" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_001_f6ff05bcfa_Result" name="feel-lower-case-function_001_f6ff05bcfa" id="_jAaMxfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_001_f6ff05bcfa_Result" name="feel-lower-case-function_001_f6ff05bcfa" id="_jAaMxfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaMw_UUEeesLuP4RHs4vA">
             <text>lower case("A")</text>
         </literalExpression>
@@ -41,7 +41,7 @@
         <description>Tests FEEL expression: 'lower case("ABC")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'lower case("ABC")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_002_0ecb21e1d8_Result" name="feel-lower-case-function_002_0ecb21e1d8" id="_jAaMyfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_002_0ecb21e1d8_Result" name="feel-lower-case-function_002_0ecb21e1d8" id="_jAaMyfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaMx_UUEeesLuP4RHs4vA">
             <text>lower case("ABC")</text>
         </literalExpression>
@@ -50,7 +50,7 @@
         <description>Tests FEEL expression: 'lower case("abc")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'lower case("abc")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_003_af9f3a8dab_Result" name="feel-lower-case-function_003_af9f3a8dab" id="_jAaMzfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_003_af9f3a8dab_Result" name="feel-lower-case-function_003_af9f3a8dab" id="_jAaMzfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaMy_UUEeesLuP4RHs4vA">
             <text>lower case("abc")</text>
         </literalExpression>
@@ -59,7 +59,7 @@
         <description>Tests FEEL expression: 'lower case("aBc4")' and expects result: '"abc4" (string)'</description>
         <question>Result of FEEL expression 'lower case("aBc4")'?</question>
         <allowedAnswers>"abc4" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_004_2dbf99e8c0_Result" name="feel-lower-case-function_004_2dbf99e8c0" id="_jAaM0fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_004_2dbf99e8c0_Result" name="feel-lower-case-function_004_2dbf99e8c0" id="_jAaM0fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaMz_UUEeesLuP4RHs4vA">
             <text>lower case("aBc4")</text>
         </literalExpression>
@@ -68,7 +68,7 @@
         <description>Tests FEEL expression: 'lower case("")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'lower case("")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_005_ad33325968_Result" name="feel-lower-case-function_005_ad33325968" id="_jAaM1fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_005_ad33325968_Result" name="feel-lower-case-function_005_ad33325968" id="_jAaM1fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaM0_UUEeesLuP4RHs4vA">
             <text>lower case("")</text>
         </literalExpression>
@@ -77,7 +77,7 @@
         <description>Tests FEEL expression: 'lower case("?@{")' and expects result: '"?@{" (string)'</description>
         <question>Result of FEEL expression 'lower case("?@{")'?</question>
         <allowedAnswers>"?@{" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_006_d8257b3b92_Result" name="feel-lower-case-function_006_d8257b3b92" id="_jAaM2fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_006_d8257b3b92_Result" name="feel-lower-case-function_006_d8257b3b92" id="_jAaM2fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaM1_UUEeesLuP4RHs4vA">
             <text>lower case("?@{")</text>
         </literalExpression>
@@ -86,7 +86,7 @@
         <description>Tests FEEL expression: 'lower case(string:"AbDcF")' and expects result: '"abdcf" (string)'</description>
         <question>Result of FEEL expression 'lower case(string:"AbDcF")'?</question>
         <allowedAnswers>"abdcf" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_007_a2ce59499a_Result" name="feel-lower-case-function_007_a2ce59499a" id="_jAaM3fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_007_a2ce59499a_Result" name="feel-lower-case-function_007_a2ce59499a" id="_jAaM3fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaM2_UUEeesLuP4RHs4vA">
             <text>lower case(string:"AbDcF")</text>
         </literalExpression>
@@ -95,7 +95,7 @@
         <description>Tests FEEL expression: 'lower case(string:"xyZ ")' and expects result: '"xyz " (string)'</description>
         <question>Result of FEEL expression 'lower case(string:"xyZ ")'?</question>
         <allowedAnswers>"xyz " (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_008_9913ad454f_Result" name="feel-lower-case-function_008_9913ad454f" id="_jAaM4fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_008_9913ad454f_Result" name="feel-lower-case-function_008_9913ad454f" id="_jAaM4fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaM3_UUEeesLuP4RHs4vA">
             <text>lower case(string:"xyZ ")</text>
         </literalExpression>
@@ -104,7 +104,7 @@
         <description>Tests FEEL expression: 'lower case(string:"123ABC")' and expects result: '"123abc" (string)'</description>
         <question>Result of FEEL expression 'lower case(string:"123ABC")'?</question>
         <allowedAnswers>"123abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-lower-case-function_009_78e6b2969b_Result" name="feel-lower-case-function_009_78e6b2969b" id="_jAaM5fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-lower-case-function_009_78e6b2969b_Result" name="feel-lower-case-function_009_78e6b2969b" id="_jAaM5fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jAaM4_UUEeesLuP4RHs4vA">
             <text>lower case(string:"123ABC")</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1107-feel-substring-before-function/1107-feel-substring-before-function.dmn
+++ b/TestCases/compliance-level-3/1107-feel-substring-before-function/1107-feel-substring-before-function.dmn
@@ -32,7 +32,7 @@
         <description>Tests FEEL expression: 'substring before("foobar","bar")' and expects result: '"foo" (string)'</description>
         <question>Result of FEEL expression 'substring before("foobar","bar")'?</question>
         <allowedAnswers>"foo" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_001_2e948ccdc7_Result" name="feel-substring-before-function_001_2e948ccdc7" id="_jBACpfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_001_2e948ccdc7_Result" name="feel-substring-before-function_001_2e948ccdc7" id="_jBACpfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACo_UUEeesLuP4RHs4vA">
             <text>substring before("foobar","bar")</text>
         </literalExpression>
@@ -41,7 +41,7 @@
         <description>Tests FEEL expression: 'substring before("foobar","o")' and expects result: '"f" (string)'</description>
         <question>Result of FEEL expression 'substring before("foobar","o")'?</question>
         <allowedAnswers>"f" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_002_f4de663db7_Result" name="feel-substring-before-function_002_f4de663db7" id="_jBACqfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_002_f4de663db7_Result" name="feel-substring-before-function_002_f4de663db7" id="_jBACqfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACp_UUEeesLuP4RHs4vA">
             <text>substring before("foobar","o")</text>
         </literalExpression>
@@ -50,7 +50,7 @@
         <description>Tests FEEL expression: 'substring before("foobar","x")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'substring before("foobar","x")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_003_60bc15bade_Result" name="feel-substring-before-function_003_60bc15bade" id="_jBACrfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_003_60bc15bade_Result" name="feel-substring-before-function_003_60bc15bade" id="_jBACrfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACq_UUEeesLuP4RHs4vA">
             <text>substring before("foobar","x")</text>
         </literalExpression>
@@ -59,7 +59,7 @@
         <description>Tests FEEL expression: 'substring before("","")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'substring before("","")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_004_6f93aa7654_Result" name="feel-substring-before-function_004_6f93aa7654" id="_jBACsfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_004_6f93aa7654_Result" name="feel-substring-before-function_004_6f93aa7654" id="_jBACsfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACr_UUEeesLuP4RHs4vA">
             <text>substring before("","")</text>
         </literalExpression>
@@ -68,7 +68,7 @@
         <description>Tests FEEL expression: 'substring before("abc","")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'substring before("abc","")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_005_c8e030633c_Result" name="feel-substring-before-function_005_c8e030633c" id="_jBACtfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_005_c8e030633c_Result" name="feel-substring-before-function_005_c8e030633c" id="_jBACtfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACs_UUEeesLuP4RHs4vA">
             <text>substring before("abc","")</text>
         </literalExpression>
@@ -77,7 +77,7 @@
         <description>Tests FEEL expression: 'substring before("abc","a")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'substring before("abc","a")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_006_1c3d39811d_Result" name="feel-substring-before-function_006_1c3d39811d" id="_jBACufUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_006_1c3d39811d_Result" name="feel-substring-before-function_006_1c3d39811d" id="_jBACufUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACt_UUEeesLuP4RHs4vA">
             <text>substring before("abc","a")</text>
         </literalExpression>
@@ -86,7 +86,7 @@
         <description>Tests FEEL expression: 'substring before("abc","c")' and expects result: '"ab" (string)'</description>
         <question>Result of FEEL expression 'substring before("abc","c")'?</question>
         <allowedAnswers>"ab" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_007_ea4e4a38b0_Result" name="feel-substring-before-function_007_ea4e4a38b0" id="_jBACvfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_007_ea4e4a38b0_Result" name="feel-substring-before-function_007_ea4e4a38b0" id="_jBACvfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACu_UUEeesLuP4RHs4vA">
             <text>substring before("abc","c")</text>
         </literalExpression>
@@ -95,7 +95,7 @@
         <description>Tests FEEL expression: 'substring before(string:"foobar",match:"bar")' and expects result: '"foo" (string)'</description>
         <question>Result of FEEL expression 'substring before(string:"foobar",match:"bar")'?</question>
         <allowedAnswers>"foo" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_008_501b0a5990_Result" name="feel-substring-before-function_008_501b0a5990" id="_jBACwfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_008_501b0a5990_Result" name="feel-substring-before-function_008_501b0a5990" id="_jBACwfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACv_UUEeesLuP4RHs4vA">
             <text>substring before(string:"foobar",match:"bar")</text>
         </literalExpression>
@@ -104,7 +104,7 @@
         <description>Tests FEEL expression: 'substring before(string:"foobar",match:"b")' and expects result: '"foo" (string)'</description>
         <question>Result of FEEL expression 'substring before(string:"foobar",match:"b")'?</question>
         <allowedAnswers>"foo" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-before-function_009_a79c5a4111_Result" name="feel-substring-before-function_009_a79c5a4111" id="_jBACxfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-before-function_009_a79c5a4111_Result" name="feel-substring-before-function_009_a79c5a4111" id="_jBACxfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBACw_UUEeesLuP4RHs4vA">
             <text>substring before(string:"foobar",match:"b")</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1108-feel-substring-after-function/1108-feel-substring-after-function.dmn
+++ b/TestCases/compliance-level-3/1108-feel-substring-after-function/1108-feel-substring-after-function.dmn
@@ -35,7 +35,7 @@
         <description>Tests FEEL expression: 'substring after("foobar","ob")' and expects result: '"ar" (string)'</description>
         <question>Result of FEEL expression 'substring after("foobar","ob")'?</question>
         <allowedAnswers>"ar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_001_f532be66f2_Result" name="feel-substring-after-function_001_f532be66f2" id="_jBculfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_001_f532be66f2_Result" name="feel-substring-after-function_001_f532be66f2" id="_jBculfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcuk_UUEeesLuP4RHs4vA">
             <text>substring after("foobar","ob")</text>
         </literalExpression>
@@ -44,7 +44,7 @@
         <description>Tests FEEL expression: 'substring after("foobar","o")' and expects result: '"obar" (string)'</description>
         <question>Result of FEEL expression 'substring after("foobar","o")'?</question>
         <allowedAnswers>"obar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_002_f20d66fc1e_Result" name="feel-substring-after-function_002_f20d66fc1e" id="_jBcumfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_002_f20d66fc1e_Result" name="feel-substring-after-function_002_f20d66fc1e" id="_jBcumfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcul_UUEeesLuP4RHs4vA">
             <text>substring after("foobar","o")</text>
         </literalExpression>
@@ -53,7 +53,7 @@
         <description>Tests FEEL expression: 'substring after("foobar","x")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'substring after("foobar","x")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_003_367612fc8b_Result" name="feel-substring-after-function_003_367612fc8b" id="_jBcunfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_003_367612fc8b_Result" name="feel-substring-after-function_003_367612fc8b" id="_jBcunfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcum_UUEeesLuP4RHs4vA">
             <text>substring after("foobar","x")</text>
         </literalExpression>
@@ -62,7 +62,7 @@
         <description>Tests FEEL expression: 'substring after("","")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'substring after("","")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_004_e448ee2dad_Result" name="feel-substring-after-function_004_e448ee2dad" id="_jBcuofUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_004_e448ee2dad_Result" name="feel-substring-after-function_004_e448ee2dad" id="_jBcuofUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcun_UUEeesLuP4RHs4vA">
             <text>substring after("","")</text>
         </literalExpression>
@@ -71,7 +71,7 @@
         <description>Tests FEEL expression: 'substring after("","a")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'substring after("","a")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_005_429efdafd0_Result" name="feel-substring-after-function_005_429efdafd0" id="_jBcupfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_005_429efdafd0_Result" name="feel-substring-after-function_005_429efdafd0" id="_jBcupfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcuo_UUEeesLuP4RHs4vA">
             <text>substring after("","a")</text>
         </literalExpression>
@@ -80,7 +80,7 @@
         <description>Tests FEEL expression: 'substring after("abc","")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'substring after("abc","")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_006_bf89d6b618_Result" name="feel-substring-after-function_006_bf89d6b618" id="_jBcuqfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_006_bf89d6b618_Result" name="feel-substring-after-function_006_bf89d6b618" id="_jBcuqfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcup_UUEeesLuP4RHs4vA">
             <text>substring after("abc","")</text>
         </literalExpression>
@@ -89,7 +89,7 @@
         <description>Tests FEEL expression: 'substring after("abc","c")' and expects result: '"" (string)'</description>
         <question>Result of FEEL expression 'substring after("abc","c")'?</question>
         <allowedAnswers>"" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_007_529baaeb0b_Result" name="feel-substring-after-function_007_529baaeb0b" id="_jBcurfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_007_529baaeb0b_Result" name="feel-substring-after-function_007_529baaeb0b" id="_jBcurfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcuq_UUEeesLuP4RHs4vA">
             <text>substring after("abc","c")</text>
         </literalExpression>
@@ -98,7 +98,7 @@
         <description>Tests FEEL expression: 'substring after("abc","a")' and expects result: '"bc" (string)'</description>
         <question>Result of FEEL expression 'substring after("abc","a")'?</question>
         <allowedAnswers>"bc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_008_1e611924ea_Result" name="feel-substring-after-function_008_1e611924ea" id="_jBcusfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_008_1e611924ea_Result" name="feel-substring-after-function_008_1e611924ea" id="_jBcusfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcur_UUEeesLuP4RHs4vA">
             <text>substring after("abc","a")</text>
         </literalExpression>
@@ -107,7 +107,7 @@
         <description>Tests FEEL expression: 'substring after(string:"foobar",match:"ob")' and expects result: '"ar" (string)'</description>
         <question>Result of FEEL expression 'substring after(string:"foobar",match:"ob")'?</question>
         <allowedAnswers>"ar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_009_712fe2842f_Result" name="feel-substring-after-function_009_712fe2842f" id="_jBcutfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_009_712fe2842f_Result" name="feel-substring-after-function_009_712fe2842f" id="_jBcutfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcus_UUEeesLuP4RHs4vA">
             <text>substring after(string:"foobar",match:"ob")</text>
         </literalExpression>
@@ -116,7 +116,7 @@
         <description>Tests FEEL expression: 'substring after(string:"foobar",match:"b")' and expects result: '"ar" (string)'</description>
         <question>Result of FEEL expression 'substring after(string:"foobar",match:"b")'?</question>
         <allowedAnswers>"ar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-substring-after-function_010_40e159d07a_Result" name="feel-substring-after-function_010_40e159d07a" id="_jBcuufUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-substring-after-function_010_40e159d07a_Result" name="feel-substring-after-function_010_40e159d07a" id="_jBcuufUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jBcut_UUEeesLuP4RHs4vA">
             <text>substring after(string:"foobar",match:"b")</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1109-feel-replace-function/1109-feel-replace-function.dmn
+++ b/TestCases/compliance-level-3/1109-feel-replace-function/1109-feel-replace-function.dmn
@@ -89,7 +89,7 @@
         <description>Tests FEEL expression: 'replace("abcd","(ab)|(a)", "[1=$1][2=$2]")' and expects result: '"[1=ab][2=]cd" (string)'</description>
         <question>Result of FEEL expression 'replace("abcd","(ab)|(a)", "[1=$1][2=$2]")'?</question>
         <allowedAnswers>"[1=ab][2=]cd" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_001_7637e5a8ed_Result" name="feel-replace-function_001_7637e5a8ed" id="_jCDLhfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_001_7637e5a8ed_Result" name="feel-replace-function_001_7637e5a8ed" id="_jCDLhfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLg_UUEeesLuP4RHs4vA">
             <text>replace("abcd","(ab)|(a)", "[1=$1][2=$2]")</text>
         </literalExpression>
@@ -98,7 +98,7 @@
         <description>Tests FEEL expression: 'replace("a","[b-z]","#")' and expects result: '"a" (string)'</description>
         <question>Result of FEEL expression 'replace("a","[b-z]","#")'?</question>
         <allowedAnswers>"a" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_002_b5c242ccd4_Result" name="feel-replace-function_002_b5c242ccd4" id="_jCDLifUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_002_b5c242ccd4_Result" name="feel-replace-function_002_b5c242ccd4" id="_jCDLifUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLh_UUEeesLuP4RHs4vA">
             <text>replace("a","[b-z]","#")</text>
         </literalExpression>
@@ -107,7 +107,7 @@
         <description>Tests FEEL expression: 'replace("a","[a-z]","#")' and expects result: '"#" (string)'</description>
         <question>Result of FEEL expression 'replace("a","[a-z]","#")'?</question>
         <allowedAnswers>"#" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_003_bf7aa95050_Result" name="feel-replace-function_003_bf7aa95050" id="_jCDLjfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_003_bf7aa95050_Result" name="feel-replace-function_003_bf7aa95050" id="_jCDLjfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLi_UUEeesLuP4RHs4vA">
             <text>replace("a","[a-z]","#")</text>
         </literalExpression>
@@ -116,7 +116,7 @@
         <description>Tests FEEL expression: 'replace("abc","def","#")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'replace("abc","def","#")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_004_55a2186006_Result" name="feel-replace-function_004_55a2186006" id="_jCDLkfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_004_55a2186006_Result" name="feel-replace-function_004_55a2186006" id="_jCDLkfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLj_UUEeesLuP4RHs4vA">
             <text>replace("abc","def","#")</text>
         </literalExpression>
@@ -125,7 +125,7 @@
         <description>Tests FEEL expression: 'replace("abc","e","#")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'replace("abc","e","#")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_005_271d93aa68_Result" name="feel-replace-function_005_271d93aa68" id="_jCDLlfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_005_271d93aa68_Result" name="feel-replace-function_005_271d93aa68" id="_jCDLlfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLk_UUEeesLuP4RHs4vA">
             <text>replace("abc","e","#")</text>
         </literalExpression>
@@ -134,7 +134,7 @@
         <description>Tests FEEL expression: 'replace("foobar","^fo*b*","#")' and expects result: '"#ar" (string)'</description>
         <question>Result of FEEL expression 'replace("foobar","^fo*b*","#")'?</question>
         <allowedAnswers>"#ar" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_006_9cd005d2e2_Result" name="feel-replace-function_006_9cd005d2e2" id="_jCDLmfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_006_9cd005d2e2_Result" name="feel-replace-function_006_9cd005d2e2" id="_jCDLmfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLl_UUEeesLuP4RHs4vA">
             <text>replace("foobar","^fo*b*","#")</text>
         </literalExpression>
@@ -143,7 +143,7 @@
         <description>Tests FEEL expression: 'replace("abc",".^[d-z]","#")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'replace("abc",".^[d-z]","#")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_007_91583e38c9_Result" name="feel-replace-function_007_91583e38c9" id="_jCDLnfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_007_91583e38c9_Result" name="feel-replace-function_007_91583e38c9" id="_jCDLnfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLm_UUEeesLuP4RHs4vA">
             <text>replace("abc",".^[d-z]","#")</text>
         </literalExpression>
@@ -152,7 +152,7 @@
         <description>Tests FEEL expression: 'replace("abracadabra","bra","*")' and expects result: '"a*cada*" (string)'</description>
         <question>Result of FEEL expression 'replace("abracadabra","bra","*")'?</question>
         <allowedAnswers>"a*cada*" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_008_8c7c3871f8_Result" name="feel-replace-function_008_8c7c3871f8" id="_jCDLofUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_008_8c7c3871f8_Result" name="feel-replace-function_008_8c7c3871f8" id="_jCDLofUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLn_UUEeesLuP4RHs4vA">
             <text>replace("abracadabra","bra","*")</text>
         </literalExpression>
@@ -161,7 +161,7 @@
         <description>Tests FEEL expression: 'replace("abracadabra","a.*a","*")' and expects result: '"*" (string)'</description>
         <question>Result of FEEL expression 'replace("abracadabra","a.*a","*")'?</question>
         <allowedAnswers>"*" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_009_b1e4220bc9_Result" name="feel-replace-function_009_b1e4220bc9" id="_jCDLpfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_009_b1e4220bc9_Result" name="feel-replace-function_009_b1e4220bc9" id="_jCDLpfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLo_UUEeesLuP4RHs4vA">
             <text>replace("abracadabra","a.*a","*")</text>
         </literalExpression>
@@ -170,7 +170,7 @@
         <description>Tests FEEL expression: 'replace("abracadabra","a.*?a","*")' and expects result: '"*c*bra" (string)'</description>
         <question>Result of FEEL expression 'replace("abracadabra","a.*?a","*")'?</question>
         <allowedAnswers>"*c*bra" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_010_cd4e7a6d9f_Result" name="feel-replace-function_010_cd4e7a6d9f" id="_jCDLqfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_010_cd4e7a6d9f_Result" name="feel-replace-function_010_cd4e7a6d9f" id="_jCDLqfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLp_UUEeesLuP4RHs4vA">
             <text>replace("abracadabra","a.*?a","*")</text>
         </literalExpression>
@@ -179,7 +179,7 @@
         <description>Tests FEEL expression: 'replace("abracadabra","a","")' and expects result: '"brcdbr" (string)'</description>
         <question>Result of FEEL expression 'replace("abracadabra","a","")'?</question>
         <allowedAnswers>"brcdbr" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_011_c310665f57_Result" name="feel-replace-function_011_c310665f57" id="_jCDLrfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_011_c310665f57_Result" name="feel-replace-function_011_c310665f57" id="_jCDLrfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLq_UUEeesLuP4RHs4vA">
             <text>replace("abracadabra","a","")</text>
         </literalExpression>
@@ -188,7 +188,7 @@
         <description>Tests FEEL expression: 'replace("abracadabra","a(.)","a$1$1")' and expects result: '"abbraccaddabbra" (string)'</description>
         <question>Result of FEEL expression 'replace("abracadabra","a(.)","a$1$1")'?</question>
         <allowedAnswers>"abbraccaddabbra" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_012_b0cf9e6723_Result" name="feel-replace-function_012_b0cf9e6723" id="_jCDLsfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_012_b0cf9e6723_Result" name="feel-replace-function_012_b0cf9e6723" id="_jCDLsfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLr_UUEeesLuP4RHs4vA">
             <text>replace("abracadabra","a(.)","a$1$1")</text>
         </literalExpression>
@@ -197,7 +197,7 @@
         <description>Tests FEEL expression: 'replace("AAAA","A+","b")' and expects result: '"b" (string)'</description>
         <question>Result of FEEL expression 'replace("AAAA","A+","b")'?</question>
         <allowedAnswers>"b" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_013_f669d03fa9_Result" name="feel-replace-function_013_f669d03fa9" id="_jCDLtfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_013_f669d03fa9_Result" name="feel-replace-function_013_f669d03fa9" id="_jCDLtfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLs_UUEeesLuP4RHs4vA">
             <text>replace("AAAA","A+","b")</text>
         </literalExpression>
@@ -206,7 +206,7 @@
         <description>Tests FEEL expression: 'replace("AAAA","A+?","b")' and expects result: '"bbbb" (string)'</description>
         <question>Result of FEEL expression 'replace("AAAA","A+?","b")'?</question>
         <allowedAnswers>"bbbb" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_014_cea33baeee_Result" name="feel-replace-function_014_cea33baeee" id="_jCDLufUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_014_cea33baeee_Result" name="feel-replace-function_014_cea33baeee" id="_jCDLufUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLt_UUEeesLuP4RHs4vA">
             <text>replace("AAAA","A+?","b")</text>
         </literalExpression>
@@ -215,7 +215,7 @@
         <description>Tests FEEL expression: 'replace("darted","^(.*?)d(.*)$","$1c$2")' and expects result: '"carted" (string)'</description>
         <question>Result of FEEL expression 'replace("darted","^(.*?)d(.*)$","$1c$2")'?</question>
         <allowedAnswers>"carted" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_015_57ce78ec8a_Result" name="feel-replace-function_015_57ce78ec8a" id="_jCDLvfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_015_57ce78ec8a_Result" name="feel-replace-function_015_57ce78ec8a" id="_jCDLvfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLu_UUEeesLuP4RHs4vA">
             <text>replace("darted","^(.*?)d(.*)$","$1c$2")</text>
         </literalExpression>
@@ -224,7 +224,7 @@
         <description>Tests FEEL expression: 'replace("reluctant","r.*?t","X")' and expects result: '"Xant" (string)'</description>
         <question>Result of FEEL expression 'replace("reluctant","r.*?t","X")'?</question>
         <allowedAnswers>"Xant" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_016_1c38095f50_Result" name="feel-replace-function_016_1c38095f50" id="_jCDLwfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_016_1c38095f50_Result" name="feel-replace-function_016_1c38095f50" id="_jCDLwfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLv_UUEeesLuP4RHs4vA">
             <text>replace("reluctant","r.*?t","X")</text>
         </literalExpression>
@@ -233,7 +233,7 @@
         <description>Tests FEEL expression: 'replace("0123456789","(\d{3})(\d{3})(\d{4})","($1) $2-$3")' and expects result: '"(012) 345-6789" (string)'</description>
         <question>Result of FEEL expression 'replace("0123456789","(\d{3})(\d{3})(\d{4})","($1) $2-$3")'?</question>
         <allowedAnswers>"(012) 345-6789" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_017_b9c3c03b87_Result" name="feel-replace-function_017_b9c3c03b87" id="_jCDLxfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_017_b9c3c03b87_Result" name="feel-replace-function_017_b9c3c03b87" id="_jCDLxfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLw_UUEeesLuP4RHs4vA">
             <text>replace("0123456789","(\d{3})(\d{3})(\d{4})","($1) $2-$3")</text>
         </literalExpression>
@@ -242,7 +242,7 @@
         <description>Tests FEEL expression: 'replace("facetiously","[iouy]","[$0]")' and expects result: '"facet[i][o][u]sl[y]" (string)'</description>
         <question>Result of FEEL expression 'replace("facetiously","[iouy]","[$0]")'?</question>
         <allowedAnswers>"facet[i][o][u]sl[y]" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_018_aba3349043_Result" name="feel-replace-function_018_aba3349043" id="_jCDLyfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_018_aba3349043_Result" name="feel-replace-function_018_aba3349043" id="_jCDLyfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLx_UUEeesLuP4RHs4vA">
             <text>replace("facetiously","[iouy]","[$0]")</text>
         </literalExpression>
@@ -251,7 +251,7 @@
         <description>Tests FEEL expression: 'replace("abc","[a-z]","#","")' and expects result: '"###" (string)'</description>
         <question>Result of FEEL expression 'replace("abc","[a-z]","#","")'?</question>
         <allowedAnswers>"###" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_019_6ef91033ad_Result" name="feel-replace-function_019_6ef91033ad" id="_jCMVcPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_019_6ef91033ad_Result" name="feel-replace-function_019_6ef91033ad" id="_jCMVcPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCDLy_UUEeesLuP4RHs4vA">
             <text>replace("abc","[a-z]","#","")</text>
         </literalExpression>
@@ -260,7 +260,7 @@
         <description>Tests FEEL expression: 'replace("a.b.c.","[a-z]","#","s")' and expects result: '"#.#.#." (string)'</description>
         <question>Result of FEEL expression 'replace("a.b.c.","[a-z]","#","s")'?</question>
         <allowedAnswers>"#.#.#." (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_020_52d93a8851_Result" name="feel-replace-function_020_52d93a8851" id="_jCMVdPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_020_52d93a8851_Result" name="feel-replace-function_020_52d93a8851" id="_jCMVdPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVcvUUEeesLuP4RHs4vA">
             <text>replace("a.b.c.","[a-z]","#","s")</text>
         </literalExpression>
@@ -269,7 +269,7 @@
         <description>Tests FEEL expression: 'replace("abc","[A-Z]","#","i")' and expects result: '"###" (string)'</description>
         <question>Result of FEEL expression 'replace("abc","[A-Z]","#","i")'?</question>
         <allowedAnswers>"###" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_021_e33828e3da_Result" name="feel-replace-function_021_e33828e3da" id="_jCMVePUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_021_e33828e3da_Result" name="feel-replace-function_021_e33828e3da" id="_jCMVePUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVdvUUEeesLuP4RHs4vA">
             <text>replace("abc","[A-Z]","#","i")</text>
         </literalExpression>
@@ -278,7 +278,7 @@
         <description>Tests FEEL expression: 'replace("abc","[a-z]","#","s")' and expects result: '"###" (string)'</description>
         <question>Result of FEEL expression 'replace("abc","[a-z]","#","s")'?</question>
         <allowedAnswers>"###" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_022_bd75fac0bd_Result" name="feel-replace-function_022_bd75fac0bd" id="_jCMVfPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_022_bd75fac0bd_Result" name="feel-replace-function_022_bd75fac0bd" id="_jCMVfPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVevUUEeesLuP4RHs4vA">
             <text>replace("abc","[a-z]","#","s")</text>
         </literalExpression>
@@ -287,7 +287,7 @@
         <description>Tests FEEL expression: 'replace("a b c d ","[a-z]","#","x")' and expects result: '"# # # # " (string)'</description>
         <question>Result of FEEL expression 'replace("a b c d ","[a-z]","#","x")'?</question>
         <allowedAnswers>"# # # # " (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_023_5c337d3725_Result" name="feel-replace-function_023_5c337d3725" id="_jCMVgPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_023_5c337d3725_Result" name="feel-replace-function_023_5c337d3725" id="_jCMVgPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVfvUUEeesLuP4RHs4vA">
             <text>replace("a b c d ","[a-z]","#","x")</text>
         </literalExpression>
@@ -296,7 +296,7 @@
         <description>Tests FEEL expression: 'replace("abc",".^[d-z]*","smix")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'replace("abc",".^[d-z]*","smix")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_024_4a89220cd6_Result" name="feel-replace-function_024_4a89220cd6" id="_jCMVhPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_024_4a89220cd6_Result" name="feel-replace-function_024_4a89220cd6" id="_jCMVhPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVgvUUEeesLuP4RHs4vA">
             <text>replace("abc",".^[d-z]*","smix")</text>
         </literalExpression>
@@ -305,7 +305,7 @@
         <description>Tests FEEL expression: 'replace(input:"abc",pattern:"[a-z]",replacement:"#")' and expects result: '"###" (string)'</description>
         <question>Result of FEEL expression 'replace(input:"abc",pattern:"[a-z]",replacement:"#")'?</question>
         <allowedAnswers>"###" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_025_b7f9525875_Result" name="feel-replace-function_025_b7f9525875" id="_jCMViPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_025_b7f9525875_Result" name="feel-replace-function_025_b7f9525875" id="_jCMViPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVhvUUEeesLuP4RHs4vA">
             <text>replace(input:"abc",pattern:"[a-z]",replacement:"#")</text>
         </literalExpression>
@@ -314,7 +314,7 @@
         <description>Tests FEEL expression: 'replace(input:"abc",pattern:"[A-Z]",replacement:"#",flags:"")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'replace(input:"abc",pattern:"[A-Z]",replacement:"#",flags:"")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_026_acb176590a_Result" name="feel-replace-function_026_acb176590a" id="_jCMVjPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_026_acb176590a_Result" name="feel-replace-function_026_acb176590a" id="_jCMVjPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVivUUEeesLuP4RHs4vA">
             <text>replace(input:"abc",pattern:"[A-Z]",replacement:"#",flags:"")</text>
         </literalExpression>
@@ -323,7 +323,7 @@
         <description>Tests FEEL expression: 'replace(input:"abc",pattern:"[A-Z]",replacement:"#",flags:"i")' and expects result: '"###" (string)'</description>
         <question>Result of FEEL expression 'replace(input:"abc",pattern:"[A-Z]",replacement:"#",flags:"i")'?</question>
         <allowedAnswers>"###" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_027_d8d25f40e5_Result" name="feel-replace-function_027_d8d25f40e5" id="_jCMVkPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_027_d8d25f40e5_Result" name="feel-replace-function_027_d8d25f40e5" id="_jCMVkPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVjvUUEeesLuP4RHs4vA">
             <text>replace(input:"abc",pattern:"[A-Z]",replacement:"#",flags:"i")</text>
         </literalExpression>
@@ -332,7 +332,7 @@
         <description>Tests FEEL expression: 'replace(input:"abc",pattern:".^[d-z]*",replacement:"#",flags:"smix")' and expects result: '"abc" (string)'</description>
         <question>Result of FEEL expression 'replace(input:"abc",pattern:".^[d-z]*",replacement:"#",flags:"smix")'?</question>
         <allowedAnswers>"abc" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-replace-function_028_96e8c698af_Result" name="feel-replace-function_028_96e8c698af" id="_jCMVlPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-replace-function_028_96e8c698af_Result" name="feel-replace-function_028_96e8c698af" id="_jCMVlPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCMVkvUUEeesLuP4RHs4vA">
             <text>replace(input:"abc",pattern:".^[d-z]*",replacement:"#",flags:"smix")</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1110-feel-contains-function/1110-feel-contains-function.dmn
+++ b/TestCases/compliance-level-3/1110-feel-contains-function/1110-feel-contains-function.dmn
@@ -35,7 +35,7 @@
         <description>Tests FEEL expression: 'contains(null,null)' and expects result: 'null (boolean)'</description>
         <question>Result of FEEL expression 'contains(null,null)'?</question>
         <allowedAnswers>null (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_001_2a4d7448c6_Result" name="feel-contains-function_ErrorCase_001_2a4d7448c6" id="_jCpBZfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_001_2a4d7448c6_Result" name="feel-contains-function_ErrorCase_001_2a4d7448c6" id="_jCpBZfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBY_UUEeesLuP4RHs4vA">
             <text>contains(null,null)</text>
         </literalExpression>
@@ -44,7 +44,7 @@
         <description>Tests FEEL expression: 'contains(null,"bar")' and expects result: 'null (boolean)'</description>
         <question>Result of FEEL expression 'contains(null,"bar")'?</question>
         <allowedAnswers>null (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_002_d2a1831b5c_Result" name="feel-contains-function_ErrorCase_002_d2a1831b5c" id="_jCpBafUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_002_d2a1831b5c_Result" name="feel-contains-function_ErrorCase_002_d2a1831b5c" id="_jCpBafUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBZ_UUEeesLuP4RHs4vA">
             <text>contains(null,"bar")</text>
         </literalExpression>
@@ -53,7 +53,7 @@
         <description>Tests FEEL expression: 'contains("bar",null)' and expects result: 'null (boolean)'</description>
         <question>Result of FEEL expression 'contains("bar",null)'?</question>
         <allowedAnswers>null (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_003_df56e0a1ad_Result" name="feel-contains-function_ErrorCase_003_df56e0a1ad" id="_jCpBbfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_003_df56e0a1ad_Result" name="feel-contains-function_ErrorCase_003_df56e0a1ad" id="_jCpBbfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBa_UUEeesLuP4RHs4vA">
             <text>contains("bar",null)</text>
         </literalExpression>
@@ -62,7 +62,7 @@
         <description>Tests FEEL expression: 'contains("foobar","bar")' and expects result: 'true (boolean)'</description>
         <question>Result of FEEL expression 'contains("foobar","bar")'?</question>
         <allowedAnswers>true (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_004_805503b274_Result" name="feel-contains-function_004_805503b274" id="_jCpBcfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_004_805503b274_Result" name="feel-contains-function_004_805503b274" id="_jCpBcfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBb_UUEeesLuP4RHs4vA">
             <text>contains("foobar","bar")</text>
         </literalExpression>
@@ -71,7 +71,7 @@
         <description>Tests FEEL expression: 'contains("foobar","o")' and expects result: 'true (boolean)'</description>
         <question>Result of FEEL expression 'contains("foobar","o")'?</question>
         <allowedAnswers>true (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_005_5c1269db16_Result" name="feel-contains-function_005_5c1269db16" id="_jCpBdfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_005_5c1269db16_Result" name="feel-contains-function_005_5c1269db16" id="_jCpBdfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBc_UUEeesLuP4RHs4vA">
             <text>contains("foobar","o")</text>
         </literalExpression>
@@ -80,7 +80,7 @@
         <description>Tests FEEL expression: 'contains("abc","")' and expects result: 'true (boolean)'</description>
         <question>Result of FEEL expression 'contains("abc","")'?</question>
         <allowedAnswers>true (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_006_babdaf4f36_Result" name="feel-contains-function_006_babdaf4f36" id="_jCpBefUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_006_babdaf4f36_Result" name="feel-contains-function_006_babdaf4f36" id="_jCpBefUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBd_UUEeesLuP4RHs4vA">
             <text>contains("abc","")</text>
         </literalExpression>
@@ -89,7 +89,7 @@
         <description>Tests FEEL expression: 'contains("","ab")' and expects result: 'false (boolean)'</description>
         <question>Result of FEEL expression 'contains("","ab")'?</question>
         <allowedAnswers>false (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_007_d24a599180_Result" name="feel-contains-function_007_d24a599180" id="_jCpBffUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_007_d24a599180_Result" name="feel-contains-function_007_d24a599180" id="_jCpBffUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBe_UUEeesLuP4RHs4vA">
             <text>contains("","ab")</text>
         </literalExpression>
@@ -98,7 +98,7 @@
         <description>Tests FEEL expression: 'contains("","")' and expects result: 'true (boolean)'</description>
         <question>Result of FEEL expression 'contains("","")'?</question>
         <allowedAnswers>true (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_008_cf1311586a_Result" name="feel-contains-function_008_cf1311586a" id="_jCpBgfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_008_cf1311586a_Result" name="feel-contains-function_008_cf1311586a" id="_jCpBgfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBf_UUEeesLuP4RHs4vA">
             <text>contains("","")</text>
         </literalExpression>
@@ -107,7 +107,7 @@
         <description>Tests FEEL expression: 'contains(string:"foobar",match:"bar")' and expects result: 'true (boolean)'</description>
         <question>Result of FEEL expression 'contains(string:"foobar",match:"bar")'?</question>
         <allowedAnswers>true (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_009_c4b50ad623_Result" name="feel-contains-function_009_c4b50ad623" id="_jCpBhfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_009_c4b50ad623_Result" name="feel-contains-function_009_c4b50ad623" id="_jCpBhfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBg_UUEeesLuP4RHs4vA">
             <text>contains(string:"foobar",match:"bar")</text>
         </literalExpression>
@@ -116,7 +116,7 @@
         <description>Tests FEEL expression: 'contains(string:"foobar",match:"b")' and expects result: 'true (boolean)'</description>
         <question>Result of FEEL expression 'contains(string:"foobar",match:"b")'?</question>
         <allowedAnswers>true (boolean)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-contains-function_010_9ae03e0e59_Result" name="feel-contains-function_010_9ae03e0e59" id="_jCpBifUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-contains-function_010_9ae03e0e59_Result" name="feel-contains-function_010_9ae03e0e59" id="_jCpBifUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jCpBh_UUEeesLuP4RHs4vA">
             <text>contains(string:"foobar",match:"b")</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1115-feel-date-function/1115-feel-date-function.dmn
+++ b/TestCases/compliance-level-3/1115-feel-date-function/1115-feel-date-function.dmn
@@ -161,7 +161,7 @@
         <description>Tests FEEL expression: 'date(null)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(null)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_001_e9ae035ab9_Result" name="feel-date-function_ErrorCase_001_e9ae035ab9" id="_jDiZRfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_001_e9ae035ab9_Result" name="feel-date-function_ErrorCase_001_e9ae035ab9" id="_jDiZRfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZQ_UUEeesLuP4RHs4vA">
             <text>date(null)</text>
         </literalExpression>
@@ -170,7 +170,7 @@
         <description>Tests FEEL expression: 'date(null,null)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(null,null)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_002_9b9e6085ce_Result" name="feel-date-function_ErrorCase_002_9b9e6085ce" id="_jDiZSfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_002_9b9e6085ce_Result" name="feel-date-function_ErrorCase_002_9b9e6085ce" id="_jDiZSfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZR_UUEeesLuP4RHs4vA">
             <text>date(null,null)</text>
         </literalExpression>
@@ -179,7 +179,7 @@
         <description>Tests FEEL expression: 'date(null,2,1)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(null,2,1)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_003_e4b7918d8f_Result" name="feel-date-function_ErrorCase_003_e4b7918d8f" id="_jDiZTfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_003_e4b7918d8f_Result" name="feel-date-function_ErrorCase_003_e4b7918d8f" id="_jDiZTfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZS_UUEeesLuP4RHs4vA">
             <text>date(null,2,1)</text>
         </literalExpression>
@@ -188,7 +188,7 @@
         <description>Tests FEEL expression: 'date(2017,null,1)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(2017,null,1)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_004_f24ed41117_Result" name="feel-date-function_ErrorCase_004_f24ed41117" id="_jDiZUfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_004_f24ed41117_Result" name="feel-date-function_ErrorCase_004_f24ed41117" id="_jDiZUfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZT_UUEeesLuP4RHs4vA">
             <text>date(2017,null,1)</text>
         </literalExpression>
@@ -197,7 +197,7 @@
         <description>Tests FEEL expression: 'date(2017,1,null)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(2017,1,null)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_005_3540a22062_Result" name="feel-date-function_ErrorCase_005_3540a22062" id="_jDiZVfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_005_3540a22062_Result" name="feel-date-function_ErrorCase_005_3540a22062" id="_jDiZVfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZU_UUEeesLuP4RHs4vA">
             <text>date(2017,1,null)</text>
         </literalExpression>
@@ -206,7 +206,7 @@
         <description>Tests FEEL expression: 'date(null,null,1)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(null,null,1)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_006_616e24dbb7_Result" name="feel-date-function_ErrorCase_006_616e24dbb7" id="_jDiZWfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_006_616e24dbb7_Result" name="feel-date-function_ErrorCase_006_616e24dbb7" id="_jDiZWfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZV_UUEeesLuP4RHs4vA">
             <text>date(null,null,1)</text>
         </literalExpression>
@@ -215,7 +215,7 @@
         <description>Tests FEEL expression: 'date(null,02,null)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(null,02,null)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_007_cda82a5d01_Result" name="feel-date-function_ErrorCase_007_cda82a5d01" id="_jDiZXfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_007_cda82a5d01_Result" name="feel-date-function_ErrorCase_007_cda82a5d01" id="_jDiZXfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZW_UUEeesLuP4RHs4vA">
             <text>date(null,02,null)</text>
         </literalExpression>
@@ -224,7 +224,7 @@
         <description>Tests FEEL expression: 'date(2017,null,null)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(2017,null,null)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_008_492649d3d0_Result" name="feel-date-function_ErrorCase_008_492649d3d0" id="_jDiZYfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_008_492649d3d0_Result" name="feel-date-function_ErrorCase_008_492649d3d0" id="_jDiZYfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZX_UUEeesLuP4RHs4vA">
             <text>date(2017,null,null)</text>
         </literalExpression>
@@ -233,7 +233,7 @@
         <description>Tests FEEL expression: 'date(null,null,null)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(null,null,null)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_009_9e00bbdad3_Result" name="feel-date-function_ErrorCase_009_9e00bbdad3" id="_jDiZZfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_009_9e00bbdad3_Result" name="feel-date-function_ErrorCase_009_9e00bbdad3" id="_jDiZZfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZY_UUEeesLuP4RHs4vA">
             <text>date(null,null,null)</text>
         </literalExpression>
@@ -242,7 +242,7 @@
         <description>Tests FEEL expression: 'date()' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date()'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_010_6d4d58d23a_Result" name="feel-date-function_ErrorCase_010_6d4d58d23a" id="_jDiZafUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_010_6d4d58d23a_Result" name="feel-date-function_ErrorCase_010_6d4d58d23a" id="_jDiZafUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZZ_UUEeesLuP4RHs4vA">
             <text>date()</text>
         </literalExpression>
@@ -251,7 +251,7 @@
         <description>Tests FEEL expression: 'date("2017-12-31")' and expects result: '2017-12-31 (date)'</description>
         <question>Result of FEEL expression 'date("2017-12-31")'?</question>
         <allowedAnswers>2017-12-31 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_011_5f0b42b1f8_Result" name="feel-date-function_011_5f0b42b1f8" id="_jDiZbfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_011_5f0b42b1f8_Result" name="feel-date-function_011_5f0b42b1f8" id="_jDiZbfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZa_UUEeesLuP4RHs4vA">
             <text>date("2017-12-31")</text>
         </literalExpression>
@@ -260,7 +260,7 @@
         <description>Tests FEEL expression: 'date("2017-01-01")' and expects result: '2017-01-01 (date)'</description>
         <question>Result of FEEL expression 'date("2017-01-01")'?</question>
         <allowedAnswers>2017-01-01 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_012_d9e4b97438_Result" name="feel-date-function_012_d9e4b97438" id="_jDiZcfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_012_d9e4b97438_Result" name="feel-date-function_012_d9e4b97438" id="_jDiZcfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZb_UUEeesLuP4RHs4vA">
             <text>date("2017-01-01")</text>
         </literalExpression>
@@ -269,7 +269,7 @@
         <description>Tests FEEL expression: 'date("-2017-12-31")' and expects result: '-2017-12-31 (date)'</description>
         <question>Result of FEEL expression 'date("-2017-12-31")'?</question>
         <allowedAnswers>-2017-12-31 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_013_d7e901ee86_Result" name="feel-date-function_013_d7e901ee86" id="_jDiZdfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_013_d7e901ee86_Result" name="feel-date-function_013_d7e901ee86" id="_jDiZdfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZc_UUEeesLuP4RHs4vA">
             <text>date("-2017-12-31")</text>
         </literalExpression>
@@ -278,7 +278,7 @@
         <description>Tests FEEL expression: 'date("-2017-01-01")' and expects result: '-2017-01-01 (date)'</description>
         <question>Result of FEEL expression 'date("-2017-01-01")'?</question>
         <allowedAnswers>-2017-01-01 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_014_fad7e00633_Result" name="feel-date-function_014_fad7e00633" id="_jDiZefUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_014_fad7e00633_Result" name="feel-date-function_014_fad7e00633" id="_jDiZefUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZd_UUEeesLuP4RHs4vA">
             <text>date("-2017-01-01")</text>
         </literalExpression>
@@ -287,7 +287,7 @@
         <description>Tests FEEL expression: 'string(date("999999999-12-31"))' and expects result: '"999999999-12-31" (string)'</description>
         <question>Result of FEEL expression 'string(date("999999999-12-31"))'?</question>
         <allowedAnswers>"999999999-12-31" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_015_1dd66594cf_Result" name="feel-date-function_015_1dd66594cf" id="_jDiZffUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_015_1dd66594cf_Result" name="feel-date-function_015_1dd66594cf" id="_jDiZffUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZe_UUEeesLuP4RHs4vA">
             <text>string(date("999999999-12-31"))</text>
         </literalExpression>
@@ -296,7 +296,7 @@
         <description>Tests FEEL expression: 'string(date("-999999999-12-31"))' and expects result: '"-999999999-12-31" (string)'</description>
         <question>Result of FEEL expression 'string(date("-999999999-12-31"))'?</question>
         <allowedAnswers>"-999999999-12-31" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_016_31f3fef4a0_Result" name="feel-date-function_016_31f3fef4a0" id="_jDiZgfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_016_31f3fef4a0_Result" name="feel-date-function_016_31f3fef4a0" id="_jDiZgfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZf_UUEeesLuP4RHs4vA">
             <text>string(date("-999999999-12-31"))</text>
         </literalExpression>
@@ -305,7 +305,7 @@
         <description>Tests FEEL expression: 'date(date and time("2017-08-14T14:25:00"))' and expects result: '2017-08-14 (date)'</description>
         <question>Result of FEEL expression 'date(date and time("2017-08-14T14:25:00"))'?</question>
         <allowedAnswers>2017-08-14 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_017_887dfef005_Result" name="feel-date-function_017_887dfef005" id="_jDiZhfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_017_887dfef005_Result" name="feel-date-function_017_887dfef005" id="_jDiZhfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZg_UUEeesLuP4RHs4vA">
             <text>date(date and time("2017-08-14T14:25:00"))</text>
         </literalExpression>
@@ -314,7 +314,7 @@
         <description>Tests FEEL expression: 'date(date and time(date and time("2017-08-14T14:25:00"),time("10:50:00")))' and expects result: '2017-08-14 (date)'</description>
         <question>Result of FEEL expression 'date(date and time(date and time("2017-08-14T14:25:00"),time("10:50:00")))'?</question>
         <allowedAnswers>2017-08-14 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_018_fc0ef0c8cb_Result" name="feel-date-function_018_fc0ef0c8cb" id="_jDiZifUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_018_fc0ef0c8cb_Result" name="feel-date-function_018_fc0ef0c8cb" id="_jDiZifUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZh_UUEeesLuP4RHs4vA">
             <text>date(date and time(date and time("2017-08-14T14:25:00"),time("10:50:00")))</text>
         </literalExpression>
@@ -323,7 +323,7 @@
         <description>Tests FEEL expression: 'date(date and time("2017-08-14T14:25:00.123456789"))' and expects result: '2017-08-14 (date)'</description>
         <question>Result of FEEL expression 'date(date and time("2017-08-14T14:25:00.123456789"))'?</question>
         <allowedAnswers>2017-08-14 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_019_b2b82796ce_Result" name="feel-date-function_019_b2b82796ce" id="_jDiZjfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_019_b2b82796ce_Result" name="feel-date-function_019_b2b82796ce" id="_jDiZjfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZi_UUEeesLuP4RHs4vA">
             <text>date(date and time("2017-08-14T14:25:00.123456789"))</text>
         </literalExpression>
@@ -332,7 +332,7 @@
         <description>Tests FEEL expression: 'date(date and time("2017-09-03T09:45:30@Europe/Paris"))' and expects result: '2017-09-03 (date)'</description>
         <question>Result of FEEL expression 'date(date and time("2017-09-03T09:45:30@Europe/Paris"))'?</question>
         <allowedAnswers>2017-09-03 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_020_7d56b7bf63_Result" name="feel-date-function_020_7d56b7bf63" id="_jDiZkfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_020_7d56b7bf63_Result" name="feel-date-function_020_7d56b7bf63" id="_jDiZkfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZj_UUEeesLuP4RHs4vA">
             <text>date(date and time("2017-09-03T09:45:30@Europe/Paris"))</text>
         </literalExpression>
@@ -341,7 +341,7 @@
         <description>Tests FEEL expression: 'date(date and time("2017-09-06T09:45:30@Asia/Dhaka"))' and expects result: '2017-09-06 (date)'</description>
         <question>Result of FEEL expression 'date(date and time("2017-09-06T09:45:30@Asia/Dhaka"))'?</question>
         <allowedAnswers>2017-09-06 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_021_95fb3d9984_Result" name="feel-date-function_021_95fb3d9984" id="_jDiZlfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_021_95fb3d9984_Result" name="feel-date-function_021_95fb3d9984" id="_jDiZlfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZk_UUEeesLuP4RHs4vA">
             <text>date(date and time("2017-09-06T09:45:30@Asia/Dhaka"))</text>
         </literalExpression>
@@ -350,7 +350,7 @@
         <description>Tests FEEL expression: 'date(date and time("2012-12-25T11:00:00Z"))' and expects result: '2012-12-25 (date)'</description>
         <question>Result of FEEL expression 'date(date and time("2012-12-25T11:00:00Z"))'?</question>
         <allowedAnswers>2012-12-25 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_022_4063db2d59_Result" name="feel-date-function_022_4063db2d59" id="_jDiZmfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_022_4063db2d59_Result" name="feel-date-function_022_4063db2d59" id="_jDiZmfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZl_UUEeesLuP4RHs4vA">
             <text>date(date and time("2012-12-25T11:00:00Z"))</text>
         </literalExpression>
@@ -359,7 +359,7 @@
         <description>Tests FEEL expression: 'date(date and time("2017-08-03T10:15:30+01:00"))' and expects result: '2017-08-03 (date)'</description>
         <question>Result of FEEL expression 'date(date and time("2017-08-03T10:15:30+01:00"))'?</question>
         <allowedAnswers>2017-08-03 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_023_4a1f604006_Result" name="feel-date-function_023_4a1f604006" id="_jDiZnfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_023_4a1f604006_Result" name="feel-date-function_023_4a1f604006" id="_jDiZnfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZm_UUEeesLuP4RHs4vA">
             <text>date(date and time("2017-08-03T10:15:30+01:00"))</text>
         </literalExpression>
@@ -368,7 +368,7 @@
         <description>Tests FEEL expression: 'date(date("2017-10-11"))' and expects result: '2017-10-11 (date)'</description>
         <question>Result of FEEL expression 'date(date("2017-10-11"))'?</question>
         <allowedAnswers>2017-10-11 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_024_3cb98a2bb8_Result" name="feel-date-function_024_3cb98a2bb8" id="_jDiZofUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_024_3cb98a2bb8_Result" name="feel-date-function_024_3cb98a2bb8" id="_jDiZofUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZn_UUEeesLuP4RHs4vA">
             <text>date(date("2017-10-11"))</text>
         </literalExpression>
@@ -377,7 +377,7 @@
         <description>Tests FEEL expression: 'date(2017,12,31)' and expects result: '2017-12-31 (date)'</description>
         <question>Result of FEEL expression 'date(2017,12,31)'?</question>
         <allowedAnswers>2017-12-31 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_025_cf0ad1313c_Result" name="feel-date-function_025_cf0ad1313c" id="_jDiZpfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_025_cf0ad1313c_Result" name="feel-date-function_025_cf0ad1313c" id="_jDiZpfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZo_UUEeesLuP4RHs4vA">
             <text>date(2017,12,31)</text>
         </literalExpression>
@@ -386,7 +386,7 @@
         <description>Tests FEEL expression: 'date(2017,01,01)' and expects result: '2017-01-01 (date)'</description>
         <question>Result of FEEL expression 'date(2017,01,01)'?</question>
         <allowedAnswers>2017-01-01 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_026_cedd7e5e5f_Result" name="feel-date-function_026_cedd7e5e5f" id="_jDiZqfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_026_cedd7e5e5f_Result" name="feel-date-function_026_cedd7e5e5f" id="_jDiZqfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDiZp_UUEeesLuP4RHs4vA">
             <text>date(2017,01,01)</text>
         </literalExpression>
@@ -395,7 +395,7 @@
         <description>Tests FEEL expression: 'date(-2017,12,31)' and expects result: '-2017-12-31 (date)'</description>
         <question>Result of FEEL expression 'date(-2017,12,31)'?</question>
         <allowedAnswers>-2017-12-31 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_027_987c5be372_Result" name="feel-date-function_027_987c5be372" id="_jDrjMvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_027_987c5be372_Result" name="feel-date-function_027_987c5be372" id="_jDrjMvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjMPUUEeesLuP4RHs4vA">
             <text>date(-2017,12,31)</text>
         </literalExpression>
@@ -404,7 +404,7 @@
         <description>Tests FEEL expression: 'date(-2017,01,01)' and expects result: '-2017-01-01 (date)'</description>
         <question>Result of FEEL expression 'date(-2017,01,01)'?</question>
         <allowedAnswers>-2017-01-01 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_028_35ca79a6cd_Result" name="feel-date-function_028_35ca79a6cd" id="_jDrjNvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_028_35ca79a6cd_Result" name="feel-date-function_028_35ca79a6cd" id="_jDrjNvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjNPUUEeesLuP4RHs4vA">
             <text>date(-2017,01,01)</text>
         </literalExpression>
@@ -413,7 +413,7 @@
         <description>Tests FEEL expression: 'string(date(999999999,12,31))' and expects result: '"999999999-12-31" (string)'</description>
         <question>Result of FEEL expression 'string(date(999999999,12,31))'?</question>
         <allowedAnswers>"999999999-12-31" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_029_88f5c7c90f_Result" name="feel-date-function_029_88f5c7c90f" id="_jDrjOvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_029_88f5c7c90f_Result" name="feel-date-function_029_88f5c7c90f" id="_jDrjOvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjOPUUEeesLuP4RHs4vA">
             <text>string(date(999999999,12,31))</text>
         </literalExpression>
@@ -422,7 +422,7 @@
         <description>Tests FEEL expression: 'string(date(-999999999,12,31))' and expects result: '"-999999999-12-31" (string)'</description>
         <question>Result of FEEL expression 'string(date(-999999999,12,31))'?</question>
         <allowedAnswers>"-999999999-12-31" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_030_9184a7bfc3_Result" name="feel-date-function_030_9184a7bfc3" id="_jDrjPvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_030_9184a7bfc3_Result" name="feel-date-function_030_9184a7bfc3" id="_jDrjPvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjPPUUEeesLuP4RHs4vA">
             <text>string(date(-999999999,12,31))</text>
         </literalExpression>
@@ -431,7 +431,7 @@
         <description>Tests FEEL expression: 'date("2012-12-25T")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("2012-12-25T")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_031_4f5ec70669_Result" name="feel-date-function_ErrorCase_031_4f5ec70669" id="_jDrjQvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_031_4f5ec70669_Result" name="feel-date-function_ErrorCase_031_4f5ec70669" id="_jDrjQvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjQPUUEeesLuP4RHs4vA">
             <text>date("2012-12-25T")</text>
         </literalExpression>
@@ -440,7 +440,7 @@
         <description>Tests FEEL expression: 'date("")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_032_fc66cc2fec_Result" name="feel-date-function_ErrorCase_032_fc66cc2fec" id="_jDrjRvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_032_fc66cc2fec_Result" name="feel-date-function_ErrorCase_032_fc66cc2fec" id="_jDrjRvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjRPUUEeesLuP4RHs4vA">
             <text>date("")</text>
         </literalExpression>
@@ -449,7 +449,7 @@
         <description>Tests FEEL expression: 'date("2012/12/25")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("2012/12/25")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_033_c3a5600c62_Result" name="feel-date-function_ErrorCase_033_c3a5600c62" id="_jDrjSvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_033_c3a5600c62_Result" name="feel-date-function_ErrorCase_033_c3a5600c62" id="_jDrjSvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjSPUUEeesLuP4RHs4vA">
             <text>date("2012/12/25")</text>
         </literalExpression>
@@ -458,7 +458,7 @@
         <description>Tests FEEL expression: 'date("0000-12-25T")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("0000-12-25T")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_034_7d2e18a10c_Result" name="feel-date-function_ErrorCase_034_7d2e18a10c" id="_jDrjTvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_034_7d2e18a10c_Result" name="feel-date-function_ErrorCase_034_7d2e18a10c" id="_jDrjTvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjTPUUEeesLuP4RHs4vA">
             <text>date("0000-12-25T")</text>
         </literalExpression>
@@ -467,7 +467,7 @@
         <description>Tests FEEL expression: 'date("9999999999-12-25")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("9999999999-12-25")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_035_e6c1bb43fd_Result" name="feel-date-function_ErrorCase_035_e6c1bb43fd" id="_jDrjUvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_035_e6c1bb43fd_Result" name="feel-date-function_ErrorCase_035_e6c1bb43fd" id="_jDrjUvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjUPUUEeesLuP4RHs4vA">
             <text>date("9999999999-12-25")</text>
         </literalExpression>
@@ -476,7 +476,7 @@
         <description>Tests FEEL expression: 'date("2017-13-10")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("2017-13-10")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_036_b826a6b5f9_Result" name="feel-date-function_ErrorCase_036_b826a6b5f9" id="_jDrjVvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_036_b826a6b5f9_Result" name="feel-date-function_ErrorCase_036_b826a6b5f9" id="_jDrjVvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjVPUUEeesLuP4RHs4vA">
             <text>date("2017-13-10")</text>
         </literalExpression>
@@ -485,7 +485,7 @@
         <description>Tests FEEL expression: 'date("2017-12-32")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("2017-12-32")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_037_cfd70896b6_Result" name="feel-date-function_ErrorCase_037_cfd70896b6" id="_jDrjWvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_037_cfd70896b6_Result" name="feel-date-function_ErrorCase_037_cfd70896b6" id="_jDrjWvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjWPUUEeesLuP4RHs4vA">
             <text>date("2017-12-32")</text>
         </literalExpression>
@@ -494,7 +494,7 @@
         <description>Tests FEEL expression: 'date("998-12-31")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("998-12-31")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_038_c26782f559_Result" name="feel-date-function_ErrorCase_038_c26782f559" id="_jDrjXvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_038_c26782f559_Result" name="feel-date-function_ErrorCase_038_c26782f559" id="_jDrjXvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjXPUUEeesLuP4RHs4vA">
             <text>date("998-12-31")</text>
         </literalExpression>
@@ -503,7 +503,7 @@
         <description>Tests FEEL expression: 'date("01211-12-31")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("01211-12-31")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_039_67a6eafa3f_Result" name="feel-date-function_ErrorCase_039_67a6eafa3f" id="_jDrjYvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_039_67a6eafa3f_Result" name="feel-date-function_ErrorCase_039_67a6eafa3f" id="_jDrjYvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjYPUUEeesLuP4RHs4vA">
             <text>date("01211-12-31")</text>
         </literalExpression>
@@ -512,7 +512,7 @@
         <description>Tests FEEL expression: 'date("2012T-12-2511:00:00Z")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("2012T-12-2511:00:00Z")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_040_dd2a2ed4a2_Result" name="feel-date-function_ErrorCase_040_dd2a2ed4a2" id="_jDrjZvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_040_dd2a2ed4a2_Result" name="feel-date-function_ErrorCase_040_dd2a2ed4a2" id="_jDrjZvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjZPUUEeesLuP4RHs4vA">
             <text>date("2012T-12-2511:00:00Z")</text>
         </literalExpression>
@@ -521,7 +521,7 @@
         <description>Tests FEEL expression: 'date("+2012-12-02")' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date("+2012-12-02")'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_041_9e7e388146_Result" name="feel-date-function_ErrorCase_041_9e7e388146" id="_jDrjavUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_041_9e7e388146_Result" name="feel-date-function_ErrorCase_041_9e7e388146" id="_jDrjavUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjaPUUEeesLuP4RHs4vA">
             <text>date("+2012-12-02")</text>
         </literalExpression>
@@ -530,7 +530,7 @@
         <description>Tests FEEL expression: 'date(2017,13,31)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(2017,13,31)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_042_8f5dd97588_Result" name="feel-date-function_ErrorCase_042_8f5dd97588" id="_jDrjbvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_042_8f5dd97588_Result" name="feel-date-function_ErrorCase_042_8f5dd97588" id="_jDrjbvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjbPUUEeesLuP4RHs4vA">
             <text>date(2017,13,31)</text>
         </literalExpression>
@@ -539,7 +539,7 @@
         <description>Tests FEEL expression: 'date(2017,12,32)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(2017,12,32)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_043_8f82301fac_Result" name="feel-date-function_ErrorCase_043_8f82301fac" id="_jDrjcvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_043_8f82301fac_Result" name="feel-date-function_ErrorCase_043_8f82301fac" id="_jDrjcvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjcPUUEeesLuP4RHs4vA">
             <text>date(2017,12,32)</text>
         </literalExpression>
@@ -548,7 +548,7 @@
         <description>Tests FEEL expression: 'date(2017,-8,2)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(2017,-8,2)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_044_74893220b4_Result" name="feel-date-function_ErrorCase_044_74893220b4" id="_jDrjdvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_044_74893220b4_Result" name="feel-date-function_ErrorCase_044_74893220b4" id="_jDrjdvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjdPUUEeesLuP4RHs4vA">
             <text>date(2017,-8,2)</text>
         </literalExpression>
@@ -557,7 +557,7 @@
         <description>Tests FEEL expression: 'date(2017,8,-2)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(2017,8,-2)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_045_969723fed5_Result" name="feel-date-function_ErrorCase_045_969723fed5" id="_jDrjevUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_045_969723fed5_Result" name="feel-date-function_ErrorCase_045_969723fed5" id="_jDrjevUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjePUUEeesLuP4RHs4vA">
             <text>date(2017,8,-2)</text>
         </literalExpression>
@@ -566,7 +566,7 @@
         <description>Tests FEEL expression: 'date(-1000999999,12,01)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(-1000999999,12,01)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_046_36bf30268a_Result" name="feel-date-function_ErrorCase_046_36bf30268a" id="_jDrjfvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_046_36bf30268a_Result" name="feel-date-function_ErrorCase_046_36bf30268a" id="_jDrjfvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjfPUUEeesLuP4RHs4vA">
             <text>date(-1000999999,12,01)</text>
         </literalExpression>
@@ -575,7 +575,7 @@
         <description>Tests FEEL expression: 'date(1000999999,12,32)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(1000999999,12,32)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_047_ba717eb672_Result" name="feel-date-function_ErrorCase_047_ba717eb672" id="_jDrjgvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_047_ba717eb672_Result" name="feel-date-function_ErrorCase_047_ba717eb672" id="_jDrjgvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjgPUUEeesLuP4RHs4vA">
             <text>date(1000999999,12,32)</text>
         </literalExpression>
@@ -584,7 +584,7 @@
         <description>Tests FEEL expression: 'date(1)' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date(1)'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_048_25595a6420_Result" name="feel-date-function_ErrorCase_048_25595a6420" id="_jDrjhvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_048_25595a6420_Result" name="feel-date-function_ErrorCase_048_25595a6420" id="_jDrjhvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjhPUUEeesLuP4RHs4vA">
             <text>date(1)</text>
         </literalExpression>
@@ -593,7 +593,7 @@
         <description>Tests FEEL expression: 'date([])' and expects result: 'null (date)'</description>
         <question>Result of FEEL expression 'date([])'?</question>
         <allowedAnswers>null (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_049_a1644ce710_Result" name="feel-date-function_ErrorCase_049_a1644ce710" id="_jDrjivUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_049_a1644ce710_Result" name="feel-date-function_ErrorCase_049_a1644ce710" id="_jDrjivUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjiPUUEeesLuP4RHs4vA">
             <text>date([])</text>
         </literalExpression>
@@ -602,7 +602,7 @@
         <description>Tests FEEL expression: 'date(from:"2012-12-25")' and expects result: '2012-12-25 (date)'</description>
         <question>Result of FEEL expression 'date(from:"2012-12-25")'?</question>
         <allowedAnswers>2012-12-25 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_050_8f1e299951_Result" name="feel-date-function_050_8f1e299951" id="_jDrjjvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_050_8f1e299951_Result" name="feel-date-function_050_8f1e299951" id="_jDrjjvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjjPUUEeesLuP4RHs4vA">
             <text>date(from:"2012-12-25")</text>
         </literalExpression>
@@ -611,7 +611,7 @@
         <description>Tests FEEL expression: 'date(from:date and time("2017-08-30T10:25:00"))' and expects result: '2017-08-30 (date)'</description>
         <question>Result of FEEL expression 'date(from:date and time("2017-08-30T10:25:00"))'?</question>
         <allowedAnswers>2017-08-30 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_051_ad98079864_Result" name="feel-date-function_051_ad98079864" id="_jD1UMPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_051_ad98079864_Result" name="feel-date-function_051_ad98079864" id="_jD1UMPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jDrjkPUUEeesLuP4RHs4vA">
             <text>date(from:date and time("2017-08-30T10:25:00"))</text>
         </literalExpression>
@@ -620,7 +620,7 @@
         <description>Tests FEEL expression: 'date(year:2017,month:08,day:30)' and expects result: '2017-08-30 (date)'</description>
         <question>Result of FEEL expression 'date(year:2017,month:08,day:30)'?</question>
         <allowedAnswers>2017-08-30 (date)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-function_052_63457d78b7_Result" name="feel-date-function_052_63457d78b7" id="_jD1UNPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-function_052_63457d78b7_Result" name="feel-date-function_052_63457d78b7" id="_jD1UNPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jD1UMvUUEeesLuP4RHs4vA">
             <text>date(year:2017,month:08,day:30)</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1116-feel-time-function/1116-feel-time-function.dmn
+++ b/TestCases/compliance-level-3/1116-feel-time-function/1116-feel-time-function.dmn
@@ -254,7 +254,7 @@
         <description>Tests FEEL expression: 'time(null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_001_bdf26fdc72_Result" name="feel-time-function_ErrorCase_001_bdf26fdc72" id="_jEusFPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_001_bdf26fdc72_Result" name="feel-time-function_ErrorCase_001_bdf26fdc72" id="_jEusFPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusEvUUEeesLuP4RHs4vA">
             <text>time(null)</text>
         </literalExpression>
@@ -263,7 +263,7 @@
         <description>Tests FEEL expression: 'time(null,11,45,duration("P0D"))' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null,11,45,duration("P0D"))'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_002_9d2e399b96_Result" name="feel-time-function_ErrorCase_002_9d2e399b96" id="_jEusGPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_002_9d2e399b96_Result" name="feel-time-function_ErrorCase_002_9d2e399b96" id="_jEusGPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusFvUUEeesLuP4RHs4vA">
             <text>time(null,11,45,duration("P0D"))</text>
         </literalExpression>
@@ -272,7 +272,7 @@
         <description>Tests FEEL expression: 'time(12,null,45,duration("P0D"))' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(12,null,45,duration("P0D"))'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_003_d1f0ea5bb9_Result" name="feel-time-function_ErrorCase_003_d1f0ea5bb9" id="_jEusHPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_003_d1f0ea5bb9_Result" name="feel-time-function_ErrorCase_003_d1f0ea5bb9" id="_jEusHPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusGvUUEeesLuP4RHs4vA">
             <text>time(12,null,45,duration("P0D"))</text>
         </literalExpression>
@@ -281,7 +281,7 @@
         <description>Tests FEEL expression: 'time(12,0,null,duration("P0D"))' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(12,0,null,duration("P0D"))'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_004_57aea91d1c_Result" name="feel-time-function_ErrorCase_004_57aea91d1c" id="_jEusIPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_004_57aea91d1c_Result" name="feel-time-function_ErrorCase_004_57aea91d1c" id="_jEusIPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusHvUUEeesLuP4RHs4vA">
             <text>time(12,0,null,duration("P0D"))</text>
         </literalExpression>
@@ -290,7 +290,7 @@
         <description>Tests FEEL expression: 'time(null,null,45,duration("P0D"))' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null,null,45,duration("P0D"))'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_005_32ea20b34f_Result" name="feel-time-function_ErrorCase_005_32ea20b34f" id="_jEusJPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_005_32ea20b34f_Result" name="feel-time-function_ErrorCase_005_32ea20b34f" id="_jEusJPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusIvUUEeesLuP4RHs4vA">
             <text>time(null,null,45,duration("P0D"))</text>
         </literalExpression>
@@ -299,7 +299,7 @@
         <description>Tests FEEL expression: 'time(null,11,null,duration("P0D"))' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null,11,null,duration("P0D"))'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_006_e266498180_Result" name="feel-time-function_ErrorCase_006_e266498180" id="_jEusKPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_006_e266498180_Result" name="feel-time-function_ErrorCase_006_e266498180" id="_jEusKPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusJvUUEeesLuP4RHs4vA">
             <text>time(null,11,null,duration("P0D"))</text>
         </literalExpression>
@@ -308,7 +308,7 @@
         <description>Tests FEEL expression: 'time(null,11,45,null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null,11,45,null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_007_ee82c7bf12_Result" name="feel-time-function_ErrorCase_007_ee82c7bf12" id="_jEusLPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_007_ee82c7bf12_Result" name="feel-time-function_ErrorCase_007_ee82c7bf12" id="_jEusLPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusKvUUEeesLuP4RHs4vA">
             <text>time(null,11,45,null)</text>
         </literalExpression>
@@ -317,7 +317,7 @@
         <description>Tests FEEL expression: 'time(12,null,null,duration("P0D"))' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(12,null,null,duration("P0D"))'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_008_08078c6c29_Result" name="feel-time-function_ErrorCase_008_08078c6c29" id="_jEusMPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_008_08078c6c29_Result" name="feel-time-function_ErrorCase_008_08078c6c29" id="_jEusMPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusLvUUEeesLuP4RHs4vA">
             <text>time(12,null,null,duration("P0D"))</text>
         </literalExpression>
@@ -326,7 +326,7 @@
         <description>Tests FEEL expression: 'time(12,11,null,null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(12,11,null,null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_009_804c21ed52_Result" name="feel-time-function_ErrorCase_009_804c21ed52" id="_jEusNPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_009_804c21ed52_Result" name="feel-time-function_ErrorCase_009_804c21ed52" id="_jEusNPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusMvUUEeesLuP4RHs4vA">
             <text>time(12,11,null,null)</text>
         </literalExpression>
@@ -335,7 +335,7 @@
         <description>Tests FEEL expression: 'time(12,null,null,null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(12,null,null,null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_010_cc773bb44b_Result" name="feel-time-function_ErrorCase_010_cc773bb44b" id="_jEusOPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_010_cc773bb44b_Result" name="feel-time-function_ErrorCase_010_cc773bb44b" id="_jEusOPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusNvUUEeesLuP4RHs4vA">
             <text>time(12,null,null,null)</text>
         </literalExpression>
@@ -344,7 +344,7 @@
         <description>Tests FEEL expression: 'time(null,0,null,null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null,0,null,null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_011_ad5b3a26b5_Result" name="feel-time-function_ErrorCase_011_ad5b3a26b5" id="_jEusPPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_011_ad5b3a26b5_Result" name="feel-time-function_ErrorCase_011_ad5b3a26b5" id="_jEusPPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusOvUUEeesLuP4RHs4vA">
             <text>time(null,0,null,null)</text>
         </literalExpression>
@@ -353,7 +353,7 @@
         <description>Tests FEEL expression: 'time(null,null,15,null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null,null,15,null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_012_3c2f416fc9_Result" name="feel-time-function_ErrorCase_012_3c2f416fc9" id="_jEusQPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_012_3c2f416fc9_Result" name="feel-time-function_ErrorCase_012_3c2f416fc9" id="_jEusQPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusPvUUEeesLuP4RHs4vA">
             <text>time(null,null,15,null)</text>
         </literalExpression>
@@ -362,7 +362,7 @@
         <description>Tests FEEL expression: 'time(null,null,null,duration("P0D"))' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null,null,null,duration("P0D"))'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_013_7f22c0bda8_Result" name="feel-time-function_ErrorCase_013_7f22c0bda8" id="_jEusRPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_013_7f22c0bda8_Result" name="feel-time-function_ErrorCase_013_7f22c0bda8" id="_jEusRPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusQvUUEeesLuP4RHs4vA">
             <text>time(null,null,null,duration("P0D"))</text>
         </literalExpression>
@@ -371,7 +371,7 @@
         <description>Tests FEEL expression: 'time(null,null,null,null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(null,null,null,null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_014_0dc13176e8_Result" name="feel-time-function_ErrorCase_014_0dc13176e8" id="_jEusSPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_014_0dc13176e8_Result" name="feel-time-function_ErrorCase_014_0dc13176e8" id="_jEusSPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusRvUUEeesLuP4RHs4vA">
             <text>time(null,null,null,null)</text>
         </literalExpression>
@@ -380,7 +380,7 @@
         <description>Tests FEEL expression: 'time(12,00,00,null)' and expects result: '12:00:00 (time)'</description>
         <question>Result of FEEL expression 'time(12,00,00,null)'?</question>
         <allowedAnswers>12:00:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_015_376d693a79_Result" name="feel-time-function_015_376d693a79" id="_jEusTPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_015_376d693a79_Result" name="feel-time-function_015_376d693a79" id="_jEusTPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusSvUUEeesLuP4RHs4vA">
             <text>time(12,00,00,null)</text>
         </literalExpression>
@@ -389,7 +389,7 @@
         <description>Tests FEEL expression: 'time()' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time()'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_016_c3cccff405_Result" name="feel-time-function_ErrorCase_016_c3cccff405" id="_jEusUPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_016_c3cccff405_Result" name="feel-time-function_ErrorCase_016_c3cccff405" id="_jEusUPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusTvUUEeesLuP4RHs4vA">
             <text>time()</text>
         </literalExpression>
@@ -398,7 +398,7 @@
         <description>Tests FEEL expression: 'time("01:02:03")' and expects result: '01:02:03 (time)'</description>
         <question>Result of FEEL expression 'time("01:02:03")'?</question>
         <allowedAnswers>01:02:03 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_017_f3683885f5_Result" name="feel-time-function_017_f3683885f5" id="_jEusVPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_017_f3683885f5_Result" name="feel-time-function_017_f3683885f5" id="_jEusVPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusUvUUEeesLuP4RHs4vA">
             <text>time("01:02:03")</text>
         </literalExpression>
@@ -407,7 +407,7 @@
         <description>Tests FEEL expression: 'time("00:00:00")' and expects result: '00:00:00 (time)'</description>
         <question>Result of FEEL expression 'time("00:00:00")'?</question>
         <allowedAnswers>00:00:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_018_35f1f2cce8_Result" name="feel-time-function_018_35f1f2cce8" id="_jEusWPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_018_35f1f2cce8_Result" name="feel-time-function_018_35f1f2cce8" id="_jEusWPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusVvUUEeesLuP4RHs4vA">
             <text>time("00:00:00")</text>
         </literalExpression>
@@ -416,7 +416,7 @@
         <description>Tests FEEL expression: 'time("11:22:33.444")' and expects result: '11:22:33.444 (time)'</description>
         <question>Result of FEEL expression 'time("11:22:33.444")'?</question>
         <allowedAnswers>11:22:33.444 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_019_879be89d63_Result" name="feel-time-function_019_879be89d63" id="_jEusXPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_019_879be89d63_Result" name="feel-time-function_019_879be89d63" id="_jEusXPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusWvUUEeesLuP4RHs4vA">
             <text>time("11:22:33.444")</text>
         </literalExpression>
@@ -425,7 +425,7 @@
         <description>Tests FEEL expression: 'time("11:22:33.123456789")' and expects result: '11:22:33.123456789 (time)'</description>
         <question>Result of FEEL expression 'time("11:22:33.123456789")'?</question>
         <allowedAnswers>11:22:33.123456789 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_020_72b421086e_Result" name="feel-time-function_020_72b421086e" id="_jEusYPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_020_72b421086e_Result" name="feel-time-function_020_72b421086e" id="_jEusYPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusXvUUEeesLuP4RHs4vA">
             <text>time("11:22:33.123456789")</text>
         </literalExpression>
@@ -434,7 +434,7 @@
         <description>Tests FEEL expression: 'time("23:59:00Z")' and expects result: '23:59:00Z (time)'</description>
         <question>Result of FEEL expression 'time("23:59:00Z")'?</question>
         <allowedAnswers>23:59:00Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_021_5c50fa1dff_Result" name="feel-time-function_021_5c50fa1dff" id="_jEusZPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_021_5c50fa1dff_Result" name="feel-time-function_021_5c50fa1dff" id="_jEusZPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusYvUUEeesLuP4RHs4vA">
             <text>time("23:59:00Z")</text>
         </literalExpression>
@@ -443,7 +443,7 @@
         <description>Tests FEEL expression: 'time("11:00:00Z")' and expects result: '11:00:00Z (time)'</description>
         <question>Result of FEEL expression 'time("11:00:00Z")'?</question>
         <allowedAnswers>11:00:00Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_022_55e76d3595_Result" name="feel-time-function_022_55e76d3595" id="_jEusaPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_022_55e76d3595_Result" name="feel-time-function_022_55e76d3595" id="_jEusaPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusZvUUEeesLuP4RHs4vA">
             <text>time("11:00:00Z")</text>
         </literalExpression>
@@ -452,7 +452,7 @@
         <description>Tests FEEL expression: 'time("00:00:00Z")' and expects result: '00:00:00Z (time)'</description>
         <question>Result of FEEL expression 'time("00:00:00Z")'?</question>
         <allowedAnswers>00:00:00Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_023_5cbbb85435_Result" name="feel-time-function_023_5cbbb85435" id="_jEusbPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_023_5cbbb85435_Result" name="feel-time-function_023_5cbbb85435" id="_jEusbPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusavUUEeesLuP4RHs4vA">
             <text>time("00:00:00Z")</text>
         </literalExpression>
@@ -461,7 +461,7 @@
         <description>Tests FEEL expression: 'time("13:20:00+02:00")' and expects result: '13:20:00+02:00 (time)'</description>
         <question>Result of FEEL expression 'time("13:20:00+02:00")'?</question>
         <allowedAnswers>13:20:00+02:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_024_5f7f735e8f_Result" name="feel-time-function_024_5f7f735e8f" id="_jEuscPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_024_5f7f735e8f_Result" name="feel-time-function_024_5f7f735e8f" id="_jEuscPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusbvUUEeesLuP4RHs4vA">
             <text>time("13:20:00+02:00")</text>
         </literalExpression>
@@ -470,7 +470,7 @@
         <description>Tests FEEL expression: 'time("13:20:00-05:00")' and expects result: '13:20:00-05:00 (time)'</description>
         <question>Result of FEEL expression 'time("13:20:00-05:00")'?</question>
         <allowedAnswers>13:20:00-05:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_025_139b25b795_Result" name="feel-time-function_025_139b25b795" id="_jEusdPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_025_139b25b795_Result" name="feel-time-function_025_139b25b795" id="_jEusdPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEuscvUUEeesLuP4RHs4vA">
             <text>time("13:20:00-05:00")</text>
         </literalExpression>
@@ -479,7 +479,7 @@
         <description>Tests FEEL expression: 'time("11:22:33-00:00")' and expects result: '11:22:33Z (time)'</description>
         <question>Result of FEEL expression 'time("11:22:33-00:00")'?</question>
         <allowedAnswers>11:22:33Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_026_c5208af118_Result" name="feel-time-function_026_c5208af118" id="_jEusePUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_026_c5208af118_Result" name="feel-time-function_026_c5208af118" id="_jEusePUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusdvUUEeesLuP4RHs4vA">
             <text>time("11:22:33-00:00")</text>
         </literalExpression>
@@ -488,7 +488,7 @@
         <description>Tests FEEL expression: 'time("11:22:33+00:00")' and expects result: '11:22:33Z (time)'</description>
         <question>Result of FEEL expression 'time("11:22:33+00:00")'?</question>
         <allowedAnswers>11:22:33Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_027_45082fd26c_Result" name="feel-time-function_027_45082fd26c" id="_jEusfPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_027_45082fd26c_Result" name="feel-time-function_027_45082fd26c" id="_jEusfPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusevUUEeesLuP4RHs4vA">
             <text>time("11:22:33+00:00")</text>
         </literalExpression>
@@ -497,7 +497,7 @@
         <description>Tests FEEL expression: 'string(time("00:01:00@Etc/UTC"))' and expects result: '"00:01:00@Etc/UTC" (string)'</description>
         <question>Result of FEEL expression 'string(time("00:01:00@Etc/UTC"))'?</question>
         <allowedAnswers>"00:01:00@Etc/UTC" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_028_eaea7a943c_Result" name="feel-time-function_028_eaea7a943c" id="_jEusgPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_028_eaea7a943c_Result" name="feel-time-function_028_eaea7a943c" id="_jEusgPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusfvUUEeesLuP4RHs4vA">
             <text>string(time("00:01:00@Etc/UTC"))</text>
         </literalExpression>
@@ -506,7 +506,7 @@
         <description>Tests FEEL expression: 'string(time("00:01:00@Europe/Paris"))' and expects result: '"00:01:00@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(time("00:01:00@Europe/Paris"))'?</question>
         <allowedAnswers>"00:01:00@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_029_f0d5c2c16a_Result" name="feel-time-function_029_f0d5c2c16a" id="_jEushPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_029_f0d5c2c16a_Result" name="feel-time-function_029_f0d5c2c16a" id="_jEushPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusgvUUEeesLuP4RHs4vA">
             <text>string(time("00:01:00@Europe/Paris"))</text>
         </literalExpression>
@@ -515,7 +515,7 @@
         <description>Tests FEEL expression: 'time(date and time("2017-08-10T10:20:00"))' and expects result: '10:20:00 (time)'</description>
         <question>Result of FEEL expression 'time(date and time("2017-08-10T10:20:00"))'?</question>
         <allowedAnswers>10:20:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_030_390d4f4648_Result" name="feel-time-function_030_390d4f4648" id="_jEusiPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_030_390d4f4648_Result" name="feel-time-function_030_390d4f4648" id="_jEusiPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEushvUUEeesLuP4RHs4vA">
             <text>time(date and time("2017-08-10T10:20:00"))</text>
         </literalExpression>
@@ -524,7 +524,7 @@
         <description>Tests FEEL expression: 'time(date and time("2017-08-10T10:20:00+00:00"))' and expects result: '10:20:00Z (time)'</description>
         <question>Result of FEEL expression 'time(date and time("2017-08-10T10:20:00+00:00"))'?</question>
         <allowedAnswers>10:20:00Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_031_4d086a3b59_Result" name="feel-time-function_031_4d086a3b59" id="_jEusjPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_031_4d086a3b59_Result" name="feel-time-function_031_4d086a3b59" id="_jEusjPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusivUUEeesLuP4RHs4vA">
             <text>time(date and time("2017-08-10T10:20:00+00:00"))</text>
         </literalExpression>
@@ -533,7 +533,7 @@
         <description>Tests FEEL expression: 'time(date and time("2017-08-10T10:20:00-00:00"))' and expects result: '10:20:00Z (time)'</description>
         <question>Result of FEEL expression 'time(date and time("2017-08-10T10:20:00-00:00"))'?</question>
         <allowedAnswers>10:20:00Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_032_d9b0d7f931_Result" name="feel-time-function_032_d9b0d7f931" id="_jEuskPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_032_d9b0d7f931_Result" name="feel-time-function_032_d9b0d7f931" id="_jEuskPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusjvUUEeesLuP4RHs4vA">
             <text>time(date and time("2017-08-10T10:20:00-00:00"))</text>
         </literalExpression>
@@ -542,7 +542,7 @@
         <description>Tests FEEL expression: 'time(date and time("2017-08-10T10:20:00+01:00"))' and expects result: '10:20:00+01:00 (time)'</description>
         <question>Result of FEEL expression 'time(date and time("2017-08-10T10:20:00+01:00"))'?</question>
         <allowedAnswers>10:20:00+01:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_033_8420160da1_Result" name="feel-time-function_033_8420160da1" id="_jEuslPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_033_8420160da1_Result" name="feel-time-function_033_8420160da1" id="_jEuslPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEuskvUUEeesLuP4RHs4vA">
             <text>time(date and time("2017-08-10T10:20:00+01:00"))</text>
         </literalExpression>
@@ -551,7 +551,7 @@
         <description>Tests FEEL expression: 'time(date and time("2017-08-10T10:20:00-01:00"))' and expects result: '10:20:00-01:00 (time)'</description>
         <question>Result of FEEL expression 'time(date and time("2017-08-10T10:20:00-01:00"))'?</question>
         <allowedAnswers>10:20:00-01:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_034_13c312c376_Result" name="feel-time-function_034_13c312c376" id="_jEusmPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_034_13c312c376_Result" name="feel-time-function_034_13c312c376" id="_jEusmPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEuslvUUEeesLuP4RHs4vA">
             <text>time(date and time("2017-08-10T10:20:00-01:00"))</text>
         </literalExpression>
@@ -560,7 +560,7 @@
         <description>Tests FEEL expression: 'time(date and time("2017-08-10T10:20:00Z"))' and expects result: '10:20:00Z (time)'</description>
         <question>Result of FEEL expression 'time(date and time("2017-08-10T10:20:00Z"))'?</question>
         <allowedAnswers>10:20:00Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_035_fbfce88ac4_Result" name="feel-time-function_035_fbfce88ac4" id="_jEusnPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_035_fbfce88ac4_Result" name="feel-time-function_035_fbfce88ac4" id="_jEusnPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusmvUUEeesLuP4RHs4vA">
             <text>time(date and time("2017-08-10T10:20:00Z"))</text>
         </literalExpression>
@@ -569,7 +569,7 @@
         <description>Tests FEEL expression: 'string(time(date and time("2017-08-10T10:20:00@Europe/Paris")))' and expects result: '"10:20:00@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(time(date and time("2017-08-10T10:20:00@Europe/Paris")))'?</question>
         <allowedAnswers>"10:20:00@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_036_eb05fabc01_Result" name="feel-time-function_036_eb05fabc01" id="_jEusoPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_036_eb05fabc01_Result" name="feel-time-function_036_eb05fabc01" id="_jEusoPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusnvUUEeesLuP4RHs4vA">
             <text>string(time(date and time("2017-08-10T10:20:00@Europe/Paris")))</text>
         </literalExpression>
@@ -578,7 +578,7 @@
         <description>Tests FEEL expression: 'string(time(date and time("2017-09-04T11:20:00@Asia/Dhaka")))' and expects result: '"11:20:00@Asia/Dhaka" (string)'</description>
         <question>Result of FEEL expression 'string(time(date and time("2017-09-04T11:20:00@Asia/Dhaka")))'?</question>
         <allowedAnswers>"11:20:00@Asia/Dhaka" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_037_eed195f693_Result" name="feel-time-function_037_eed195f693" id="_jEuspPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_037_eed195f693_Result" name="feel-time-function_037_eed195f693" id="_jEuspPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusovUUEeesLuP4RHs4vA">
             <text>string(time(date and time("2017-09-04T11:20:00@Asia/Dhaka")))</text>
         </literalExpression>
@@ -587,7 +587,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 45, null)' and expects result: '11:59:45 (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 45, null)'?</question>
         <allowedAnswers>11:59:45 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_038_05b311131c_Result" name="feel-time-function_038_05b311131c" id="_jEusqPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_038_05b311131c_Result" name="feel-time-function_038_05b311131c" id="_jEusqPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEuspvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 45, null)</text>
         </literalExpression>
@@ -596,7 +596,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 45, duration("PT0H"))' and expects result: '11:59:45Z (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 45, duration("PT0H"))'?</question>
         <allowedAnswers>11:59:45Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_039_5b65992f0d_Result" name="feel-time-function_039_5b65992f0d" id="_jEusrPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_039_5b65992f0d_Result" name="feel-time-function_039_5b65992f0d" id="_jEusrPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusqvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 45, duration("PT0H"))</text>
         </literalExpression>
@@ -605,7 +605,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 45, duration("PT2H"))' and expects result: '11:59:45+02:00 (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 45, duration("PT2H"))'?</question>
         <allowedAnswers>11:59:45+02:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_040_6c9d17b491_Result" name="feel-time-function_040_6c9d17b491" id="_jEussPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_040_6c9d17b491_Result" name="feel-time-function_040_6c9d17b491" id="_jEussPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusrvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 45, duration("PT2H"))</text>
         </literalExpression>
@@ -614,7 +614,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 45, duration("-PT2H"))' and expects result: '11:59:45-02:00 (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 45, duration("-PT2H"))'?</question>
         <allowedAnswers>11:59:45-02:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_041_29a448d57e_Result" name="feel-time-function_041_29a448d57e" id="_jEustPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_041_29a448d57e_Result" name="feel-time-function_041_29a448d57e" id="_jEustPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEussvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 45, duration("-PT2H"))</text>
         </literalExpression>
@@ -623,7 +623,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 00, duration("PT2H1M"))' and expects result: '11:59:00+02:01 (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 00, duration("PT2H1M"))'?</question>
         <allowedAnswers>11:59:00+02:01 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_042_00146f2977_Result" name="feel-time-function_042_00146f2977" id="_jEusuPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_042_00146f2977_Result" name="feel-time-function_042_00146f2977" id="_jEusuPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEustvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 00, duration("PT2H1M"))</text>
         </literalExpression>
@@ -632,7 +632,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 00, duration("-PT2H1M"))' and expects result: '11:59:00-02:01 (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 00, duration("-PT2H1M"))'?</question>
         <allowedAnswers>11:59:00-02:01 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_043_2edfae8414_Result" name="feel-time-function_043_2edfae8414" id="_jEusvPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_043_2edfae8414_Result" name="feel-time-function_043_2edfae8414" id="_jEusvPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusuvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 00, duration("-PT2H1M"))</text>
         </literalExpression>
@@ -641,7 +641,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 00, duration("PT2H1M0S"))' and expects result: '11:59:00+02:01 (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 00, duration("PT2H1M0S"))'?</question>
         <allowedAnswers>11:59:00+02:01 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_044_3073ffd026_Result" name="feel-time-function_044_3073ffd026" id="_jEuswPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_044_3073ffd026_Result" name="feel-time-function_044_3073ffd026" id="_jEuswPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusvvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 00, duration("PT2H1M0S"))</text>
         </literalExpression>
@@ -650,7 +650,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 00, duration("-PT2H1M0S"))' and expects result: '11:59:00-02:01 (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 00, duration("-PT2H1M0S"))'?</question>
         <allowedAnswers>11:59:00-02:01 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_045_ad1339e858_Result" name="feel-time-function_045_ad1339e858" id="_jEusxPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_045_ad1339e858_Result" name="feel-time-function_045_ad1339e858" id="_jEusxPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEuswvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 00, duration("-PT2H1M0S"))</text>
         </literalExpression>
@@ -659,7 +659,7 @@
         <description>Tests FEEL expression: 'string(time(11, 59, 45, duration("PT2H45M55S")))' and expects result: '"11:59:45+02:45:55" (string)'</description>
         <question>Result of FEEL expression 'string(time(11, 59, 45, duration("PT2H45M55S")))'?</question>
         <allowedAnswers>"11:59:45+02:45:55" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_046_7b80221ec1_Result" name="feel-time-function_046_7b80221ec1" id="_jEusyPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_046_7b80221ec1_Result" name="feel-time-function_046_7b80221ec1" id="_jEusyPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusxvUUEeesLuP4RHs4vA">
             <text>string(time(11, 59, 45, duration("PT2H45M55S")))</text>
         </literalExpression>
@@ -668,7 +668,7 @@
         <description>Tests FEEL expression: 'string(time(11, 59, 45, duration("-PT2H45M55S")))' and expects result: '"11:59:45-02:45:55" (string)'</description>
         <question>Result of FEEL expression 'string(time(11, 59, 45, duration("-PT2H45M55S")))'?</question>
         <allowedAnswers>"11:59:45-02:45:55" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_047_33cd7b9b15_Result" name="feel-time-function_047_33cd7b9b15" id="_jEuszPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_047_33cd7b9b15_Result" name="feel-time-function_047_33cd7b9b15" id="_jEuszPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEusyvUUEeesLuP4RHs4vA">
             <text>string(time(11, 59, 45, duration("-PT2H45M55S")))</text>
         </literalExpression>
@@ -677,7 +677,7 @@
         <description>Tests FEEL expression: 'time(11, 59, 45, duration("-PT0H"))' and expects result: '11:59:45Z (time)'</description>
         <question>Result of FEEL expression 'time(11, 59, 45, duration("-PT0H"))'?</question>
         <allowedAnswers>11:59:45Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_048_9bedd52886_Result" name="feel-time-function_048_9bedd52886" id="_jEus0PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_048_9bedd52886_Result" name="feel-time-function_048_9bedd52886" id="_jEus0PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEuszvUUEeesLuP4RHs4vA">
             <text>time(11, 59, 45, duration("-PT0H"))</text>
         </literalExpression>
@@ -686,7 +686,7 @@
         <description>Tests FEEL expression: 'time(date and time(date and time("2017-08-10T10:20:00"),time("23:59:01")))' and expects result: '23:59:01 (time)'</description>
         <question>Result of FEEL expression 'time(date and time(date and time("2017-08-10T10:20:00"),time("23:59:01")))'?</question>
         <allowedAnswers>23:59:01 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_049_617d9e09d6_Result" name="feel-time-function_049_617d9e09d6" id="_jEus1PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_049_617d9e09d6_Result" name="feel-time-function_049_617d9e09d6" id="_jEus1PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus0vUUEeesLuP4RHs4vA">
             <text>time(date and time(date and time("2017-08-10T10:20:00"),time("23:59:01")))</text>
         </literalExpression>
@@ -695,7 +695,7 @@
         <description>Tests FEEL expression: 'time(date and time(date and time("2017-08-10T10:20:00"),time("23:59:01.987654321")))' and expects result: '23:59:01.987654321 (time)'</description>
         <question>Result of FEEL expression 'time(date and time(date and time("2017-08-10T10:20:00"),time("23:59:01.987654321")))'?</question>
         <allowedAnswers>23:59:01.987654321 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_050_524d9a8146_Result" name="feel-time-function_050_524d9a8146" id="_jEus2PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_050_524d9a8146_Result" name="feel-time-function_050_524d9a8146" id="_jEus2PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus1vUUEeesLuP4RHs4vA">
             <text>time(date and time(date and time("2017-08-10T10:20:00"),time("23:59:01.987654321")))</text>
         </literalExpression>
@@ -704,7 +704,7 @@
         <description>Tests FEEL expression: 'time(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30+02:00")))' and expects result: '09:15:30+02:00 (time)'</description>
         <question>Result of FEEL expression 'time(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30+02:00")))'?</question>
         <allowedAnswers>09:15:30+02:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_051_a71d2a08f7_Result" name="feel-time-function_051_a71d2a08f7" id="_jEus3PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_051_a71d2a08f7_Result" name="feel-time-function_051_a71d2a08f7" id="_jEus3PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus2vUUEeesLuP4RHs4vA">
             <text>time(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30+02:00")))</text>
         </literalExpression>
@@ -713,7 +713,7 @@
         <description>Tests FEEL expression: 'time(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30Z")))' and expects result: '09:15:30Z (time)'</description>
         <question>Result of FEEL expression 'time(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30Z")))'?</question>
         <allowedAnswers>09:15:30Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_052_d825d58888_Result" name="feel-time-function_052_d825d58888" id="_jEus4PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_052_d825d58888_Result" name="feel-time-function_052_d825d58888" id="_jEus4PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus3vUUEeesLuP4RHs4vA">
             <text>time(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30Z")))</text>
         </literalExpression>
@@ -722,7 +722,7 @@
         <description>Tests FEEL expression: 'time(date("2017-08-10"))' and expects result: '00:00:00Z (time)'</description>
         <question>Result of FEEL expression 'time(date("2017-08-10"))'?</question>
         <allowedAnswers>00:00:00Z (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_053_3d956966c0_Result" name="feel-time-function_053_3d956966c0" id="_jEus5PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_053_3d956966c0_Result" name="feel-time-function_053_3d956966c0" id="_jEus5PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus4vUUEeesLuP4RHs4vA">
             <text>time(date("2017-08-10"))</text>
         </literalExpression>
@@ -731,7 +731,7 @@
         <description>Tests FEEL expression: 'time(2017)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(2017)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_054_fdc3094237_Result" name="feel-time-function_ErrorCase_054_fdc3094237" id="_jEus6PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_054_fdc3094237_Result" name="feel-time-function_ErrorCase_054_fdc3094237" id="_jEus6PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus5vUUEeesLuP4RHs4vA">
             <text>time(2017)</text>
         </literalExpression>
@@ -740,7 +740,7 @@
         <description>Tests FEEL expression: 'time([])' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time([])'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_055_9b47db6ea4_Result" name="feel-time-function_ErrorCase_055_9b47db6ea4" id="_jEus7PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_055_9b47db6ea4_Result" name="feel-time-function_ErrorCase_055_9b47db6ea4" id="_jEus7PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus6vUUEeesLuP4RHs4vA">
             <text>time([])</text>
         </literalExpression>
@@ -749,7 +749,7 @@
         <description>Tests FEEL expression: 'time("")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_056_a8e828d64d_Result" name="feel-time-function_ErrorCase_056_a8e828d64d" id="_jEus8PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_056_a8e828d64d_Result" name="feel-time-function_ErrorCase_056_a8e828d64d" id="_jEus8PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus7vUUEeesLuP4RHs4vA">
             <text>time("")</text>
         </literalExpression>
@@ -758,7 +758,7 @@
         <description>Tests FEEL expression: 'time("23:59:60")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("23:59:60")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_057_d039115cce_Result" name="feel-time-function_ErrorCase_057_d039115cce" id="_jEus9PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_057_d039115cce_Result" name="feel-time-function_ErrorCase_057_d039115cce" id="_jEus9PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus8vUUEeesLuP4RHs4vA">
             <text>time("23:59:60")</text>
         </literalExpression>
@@ -767,7 +767,7 @@
         <description>Tests FEEL expression: 'time("24:00:01")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("24:00:01")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_058_81dd4b1639_Result" name="feel-time-function_ErrorCase_058_81dd4b1639" id="_jEus-PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_058_81dd4b1639_Result" name="feel-time-function_ErrorCase_058_81dd4b1639" id="_jEus-PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jEus9vUUEeesLuP4RHs4vA">
             <text>time("24:00:01")</text>
         </literalExpression>
@@ -776,7 +776,7 @@
         <description>Tests FEEL expression: 'time("24:01:00")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("24:01:00")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_059_c7e1705fe1_Result" name="feel-time-function_ErrorCase_059_c7e1705fe1" id="_jE32AvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_059_c7e1705fe1_Result" name="feel-time-function_ErrorCase_059_c7e1705fe1" id="_jE32AvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32APUUEeesLuP4RHs4vA">
             <text>time("24:01:00")</text>
         </literalExpression>
@@ -785,7 +785,7 @@
         <description>Tests FEEL expression: 'time("25:00:00")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("25:00:00")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_060_0cf4734fae_Result" name="feel-time-function_ErrorCase_060_0cf4734fae" id="_jE32BvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_060_0cf4734fae_Result" name="feel-time-function_ErrorCase_060_0cf4734fae" id="_jE32BvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32BPUUEeesLuP4RHs4vA">
             <text>time("25:00:00")</text>
         </literalExpression>
@@ -794,7 +794,7 @@
         <description>Tests FEEL expression: 'time("00:60:00")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("00:60:00")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_061_da2717f085_Result" name="feel-time-function_ErrorCase_061_da2717f085" id="_jE32CvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_061_da2717f085_Result" name="feel-time-function_ErrorCase_061_da2717f085" id="_jE32CvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32CPUUEeesLuP4RHs4vA">
             <text>time("00:60:00")</text>
         </literalExpression>
@@ -803,7 +803,7 @@
         <description>Tests FEEL expression: 'time("00:00:61")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("00:00:61")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_062_6cd1313fa9_Result" name="feel-time-function_ErrorCase_062_6cd1313fa9" id="_jE32DvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_062_6cd1313fa9_Result" name="feel-time-function_ErrorCase_062_6cd1313fa9" id="_jE32DvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32DPUUEeesLuP4RHs4vA">
             <text>time("00:00:61")</text>
         </literalExpression>
@@ -812,7 +812,7 @@
         <description>Tests FEEL expression: 'time("7:00:00")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("7:00:00")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_063_e85c40b474_Result" name="feel-time-function_ErrorCase_063_e85c40b474" id="_jE32EvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_063_e85c40b474_Result" name="feel-time-function_ErrorCase_063_e85c40b474" id="_jE32EvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32EPUUEeesLuP4RHs4vA">
             <text>time("7:00:00")</text>
         </literalExpression>
@@ -821,7 +821,7 @@
         <description>Tests FEEL expression: 'time("07:1:00")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("07:1:00")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_064_df74038c67_Result" name="feel-time-function_ErrorCase_064_df74038c67" id="_jE32FvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_064_df74038c67_Result" name="feel-time-function_ErrorCase_064_df74038c67" id="_jE32FvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32FPUUEeesLuP4RHs4vA">
             <text>time("07:1:00")</text>
         </literalExpression>
@@ -830,7 +830,7 @@
         <description>Tests FEEL expression: 'time("07:01:2")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("07:01:2")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_065_79eaef6fee_Result" name="feel-time-function_ErrorCase_065_79eaef6fee" id="_jE32GvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_065_79eaef6fee_Result" name="feel-time-function_ErrorCase_065_79eaef6fee" id="_jE32GvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32GPUUEeesLuP4RHs4vA">
             <text>time("07:01:2")</text>
         </literalExpression>
@@ -839,7 +839,7 @@
         <description>Tests FEEL expression: 'time("13:20:00@xyz/abc")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("13:20:00@xyz/abc")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_066_5116e12fd3_Result" name="feel-time-function_ErrorCase_066_5116e12fd3" id="_jE32HvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_066_5116e12fd3_Result" name="feel-time-function_ErrorCase_066_5116e12fd3" id="_jE32HvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32HPUUEeesLuP4RHs4vA">
             <text>time("13:20:00@xyz/abc")</text>
         </literalExpression>
@@ -848,7 +848,7 @@
         <description>Tests FEEL expression: 'time("13:20:00+19:00")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("13:20:00+19:00")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_067_8285edad7b_Result" name="feel-time-function_ErrorCase_067_8285edad7b" id="_jE32IvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_067_8285edad7b_Result" name="feel-time-function_ErrorCase_067_8285edad7b" id="_jE32IvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32IPUUEeesLuP4RHs4vA">
             <text>time("13:20:00+19:00")</text>
         </literalExpression>
@@ -857,7 +857,7 @@
         <description>Tests FEEL expression: 'time("13:20:00-19:00")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("13:20:00-19:00")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_068_ad528abb23_Result" name="feel-time-function_ErrorCase_068_ad528abb23" id="_jE32JvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_068_ad528abb23_Result" name="feel-time-function_ErrorCase_068_ad528abb23" id="_jE32JvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32JPUUEeesLuP4RHs4vA">
             <text>time("13:20:00-19:00")</text>
         </literalExpression>
@@ -866,7 +866,7 @@
         <description>Tests FEEL expression: 'time("13:20:00+5:00")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("13:20:00+5:00")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_069_5096701e2e_Result" name="feel-time-function_ErrorCase_069_5096701e2e" id="_jE32KvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_069_5096701e2e_Result" name="feel-time-function_ErrorCase_069_5096701e2e" id="_jE32KvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32KPUUEeesLuP4RHs4vA">
             <text>time("13:20:00+5:00")</text>
         </literalExpression>
@@ -875,7 +875,7 @@
         <description>Tests FEEL expression: 'time("13:20:00+5")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("13:20:00+5")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_070_8b2e39f570_Result" name="feel-time-function_ErrorCase_070_8b2e39f570" id="_jE32LvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_070_8b2e39f570_Result" name="feel-time-function_ErrorCase_070_8b2e39f570" id="_jE32LvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32LPUUEeesLuP4RHs4vA">
             <text>time("13:20:00+5")</text>
         </literalExpression>
@@ -884,7 +884,7 @@
         <description>Tests FEEL expression: 'time("13:20:00+02:00@Europe/Paris")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("13:20:00+02:00@Europe/Paris")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_071_cf9417648b_Result" name="feel-time-function_ErrorCase_071_cf9417648b" id="_jE32MvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_071_cf9417648b_Result" name="feel-time-function_ErrorCase_071_cf9417648b" id="_jE32MvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32MPUUEeesLuP4RHs4vA">
             <text>time("13:20:00+02:00@Europe/Paris")</text>
         </literalExpression>
@@ -893,7 +893,7 @@
         <description>Tests FEEL expression: 'time("7:20")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("7:20")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_072_4c8c3835e4_Result" name="feel-time-function_ErrorCase_072_4c8c3835e4" id="_jE32NvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_072_4c8c3835e4_Result" name="feel-time-function_ErrorCase_072_4c8c3835e4" id="_jE32NvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32NPUUEeesLuP4RHs4vA">
             <text>time("7:20")</text>
         </literalExpression>
@@ -902,7 +902,7 @@
         <description>Tests FEEL expression: 'time("07:2")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("07:2")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_073_a5fc245959_Result" name="feel-time-function_ErrorCase_073_a5fc245959" id="_jE32OvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_073_a5fc245959_Result" name="feel-time-function_ErrorCase_073_a5fc245959" id="_jE32OvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32OPUUEeesLuP4RHs4vA">
             <text>time("07:2")</text>
         </literalExpression>
@@ -911,7 +911,7 @@
         <description>Tests FEEL expression: 'time("11:30:00T")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("11:30:00T")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_074_387d4411ea_Result" name="feel-time-function_ErrorCase_074_387d4411ea" id="_jE32PvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_074_387d4411ea_Result" name="feel-time-function_ErrorCase_074_387d4411ea" id="_jE32PvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32PPUUEeesLuP4RHs4vA">
             <text>time("11:30:00T")</text>
         </literalExpression>
@@ -920,7 +920,7 @@
         <description>Tests FEEL expression: 'time("2012T-12-2511:00:00Z")' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time("2012T-12-2511:00:00Z")'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_075_1606dda03d_Result" name="feel-time-function_ErrorCase_075_1606dda03d" id="_jE32QvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_075_1606dda03d_Result" name="feel-time-function_ErrorCase_075_1606dda03d" id="_jE32QvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32QPUUEeesLuP4RHs4vA">
             <text>time("2012T-12-2511:00:00Z")</text>
         </literalExpression>
@@ -929,7 +929,7 @@
         <description>Tests FEEL expression: 'time(24, 59, 45, null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(24, 59, 45, null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_076_cb117ca612_Result" name="feel-time-function_ErrorCase_076_cb117ca612" id="_jE32RvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_076_cb117ca612_Result" name="feel-time-function_ErrorCase_076_cb117ca612" id="_jE32RvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32RPUUEeesLuP4RHs4vA">
             <text>time(24, 59, 45, null)</text>
         </literalExpression>
@@ -938,7 +938,7 @@
         <description>Tests FEEL expression: 'time(-24, 59, 45, null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(-24, 59, 45, null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_077_a4daad060c_Result" name="feel-time-function_ErrorCase_077_a4daad060c" id="_jE32SvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_077_a4daad060c_Result" name="feel-time-function_ErrorCase_077_a4daad060c" id="_jE32SvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32SPUUEeesLuP4RHs4vA">
             <text>time(-24, 59, 45, null)</text>
         </literalExpression>
@@ -947,7 +947,7 @@
         <description>Tests FEEL expression: 'time(23, 60, 45, null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(23, 60, 45, null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_078_c2fe73418b_Result" name="feel-time-function_ErrorCase_078_c2fe73418b" id="_jE32TvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_078_c2fe73418b_Result" name="feel-time-function_ErrorCase_078_c2fe73418b" id="_jE32TvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32TPUUEeesLuP4RHs4vA">
             <text>time(23, 60, 45, null)</text>
         </literalExpression>
@@ -956,7 +956,7 @@
         <description>Tests FEEL expression: 'time(23, 59, 60, null)' and expects result: 'null (time)'</description>
         <question>Result of FEEL expression 'time(23, 59, 60, null)'?</question>
         <allowedAnswers>null (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_079_d2d226c3cd_Result" name="feel-time-function_ErrorCase_079_d2d226c3cd" id="_jE32UvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_079_d2d226c3cd_Result" name="feel-time-function_ErrorCase_079_d2d226c3cd" id="_jE32UvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32UPUUEeesLuP4RHs4vA">
             <text>time(23, 59, 60, null)</text>
         </literalExpression>
@@ -965,7 +965,7 @@
         <description>Tests FEEL expression: 'time(from:date and time("2012-12-24T23:59:00"))' and expects result: '23:59:00 (time)'</description>
         <question>Result of FEEL expression 'time(from:date and time("2012-12-24T23:59:00"))'?</question>
         <allowedAnswers>23:59:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_080_2bbb8c86af_Result" name="feel-time-function_080_2bbb8c86af" id="_jE32VvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_080_2bbb8c86af_Result" name="feel-time-function_080_2bbb8c86af" id="_jE32VvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32VPUUEeesLuP4RHs4vA">
             <text>time(from:date and time("2012-12-24T23:59:00"))</text>
         </literalExpression>
@@ -974,7 +974,7 @@
         <description>Tests FEEL expression: 'time(from: "12:45:00")' and expects result: '12:45:00 (time)'</description>
         <question>Result of FEEL expression 'time(from: "12:45:00")'?</question>
         <allowedAnswers>12:45:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_081_69f4e0231e_Result" name="feel-time-function_081_69f4e0231e" id="_jE32WvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_081_69f4e0231e_Result" name="feel-time-function_081_69f4e0231e" id="_jE32WvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32WPUUEeesLuP4RHs4vA">
             <text>time(from: "12:45:00")</text>
         </literalExpression>
@@ -983,7 +983,7 @@
         <description>Tests FEEL expression: 'time(hour:11, minute:59, second:0, offset: duration("PT2H1M0S"))' and expects result: '11:59:00+02:01 (time)'</description>
         <question>Result of FEEL expression 'time(hour:11, minute:59, second:0, offset: duration("PT2H1M0S"))'?</question>
         <allowedAnswers>11:59:00+02:01 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_082_36a78e5396_Result" name="feel-time-function_082_36a78e5396" id="_jE32XvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_082_36a78e5396_Result" name="feel-time-function_082_36a78e5396" id="_jE32XvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32XPUUEeesLuP4RHs4vA">
             <text>time(hour:11, minute:59, second:0, offset: duration("PT2H1M0S"))</text>
         </literalExpression>
@@ -992,7 +992,7 @@
         <description>Tests FEEL expression: 'time(hour:11, minute:59, second:0, offset: duration("-PT2H"))' and expects result: '11:59:00-02:00 (time)'</description>
         <question>Result of FEEL expression 'time(hour:11, minute:59, second:0, offset: duration("-PT2H"))'?</question>
         <allowedAnswers>11:59:00-02:00 (time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-time-function_083_6b608254c7_Result" name="feel-time-function_083_6b608254c7" id="_jE32YvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-time-function_083_6b608254c7_Result" name="feel-time-function_083_6b608254c7" id="_jE32YvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jE32YPUUEeesLuP4RHs4vA">
             <text>time(hour:11, minute:59, second:0, offset: duration("-PT2H"))</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1117-feel-date-and-time-function/1117-feel-date-and-time-function.dmn
+++ b/TestCases/compliance-level-3/1117-feel-date-and-time-function/1117-feel-date-and-time-function.dmn
@@ -269,7 +269,7 @@
         <description>Tests FEEL expression: 'date and time(null)' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time(null)'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_001_05fd7d6215_Result" name="feel-date-and-time-function_ErrorCase_001_05fd7d6215" id="_jFxN5fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_001_05fd7d6215_Result" name="feel-date-and-time-function_ErrorCase_001_05fd7d6215" id="_jFxN5fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxN4_UUEeesLuP4RHs4vA">
             <text>date and time(null)</text>
         </literalExpression>
@@ -278,7 +278,7 @@
         <description>Tests FEEL expression: 'date and time(null,null)' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time(null,null)'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_002_8c66ed2d1a_Result" name="feel-date-and-time-function_ErrorCase_002_8c66ed2d1a" id="_jFxN6fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_002_8c66ed2d1a_Result" name="feel-date-and-time-function_ErrorCase_002_8c66ed2d1a" id="_jFxN6fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxN5_UUEeesLuP4RHs4vA">
             <text>date and time(null,null)</text>
         </literalExpression>
@@ -287,7 +287,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-08-10T10:20:00"),null)' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-08-10T10:20:00"),null)'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_003_335cff371a_Result" name="feel-date-and-time-function_ErrorCase_003_335cff371a" id="_jFxN7fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_003_335cff371a_Result" name="feel-date-and-time-function_ErrorCase_003_335cff371a" id="_jFxN7fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxN6_UUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-08-10T10:20:00"),null)</text>
         </literalExpression>
@@ -296,7 +296,7 @@
         <description>Tests FEEL expression: 'date and time(date("2017-08-10"),null)' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date("2017-08-10"),null)'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_004_28ef3e7882_Result" name="feel-date-and-time-function_ErrorCase_004_28ef3e7882" id="_jFxN8fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_004_28ef3e7882_Result" name="feel-date-and-time-function_ErrorCase_004_28ef3e7882" id="_jFxN8fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxN7_UUEeesLuP4RHs4vA">
             <text>date and time(date("2017-08-10"),null)</text>
         </literalExpression>
@@ -305,7 +305,7 @@
         <description>Tests FEEL expression: 'date and time(null,time("23:59:01"))' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time(null,time("23:59:01"))'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_005_15df95b27a_Result" name="feel-date-and-time-function_ErrorCase_005_15df95b27a" id="_jFxN9fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_005_15df95b27a_Result" name="feel-date-and-time-function_ErrorCase_005_15df95b27a" id="_jFxN9fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxN8_UUEeesLuP4RHs4vA">
             <text>date and time(null,time("23:59:01"))</text>
         </literalExpression>
@@ -314,7 +314,7 @@
         <description>Tests FEEL expression: 'date and time()' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time()'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_006_8c794da0bb_Result" name="feel-date-and-time-function_ErrorCase_006_8c794da0bb" id="_jFxN-fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_006_8c794da0bb_Result" name="feel-date-and-time-function_ErrorCase_006_8c794da0bb" id="_jFxN-fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxN9_UUEeesLuP4RHs4vA">
             <text>date and time()</text>
         </literalExpression>
@@ -323,7 +323,7 @@
         <description>Tests FEEL expression: 'date and time("2012-12-24")' and expects result: '2012-12-24T00:00:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2012-12-24")'?</question>
         <allowedAnswers>2012-12-24T00:00:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_007_59863d1b57_Result" name="feel-date-and-time-function_007_59863d1b57" id="_jFxN_fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_007_59863d1b57_Result" name="feel-date-and-time-function_007_59863d1b57" id="_jFxN_fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxN-_UUEeesLuP4RHs4vA">
             <text>date and time("2012-12-24")</text>
         </literalExpression>
@@ -332,7 +332,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T00:00:00")' and expects result: '2017-12-31T00:00:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T00:00:00")'?</question>
         <allowedAnswers>2017-12-31T00:00:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_008_83eb9a93ba_Result" name="feel-date-and-time-function_008_83eb9a93ba" id="_jFxOAfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_008_83eb9a93ba_Result" name="feel-date-and-time-function_008_83eb9a93ba" id="_jFxOAfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxN__UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T00:00:00")</text>
         </literalExpression>
@@ -341,7 +341,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33")' and expects result: '2017-12-31T11:22:33 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33")'?</question>
         <allowedAnswers>2017-12-31T11:22:33 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_009_1982fa549c_Result" name="feel-date-and-time-function_009_1982fa549c" id="_jFxOBfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_009_1982fa549c_Result" name="feel-date-and-time-function_009_1982fa549c" id="_jFxOBfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOA_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33")</text>
         </literalExpression>
@@ -350,7 +350,7 @@
         <description>Tests FEEL expression: 'date and time("-2017-12-31T11:22:33")' and expects result: '-2017-12-31T11:22:33 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("-2017-12-31T11:22:33")'?</question>
         <allowedAnswers>-2017-12-31T11:22:33 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_010_59f5b47012_Result" name="feel-date-and-time-function_010_59f5b47012" id="_jFxOCfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_010_59f5b47012_Result" name="feel-date-and-time-function_010_59f5b47012" id="_jFxOCfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOB_UUEeesLuP4RHs4vA">
             <text>date and time("-2017-12-31T11:22:33")</text>
         </literalExpression>
@@ -359,7 +359,7 @@
         <description>Tests FEEL expression: 'string(date and time("99999-12-31T11:22:33"))' and expects result: '"99999-12-31T11:22:33" (string)'</description>
         <question>Result of FEEL expression 'string(date and time("99999-12-31T11:22:33"))'?</question>
         <allowedAnswers>"99999-12-31T11:22:33" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_011_eec2d5bdcd_Result" name="feel-date-and-time-function_011_eec2d5bdcd" id="_jFxODfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_011_eec2d5bdcd_Result" name="feel-date-and-time-function_011_eec2d5bdcd" id="_jFxODfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOC_UUEeesLuP4RHs4vA">
             <text>string(date and time("99999-12-31T11:22:33"))</text>
         </literalExpression>
@@ -368,7 +368,7 @@
         <description>Tests FEEL expression: 'string(date and time("-99999-12-31T11:22:33"))' and expects result: '"-99999-12-31T11:22:33" (string)'</description>
         <question>Result of FEEL expression 'string(date and time("-99999-12-31T11:22:33"))'?</question>
         <allowedAnswers>"-99999-12-31T11:22:33" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_012_225a105eef_Result" name="feel-date-and-time-function_012_225a105eef" id="_jFxOEfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_012_225a105eef_Result" name="feel-date-and-time-function_012_225a105eef" id="_jFxOEfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOD_UUEeesLuP4RHs4vA">
             <text>string(date and time("-99999-12-31T11:22:33"))</text>
         </literalExpression>
@@ -377,7 +377,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33.345")' and expects result: '2017-12-31T11:22:33.345 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33.345")'?</question>
         <allowedAnswers>2017-12-31T11:22:33.345 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_013_c4fd0a0e8d_Result" name="feel-date-and-time-function_013_c4fd0a0e8d" id="_jFxOFfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_013_c4fd0a0e8d_Result" name="feel-date-and-time-function_013_c4fd0a0e8d" id="_jFxOFfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOE_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33.345")</text>
         </literalExpression>
@@ -386,7 +386,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33.123456789")' and expects result: '2017-12-31T11:22:33.123456789 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33.123456789")'?</question>
         <allowedAnswers>2017-12-31T11:22:33.123456789 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_014_ded0e5fe2f_Result" name="feel-date-and-time-function_014_ded0e5fe2f" id="_jFxOGfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_014_ded0e5fe2f_Result" name="feel-date-and-time-function_014_ded0e5fe2f" id="_jFxOGfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOF_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33.123456789")</text>
         </literalExpression>
@@ -395,7 +395,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33Z")' and expects result: '2017-12-31T11:22:33Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33Z")'?</question>
         <allowedAnswers>2017-12-31T11:22:33Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_015_9e27148afd_Result" name="feel-date-and-time-function_015_9e27148afd" id="_jFxOHfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_015_9e27148afd_Result" name="feel-date-and-time-function_015_9e27148afd" id="_jFxOHfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOG_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33Z")</text>
         </literalExpression>
@@ -404,7 +404,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33.567Z")' and expects result: '2017-12-31T11:22:33.567Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33.567Z")'?</question>
         <allowedAnswers>2017-12-31T11:22:33.567Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_016_c08e4d417a_Result" name="feel-date-and-time-function_016_c08e4d417a" id="_jFxOIfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_016_c08e4d417a_Result" name="feel-date-and-time-function_016_c08e4d417a" id="_jFxOIfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOH_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33.567Z")</text>
         </literalExpression>
@@ -413,7 +413,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33+01:00")' and expects result: '2017-12-31T11:22:33+01:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33+01:00")'?</question>
         <allowedAnswers>2017-12-31T11:22:33+01:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_017_47816add0e_Result" name="feel-date-and-time-function_017_47816add0e" id="_jFxOJfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_017_47816add0e_Result" name="feel-date-and-time-function_017_47816add0e" id="_jFxOJfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOI_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33+01:00")</text>
         </literalExpression>
@@ -422,7 +422,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33-02:00")' and expects result: '2017-12-31T11:22:33-02:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33-02:00")'?</question>
         <allowedAnswers>2017-12-31T11:22:33-02:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_018_0614e473e7_Result" name="feel-date-and-time-function_018_0614e473e7" id="_jFxOKfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_018_0614e473e7_Result" name="feel-date-and-time-function_018_0614e473e7" id="_jFxOKfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOJ_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33-02:00")</text>
         </literalExpression>
@@ -431,7 +431,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33+01:35")' and expects result: '2017-12-31T11:22:33+01:35 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33+01:35")'?</question>
         <allowedAnswers>2017-12-31T11:22:33+01:35 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_019_c312e3dfe3_Result" name="feel-date-and-time-function_019_c312e3dfe3" id="_jFxOLfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_019_c312e3dfe3_Result" name="feel-date-and-time-function_019_c312e3dfe3" id="_jFxOLfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOK_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33+01:35")</text>
         </literalExpression>
@@ -440,7 +440,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33-01:35")' and expects result: '2017-12-31T11:22:33-01:35 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33-01:35")'?</question>
         <allowedAnswers>2017-12-31T11:22:33-01:35 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_020_29e0585b6f_Result" name="feel-date-and-time-function_020_29e0585b6f" id="_jFxOMfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_020_29e0585b6f_Result" name="feel-date-and-time-function_020_29e0585b6f" id="_jFxOMfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOL_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33-01:35")</text>
         </literalExpression>
@@ -449,7 +449,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T11:22:33.456+01:35")' and expects result: '2017-12-31T11:22:33.456+01:35 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T11:22:33.456+01:35")'?</question>
         <allowedAnswers>2017-12-31T11:22:33.456+01:35 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_021_99f0215b60_Result" name="feel-date-and-time-function_021_99f0215b60" id="_jFxONfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_021_99f0215b60_Result" name="feel-date-and-time-function_021_99f0215b60" id="_jFxONfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOM_UUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T11:22:33.456+01:35")</text>
         </literalExpression>
@@ -458,7 +458,7 @@
         <description>Tests FEEL expression: 'date and time("-2017-12-31T11:22:33.456+01:35")' and expects result: '-2017-12-31T11:22:33.456+01:35 (date and time)'</description>
         <question>Result of FEEL expression 'date and time("-2017-12-31T11:22:33.456+01:35")'?</question>
         <allowedAnswers>-2017-12-31T11:22:33.456+01:35 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_022_b8b20f0328_Result" name="feel-date-and-time-function_022_b8b20f0328" id="_jFxOOfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_022_b8b20f0328_Result" name="feel-date-and-time-function_022_b8b20f0328" id="_jFxOOfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxON_UUEeesLuP4RHs4vA">
             <text>date and time("-2017-12-31T11:22:33.456+01:35")</text>
         </literalExpression>
@@ -467,7 +467,7 @@
         <description>Tests FEEL expression: 'string(date and time("2011-12-31T10:15:30@Europe/Paris"))' and expects result: '"2011-12-31T10:15:30@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time("2011-12-31T10:15:30@Europe/Paris"))'?</question>
         <allowedAnswers>"2011-12-31T10:15:30@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_023_2e41497673_Result" name="feel-date-and-time-function_023_2e41497673" id="_jFxOPfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_023_2e41497673_Result" name="feel-date-and-time-function_023_2e41497673" id="_jFxOPfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOO_UUEeesLuP4RHs4vA">
             <text>string(date and time("2011-12-31T10:15:30@Europe/Paris"))</text>
         </literalExpression>
@@ -476,7 +476,7 @@
         <description>Tests FEEL expression: 'string(date and time("2011-12-31T10:15:30@Etc/UTC"))' and expects result: '"2011-12-31T10:15:30@Etc/UTC" (string)'</description>
         <question>Result of FEEL expression 'string(date and time("2011-12-31T10:15:30@Etc/UTC"))'?</question>
         <allowedAnswers>"2011-12-31T10:15:30@Etc/UTC" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_024_b4d1fb8735_Result" name="feel-date-and-time-function_024_b4d1fb8735" id="_jFxOQfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_024_b4d1fb8735_Result" name="feel-date-and-time-function_024_b4d1fb8735" id="_jFxOQfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOP_UUEeesLuP4RHs4vA">
             <text>string(date and time("2011-12-31T10:15:30@Etc/UTC"))</text>
         </literalExpression>
@@ -485,7 +485,7 @@
         <description>Tests FEEL expression: 'string(date and time("2011-12-31T10:15:30.987@Europe/Paris"))' and expects result: '"2011-12-31T10:15:30.987@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time("2011-12-31T10:15:30.987@Europe/Paris"))'?</question>
         <allowedAnswers>"2011-12-31T10:15:30.987@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_025_0cb7f83ec6_Result" name="feel-date-and-time-function_025_0cb7f83ec6" id="_jFxORfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_025_0cb7f83ec6_Result" name="feel-date-and-time-function_025_0cb7f83ec6" id="_jFxORfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOQ_UUEeesLuP4RHs4vA">
             <text>string(date and time("2011-12-31T10:15:30.987@Europe/Paris"))</text>
         </literalExpression>
@@ -494,7 +494,7 @@
         <description>Tests FEEL expression: 'string(date and time("2011-12-31T10:15:30.123456789@Europe/Paris"))' and expects result: '"2011-12-31T10:15:30.123456789@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time("2011-12-31T10:15:30.123456789@Europe/Paris"))'?</question>
         <allowedAnswers>"2011-12-31T10:15:30.123456789@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_026_5ba081cd5f_Result" name="feel-date-and-time-function_026_5ba081cd5f" id="_jFxOSfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_026_5ba081cd5f_Result" name="feel-date-and-time-function_026_5ba081cd5f" id="_jFxOSfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOR_UUEeesLuP4RHs4vA">
             <text>string(date and time("2011-12-31T10:15:30.123456789@Europe/Paris"))</text>
         </literalExpression>
@@ -503,7 +503,7 @@
         <description>Tests FEEL expression: 'string(date and time("999999999-12-31T23:59:59.999999999@Europe/Paris"))' and expects result: '"999999999-12-31T23:59:59.999999999@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time("999999999-12-31T23:59:59.999999999@Europe/Paris"))'?</question>
         <allowedAnswers>"999999999-12-31T23:59:59.999999999@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_027_ae365197dd_Result" name="feel-date-and-time-function_027_ae365197dd" id="_jFxOTfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_027_ae365197dd_Result" name="feel-date-and-time-function_027_ae365197dd" id="_jFxOTfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOS_UUEeesLuP4RHs4vA">
             <text>string(date and time("999999999-12-31T23:59:59.999999999@Europe/Paris"))</text>
         </literalExpression>
@@ -512,7 +512,7 @@
         <description>Tests FEEL expression: 'string(date and time("-999999999-12-31T23:59:59.999999999+02:00"))' and expects result: '"-999999999-12-31T23:59:59.999999999+02:00" (string)'</description>
         <question>Result of FEEL expression 'string(date and time("-999999999-12-31T23:59:59.999999999+02:00"))'?</question>
         <allowedAnswers>"-999999999-12-31T23:59:59.999999999+02:00" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_028_1c3d56275f_Result" name="feel-date-and-time-function_028_1c3d56275f" id="_jFxOUfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_028_1c3d56275f_Result" name="feel-date-and-time-function_028_1c3d56275f" id="_jFxOUfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOT_UUEeesLuP4RHs4vA">
             <text>string(date and time("-999999999-12-31T23:59:59.999999999+02:00"))</text>
         </literalExpression>
@@ -521,7 +521,7 @@
         <description>Tests FEEL expression: 'date and time(date("2017-01-01"),time("23:59:01"))' and expects result: '2017-01-01T23:59:01 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date("2017-01-01"),time("23:59:01"))'?</question>
         <allowedAnswers>2017-01-01T23:59:01 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_029_e3a5e786a0_Result" name="feel-date-and-time-function_029_e3a5e786a0" id="_jFxOVfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_029_e3a5e786a0_Result" name="feel-date-and-time-function_029_e3a5e786a0" id="_jFxOVfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOU_UUEeesLuP4RHs4vA">
             <text>date and time(date("2017-01-01"),time("23:59:01"))</text>
         </literalExpression>
@@ -530,7 +530,7 @@
         <description>Tests FEEL expression: 'date and time(date("2017-01-01"),time("23:59:01Z"))' and expects result: '2017-01-01T23:59:01Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date("2017-01-01"),time("23:59:01Z"))'?</question>
         <allowedAnswers>2017-01-01T23:59:01Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_030_2f97bff606_Result" name="feel-date-and-time-function_030_2f97bff606" id="_jFxOWfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_030_2f97bff606_Result" name="feel-date-and-time-function_030_2f97bff606" id="_jFxOWfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOV_UUEeesLuP4RHs4vA">
             <text>date and time(date("2017-01-01"),time("23:59:01Z"))</text>
         </literalExpression>
@@ -539,7 +539,7 @@
         <description>Tests FEEL expression: 'date and time(date("2017-01-01"),time("23:59:01+02:00"))' and expects result: '2017-01-01T23:59:01+02:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date("2017-01-01"),time("23:59:01+02:00"))'?</question>
         <allowedAnswers>2017-01-01T23:59:01+02:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_031_61e70c285f_Result" name="feel-date-and-time-function_031_61e70c285f" id="_jFxOXfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_031_61e70c285f_Result" name="feel-date-and-time-function_031_61e70c285f" id="_jFxOXfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOW_UUEeesLuP4RHs4vA">
             <text>date and time(date("2017-01-01"),time("23:59:01+02:00"))</text>
         </literalExpression>
@@ -548,7 +548,7 @@
         <description>Tests FEEL expression: 'string(date and time(date("2017-01-01"),time("23:59:01@Europe/Paris")))' and expects result: '"2017-01-01T23:59:01@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time(date("2017-01-01"),time("23:59:01@Europe/Paris")))'?</question>
         <allowedAnswers>"2017-01-01T23:59:01@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_032_1e95e8726e_Result" name="feel-date-and-time-function_032_1e95e8726e" id="_jFxOYfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_032_1e95e8726e_Result" name="feel-date-and-time-function_032_1e95e8726e" id="_jFxOYfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOX_UUEeesLuP4RHs4vA">
             <text>string(date and time(date("2017-01-01"),time("23:59:01@Europe/Paris")))</text>
         </literalExpression>
@@ -557,7 +557,7 @@
         <description>Tests FEEL expression: 'string(date and time(date("2017-01-01"),time("23:59:01.123456789@Europe/Paris")))' and expects result: '"2017-01-01T23:59:01.123456789@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time(date("2017-01-01"),time("23:59:01.123456789@Europe/Paris")))'?</question>
         <allowedAnswers>"2017-01-01T23:59:01.123456789@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_033_2fac4d6807_Result" name="feel-date-and-time-function_033_2fac4d6807" id="_jFxOZfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_033_2fac4d6807_Result" name="feel-date-and-time-function_033_2fac4d6807" id="_jFxOZfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOY_UUEeesLuP4RHs4vA">
             <text>string(date and time(date("2017-01-01"),time("23:59:01.123456789@Europe/Paris")))</text>
         </literalExpression>
@@ -566,7 +566,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-08-10T10:20:00"),time("23:59:01"))' and expects result: '2017-08-10T23:59:01 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-08-10T10:20:00"),time("23:59:01"))'?</question>
         <allowedAnswers>2017-08-10T23:59:01 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_034_75580be3aa_Result" name="feel-date-and-time-function_034_75580be3aa" id="_jFxOafUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_034_75580be3aa_Result" name="feel-date-and-time-function_034_75580be3aa" id="_jFxOafUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOZ_UUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-08-10T10:20:00"),time("23:59:01"))</text>
         </literalExpression>
@@ -575,7 +575,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-08-10T10:20:00"),time("23:59:01.987654321"))' and expects result: '2017-08-10T23:59:01.987654321 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-08-10T10:20:00"),time("23:59:01.987654321"))'?</question>
         <allowedAnswers>2017-08-10T23:59:01.987654321 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_035_831b1ad0c5_Result" name="feel-date-and-time-function_035_831b1ad0c5" id="_jFxObfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_035_831b1ad0c5_Result" name="feel-date-and-time-function_035_831b1ad0c5" id="_jFxObfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOa_UUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-08-10T10:20:00"),time("23:59:01.987654321"))</text>
         </literalExpression>
@@ -584,7 +584,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00"),time("09:15:30+02:00"))' and expects result: '2017-09-05T09:15:30+02:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00"),time("09:15:30+02:00"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30+02:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_036_189e1c3095_Result" name="feel-date-and-time-function_036_189e1c3095" id="_jFxOcfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_036_189e1c3095_Result" name="feel-date-and-time-function_036_189e1c3095" id="_jFxOcfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOb_UUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00"),time("09:15:30+02:00"))</text>
         </literalExpression>
@@ -593,7 +593,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00"),time("09:15:30Z"))' and expects result: '2017-09-05T09:15:30Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00"),time("09:15:30Z"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_037_c7aec7ecf7_Result" name="feel-date-and-time-function_037_c7aec7ecf7" id="_jFxOdfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_037_c7aec7ecf7_Result" name="feel-date-and-time-function_037_c7aec7ecf7" id="_jFxOdfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOc_UUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00"),time("09:15:30Z"))</text>
         </literalExpression>
@@ -602,7 +602,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.987654321+02:00"))' and expects result: '2017-09-05T09:15:30.987654321+02:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.987654321+02:00"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30.987654321+02:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_038_1493e6d873_Result" name="feel-date-and-time-function_038_1493e6d873" id="_jF6-4PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_038_1493e6d873_Result" name="feel-date-and-time-function_038_1493e6d873" id="_jF6-4PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jFxOd_UUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.987654321+02:00"))</text>
         </literalExpression>
@@ -611,7 +611,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.123456Z"))' and expects result: '2017-09-05T09:15:30.123456Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.123456Z"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30.123456Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_039_593292b25c_Result" name="feel-date-and-time-function_039_593292b25c" id="_jF6-5PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_039_593292b25c_Result" name="feel-date-and-time-function_039_593292b25c" id="_jF6-5PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6-4vUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.123456Z"))</text>
         </literalExpression>
@@ -620,7 +620,7 @@
         <description>Tests FEEL expression: 'string(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.987654321@Europe/Paris")))' and expects result: '"2017-09-05T09:15:30.987654321@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.987654321@Europe/Paris")))'?</question>
         <allowedAnswers>"2017-09-05T09:15:30.987654321@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_040_d9116e1daa_Result" name="feel-date-and-time-function_040_d9116e1daa" id="_jF6-6PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_040_d9116e1daa_Result" name="feel-date-and-time-function_040_d9116e1daa" id="_jF6-6PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6-5vUUEeesLuP4RHs4vA">
             <text>string(date and time(date and time("2017-09-05T10:20:00"),time("09:15:30.987654321@Europe/Paris")))</text>
         </literalExpression>
@@ -629,7 +629,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-08-10T10:20:00+02:00"),time("23:59:01"))' and expects result: '2017-08-10T23:59:01 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-08-10T10:20:00+02:00"),time("23:59:01"))'?</question>
         <allowedAnswers>2017-08-10T23:59:01 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_041_c6decfe6a3_Result" name="feel-date-and-time-function_041_c6decfe6a3" id="_jF6-7PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_041_c6decfe6a3_Result" name="feel-date-and-time-function_041_c6decfe6a3" id="_jF6-7PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6-6vUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-08-10T10:20:00+02:00"),time("23:59:01"))</text>
         </literalExpression>
@@ -638,7 +638,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-08-10T10:20:00+02:00"),time("23:59:01.987654321"))' and expects result: '2017-08-10T23:59:01.987654321 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-08-10T10:20:00+02:00"),time("23:59:01.987654321"))'?</question>
         <allowedAnswers>2017-08-10T23:59:01.987654321 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_042_0cbcc3d1dc_Result" name="feel-date-and-time-function_042_0cbcc3d1dc" id="_jF6-8PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_042_0cbcc3d1dc_Result" name="feel-date-and-time-function_042_0cbcc3d1dc" id="_jF6-8PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6-7vUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-08-10T10:20:00+02:00"),time("23:59:01.987654321"))</text>
         </literalExpression>
@@ -647,7 +647,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30+02:00"))' and expects result: '2017-09-05T09:15:30+02:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30+02:00"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30+02:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_043_2e4177d00c_Result" name="feel-date-and-time-function_043_2e4177d00c" id="_jF6-9PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_043_2e4177d00c_Result" name="feel-date-and-time-function_043_2e4177d00c" id="_jF6-9PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6-8vUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30+02:00"))</text>
         </literalExpression>
@@ -656,7 +656,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30Z"))' and expects result: '2017-09-05T09:15:30Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30Z"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_044_9404547f9d_Result" name="feel-date-and-time-function_044_9404547f9d" id="_jF6--PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_044_9404547f9d_Result" name="feel-date-and-time-function_044_9404547f9d" id="_jF6--PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6-9vUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30Z"))</text>
         </literalExpression>
@@ -665,7 +665,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00+02:00"),time("09:15:30.987654321+02:00"))' and expects result: '2017-09-05T09:15:30.987654321+02:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00+02:00"),time("09:15:30.987654321+02:00"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30.987654321+02:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_045_5d93a541eb_Result" name="feel-date-and-time-function_045_5d93a541eb" id="_jF6-_PUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_045_5d93a541eb_Result" name="feel-date-and-time-function_045_5d93a541eb" id="_jF6-_PUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6--vUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00+02:00"),time("09:15:30.987654321+02:00"))</text>
         </literalExpression>
@@ -674,7 +674,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00+02:00"),time("09:15:30.123456Z"))' and expects result: '2017-09-05T09:15:30.123456Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00+02:00"),time("09:15:30.123456Z"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30.123456Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_046_89c1cd8daa_Result" name="feel-date-and-time-function_046_89c1cd8daa" id="_jF6_APUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_046_89c1cd8daa_Result" name="feel-date-and-time-function_046_89c1cd8daa" id="_jF6_APUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6-_vUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00+02:00"),time("09:15:30.123456Z"))</text>
         </literalExpression>
@@ -683,7 +683,7 @@
         <description>Tests FEEL expression: 'string(date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30.987654321@Europe/Paris")))' and expects result: '"2017-09-05T09:15:30.987654321@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30.987654321@Europe/Paris")))'?</question>
         <allowedAnswers>"2017-09-05T09:15:30.987654321@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_047_60ea7838ce_Result" name="feel-date-and-time-function_047_60ea7838ce" id="_jF6_BPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_047_60ea7838ce_Result" name="feel-date-and-time-function_047_60ea7838ce" id="_jF6_BPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_AvUUEeesLuP4RHs4vA">
             <text>string(date and time(date and time("2017-09-05T10:20:00-01:00"),time("09:15:30.987654321@Europe/Paris")))</text>
         </literalExpression>
@@ -692,7 +692,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-08-10T10:20:00@Europe/Paris"),time("23:59:01"))' and expects result: '2017-08-10T23:59:01 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-08-10T10:20:00@Europe/Paris"),time("23:59:01"))'?</question>
         <allowedAnswers>2017-08-10T23:59:01 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_048_e387922273_Result" name="feel-date-and-time-function_048_e387922273" id="_jF6_CPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_048_e387922273_Result" name="feel-date-and-time-function_048_e387922273" id="_jF6_CPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_BvUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-08-10T10:20:00@Europe/Paris"),time("23:59:01"))</text>
         </literalExpression>
@@ -701,7 +701,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-08-10T10:20:00@Europe/Paris"),time("23:59:01.987654321"))' and expects result: '2017-08-10T23:59:01.987654321 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-08-10T10:20:00@Europe/Paris"),time("23:59:01.987654321"))'?</question>
         <allowedAnswers>2017-08-10T23:59:01.987654321 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_049_eb9cd1f777_Result" name="feel-date-and-time-function_049_eb9cd1f777" id="_jF6_DPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_049_eb9cd1f777_Result" name="feel-date-and-time-function_049_eb9cd1f777" id="_jF6_DPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_CvUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-08-10T10:20:00@Europe/Paris"),time("23:59:01.987654321"))</text>
         </literalExpression>
@@ -710,7 +710,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30+02:00"))' and expects result: '2017-09-05T09:15:30+02:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30+02:00"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30+02:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_050_2d960354af_Result" name="feel-date-and-time-function_050_2d960354af" id="_jF6_EPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_050_2d960354af_Result" name="feel-date-and-time-function_050_2d960354af" id="_jF6_EPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_DvUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30+02:00"))</text>
         </literalExpression>
@@ -719,7 +719,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30Z"))' and expects result: '2017-09-05T09:15:30Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30Z"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_051_46bdaa00b0_Result" name="feel-date-and-time-function_051_46bdaa00b0" id="_jF6_FPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_051_46bdaa00b0_Result" name="feel-date-and-time-function_051_46bdaa00b0" id="_jF6_FPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_EvUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30Z"))</text>
         </literalExpression>
@@ -728,7 +728,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.987654321+02:00"))' and expects result: '2017-09-05T09:15:30.987654321+02:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.987654321+02:00"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30.987654321+02:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_052_911dbd0a24_Result" name="feel-date-and-time-function_052_911dbd0a24" id="_jF6_GPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_052_911dbd0a24_Result" name="feel-date-and-time-function_052_911dbd0a24" id="_jF6_GPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_FvUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.987654321+02:00"))</text>
         </literalExpression>
@@ -737,7 +737,7 @@
         <description>Tests FEEL expression: 'date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.123456Z"))' and expects result: '2017-09-05T09:15:30.123456Z (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.123456Z"))'?</question>
         <allowedAnswers>2017-09-05T09:15:30.123456Z (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_053_283c083df9_Result" name="feel-date-and-time-function_053_283c083df9" id="_jF6_HPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_053_283c083df9_Result" name="feel-date-and-time-function_053_283c083df9" id="_jF6_HPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_GvUUEeesLuP4RHs4vA">
             <text>date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.123456Z"))</text>
         </literalExpression>
@@ -746,7 +746,7 @@
         <description>Tests FEEL expression: 'string(date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.987654321@Europe/Paris")))' and expects result: '"2017-09-05T09:15:30.987654321@Europe/Paris" (string)'</description>
         <question>Result of FEEL expression 'string(date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.987654321@Europe/Paris")))'?</question>
         <allowedAnswers>"2017-09-05T09:15:30.987654321@Europe/Paris" (string)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_054_2561a406fc_Result" name="feel-date-and-time-function_054_2561a406fc" id="_jF6_IPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_054_2561a406fc_Result" name="feel-date-and-time-function_054_2561a406fc" id="_jF6_IPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_HvUUEeesLuP4RHs4vA">
             <text>string(date and time(date and time("2017-09-05T10:20:00@Europe/Paris"),time("09:15:30.987654321@Europe/Paris")))</text>
         </literalExpression>
@@ -755,7 +755,7 @@
         <description>Tests FEEL expression: 'date and time(2017)' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time(2017)'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_055_6ce9202e17_Result" name="feel-date-and-time-function_ErrorCase_055_6ce9202e17" id="_jF6_JPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_055_6ce9202e17_Result" name="feel-date-and-time-function_ErrorCase_055_6ce9202e17" id="_jF6_JPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_IvUUEeesLuP4RHs4vA">
             <text>date and time(2017)</text>
         </literalExpression>
@@ -764,7 +764,7 @@
         <description>Tests FEEL expression: 'date and time([])' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time([])'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_056_e66397568e_Result" name="feel-date-and-time-function_ErrorCase_056_e66397568e" id="_jF6_KPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_056_e66397568e_Result" name="feel-date-and-time-function_ErrorCase_056_e66397568e" id="_jF6_KPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_JvUUEeesLuP4RHs4vA">
             <text>date and time([])</text>
         </literalExpression>
@@ -773,7 +773,7 @@
         <description>Tests FEEL expression: 'date and time("")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_057_0452ca8719_Result" name="feel-date-and-time-function_ErrorCase_057_0452ca8719" id="_jF6_LPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_057_0452ca8719_Result" name="feel-date-and-time-function_ErrorCase_057_0452ca8719" id="_jF6_LPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_KvUUEeesLuP4RHs4vA">
             <text>date and time("")</text>
         </literalExpression>
@@ -782,7 +782,7 @@
         <description>Tests FEEL expression: 'date and time("11:00:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("11:00:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_058_588040ceaa_Result" name="feel-date-and-time-function_ErrorCase_058_588040ceaa" id="_jF6_MPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_058_588040ceaa_Result" name="feel-date-and-time-function_ErrorCase_058_588040ceaa" id="_jF6_MPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_LvUUEeesLuP4RHs4vA">
             <text>date and time("11:00:00")</text>
         </literalExpression>
@@ -791,7 +791,7 @@
         <description>Tests FEEL expression: 'date and time("2011-12-0310:15:30")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2011-12-0310:15:30")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_059_dfc62a3ebc_Result" name="feel-date-and-time-function_ErrorCase_059_dfc62a3ebc" id="_jF6_NPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_059_dfc62a3ebc_Result" name="feel-date-and-time-function_ErrorCase_059_dfc62a3ebc" id="_jF6_NPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_MvUUEeesLuP4RHs4vA">
             <text>date and time("2011-12-0310:15:30")</text>
         </literalExpression>
@@ -800,7 +800,7 @@
         <description>Tests FEEL expression: 'date and time("2011-12-03T10:15:30+01:00@Europe/Paris")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2011-12-03T10:15:30+01:00@Europe/Paris")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_060_890c302575_Result" name="feel-date-and-time-function_ErrorCase_060_890c302575" id="_jF6_OPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_060_890c302575_Result" name="feel-date-and-time-function_ErrorCase_060_890c302575" id="_jF6_OPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_NvUUEeesLuP4RHs4vA">
             <text>date and time("2011-12-03T10:15:30+01:00@Europe/Paris")</text>
         </literalExpression>
@@ -809,7 +809,7 @@
         <description>Tests FEEL expression: 'date and time("9999999999-12-27T11:22:33")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("9999999999-12-27T11:22:33")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_061_38ea1fc94d_Result" name="feel-date-and-time-function_ErrorCase_061_38ea1fc94d" id="_jF6_PPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_061_38ea1fc94d_Result" name="feel-date-and-time-function_ErrorCase_061_38ea1fc94d" id="_jF6_PPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_OvUUEeesLuP4RHs4vA">
             <text>date and time("9999999999-12-27T11:22:33")</text>
         </literalExpression>
@@ -818,7 +818,7 @@
         <description>Tests FEEL expression: 'date and time("2017-13-10T11:22:33")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-13-10T11:22:33")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_062_528aa370a3_Result" name="feel-date-and-time-function_ErrorCase_062_528aa370a3" id="_jF6_QPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_062_528aa370a3_Result" name="feel-date-and-time-function_ErrorCase_062_528aa370a3" id="_jF6_QPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_PvUUEeesLuP4RHs4vA">
             <text>date and time("2017-13-10T11:22:33")</text>
         </literalExpression>
@@ -827,7 +827,7 @@
         <description>Tests FEEL expression: 'date and time("2017-00-10T11:22:33")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-00-10T11:22:33")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_063_2c94303011_Result" name="feel-date-and-time-function_ErrorCase_063_2c94303011" id="_jF6_RPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_063_2c94303011_Result" name="feel-date-and-time-function_ErrorCase_063_2c94303011" id="_jF6_RPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_QvUUEeesLuP4RHs4vA">
             <text>date and time("2017-00-10T11:22:33")</text>
         </literalExpression>
@@ -836,7 +836,7 @@
         <description>Tests FEEL expression: 'date and time("2017-13-32T11:22:33")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-13-32T11:22:33")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_064_926a372666_Result" name="feel-date-and-time-function_ErrorCase_064_926a372666" id="_jF6_SPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_064_926a372666_Result" name="feel-date-and-time-function_ErrorCase_064_926a372666" id="_jF6_SPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_RvUUEeesLuP4RHs4vA">
             <text>date and time("2017-13-32T11:22:33")</text>
         </literalExpression>
@@ -845,7 +845,7 @@
         <description>Tests FEEL expression: 'date and time("2017-13-0T11:22:33")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-13-0T11:22:33")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_065_a13de18ee4_Result" name="feel-date-and-time-function_ErrorCase_065_a13de18ee4" id="_jF6_TPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_065_a13de18ee4_Result" name="feel-date-and-time-function_ErrorCase_065_a13de18ee4" id="_jF6_TPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_SvUUEeesLuP4RHs4vA">
             <text>date and time("2017-13-0T11:22:33")</text>
         </literalExpression>
@@ -854,7 +854,7 @@
         <description>Tests FEEL expression: 'date and time("998-12-31T11:22:33")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("998-12-31T11:22:33")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_066_e9f3d6d2c2_Result" name="feel-date-and-time-function_ErrorCase_066_e9f3d6d2c2" id="_jF6_UPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_066_e9f3d6d2c2_Result" name="feel-date-and-time-function_ErrorCase_066_e9f3d6d2c2" id="_jF6_UPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_TvUUEeesLuP4RHs4vA">
             <text>date and time("998-12-31T11:22:33")</text>
         </literalExpression>
@@ -863,7 +863,7 @@
         <description>Tests FEEL expression: 'date and time("01211-12-31T11:22:33")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("01211-12-31T11:22:33")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_067_35fef99b53_Result" name="feel-date-and-time-function_ErrorCase_067_35fef99b53" id="_jF6_VPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_067_35fef99b53_Result" name="feel-date-and-time-function_ErrorCase_067_35fef99b53" id="_jF6_VPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_UvUUEeesLuP4RHs4vA">
             <text>date and time("01211-12-31T11:22:33")</text>
         </literalExpression>
@@ -872,7 +872,7 @@
         <description>Tests FEEL expression: 'date and time("+99999-12-01T11:22:33")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("+99999-12-01T11:22:33")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_068_abaa1c2774_Result" name="feel-date-and-time-function_ErrorCase_068_abaa1c2774" id="_jF6_WPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_068_abaa1c2774_Result" name="feel-date-and-time-function_ErrorCase_068_abaa1c2774" id="_jF6_WPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_VvUUEeesLuP4RHs4vA">
             <text>date and time("+99999-12-01T11:22:33")</text>
         </literalExpression>
@@ -881,7 +881,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T24:00:01")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T24:00:01")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_069_ca84e9c806_Result" name="feel-date-and-time-function_ErrorCase_069_ca84e9c806" id="_jF6_XPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_069_ca84e9c806_Result" name="feel-date-and-time-function_ErrorCase_069_ca84e9c806" id="_jF6_XPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_WvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T24:00:01")</text>
         </literalExpression>
@@ -890,7 +890,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T24:01:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T24:01:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_070_889c75a0cf_Result" name="feel-date-and-time-function_ErrorCase_070_889c75a0cf" id="_jF6_YPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_070_889c75a0cf_Result" name="feel-date-and-time-function_ErrorCase_070_889c75a0cf" id="_jF6_YPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_XvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T24:01:00")</text>
         </literalExpression>
@@ -899,7 +899,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T25:00:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T25:00:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_071_e90b813dfe_Result" name="feel-date-and-time-function_ErrorCase_071_e90b813dfe" id="_jF6_ZPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_071_e90b813dfe_Result" name="feel-date-and-time-function_ErrorCase_071_e90b813dfe" id="_jF6_ZPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_YvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T25:00:00")</text>
         </literalExpression>
@@ -908,7 +908,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T00:60:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T00:60:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_072_9f3e9b9c21_Result" name="feel-date-and-time-function_ErrorCase_072_9f3e9b9c21" id="_jF6_aPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_072_9f3e9b9c21_Result" name="feel-date-and-time-function_ErrorCase_072_9f3e9b9c21" id="_jF6_aPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_ZvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T00:60:00")</text>
         </literalExpression>
@@ -917,7 +917,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T00:00:61")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T00:00:61")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_073_717548bec6_Result" name="feel-date-and-time-function_ErrorCase_073_717548bec6" id="_jF6_bPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_073_717548bec6_Result" name="feel-date-and-time-function_ErrorCase_073_717548bec6" id="_jF6_bPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_avUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T00:00:61")</text>
         </literalExpression>
@@ -926,7 +926,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T7:00:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T7:00:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_074_a15e7f8d29_Result" name="feel-date-and-time-function_ErrorCase_074_a15e7f8d29" id="_jF6_cPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_074_a15e7f8d29_Result" name="feel-date-and-time-function_ErrorCase_074_a15e7f8d29" id="_jF6_cPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_bvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T7:00:00")</text>
         </literalExpression>
@@ -935,7 +935,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T07:1:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T07:1:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_075_4c3b8e7097_Result" name="feel-date-and-time-function_ErrorCase_075_4c3b8e7097" id="_jF6_dPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_075_4c3b8e7097_Result" name="feel-date-and-time-function_ErrorCase_075_4c3b8e7097" id="_jF6_dPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_cvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T07:1:00")</text>
         </literalExpression>
@@ -944,7 +944,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T07:01:2")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T07:01:2")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_076_4d31fed18e_Result" name="feel-date-and-time-function_ErrorCase_076_4d31fed18e" id="_jF6_ePUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_076_4d31fed18e_Result" name="feel-date-and-time-function_ErrorCase_076_4d31fed18e" id="_jF6_ePUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_dvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T07:01:2")</text>
         </literalExpression>
@@ -953,7 +953,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T13:20:00@xyz/abc")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T13:20:00@xyz/abc")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_077_f83b3ac8bb_Result" name="feel-date-and-time-function_ErrorCase_077_f83b3ac8bb" id="_jF6_fPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_077_f83b3ac8bb_Result" name="feel-date-and-time-function_ErrorCase_077_f83b3ac8bb" id="_jF6_fPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_evUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T13:20:00@xyz/abc")</text>
         </literalExpression>
@@ -962,7 +962,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T13:20:00+19:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T13:20:00+19:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_078_e113dabcdd_Result" name="feel-date-and-time-function_ErrorCase_078_e113dabcdd" id="_jF6_gPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_078_e113dabcdd_Result" name="feel-date-and-time-function_ErrorCase_078_e113dabcdd" id="_jF6_gPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_fvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T13:20:00+19:00")</text>
         </literalExpression>
@@ -971,7 +971,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T13:20:00-19:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T13:20:00-19:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_079_2e6f80eb94_Result" name="feel-date-and-time-function_ErrorCase_079_2e6f80eb94" id="_jF6_hPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_079_2e6f80eb94_Result" name="feel-date-and-time-function_ErrorCase_079_2e6f80eb94" id="_jF6_hPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_gvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T13:20:00-19:00")</text>
         </literalExpression>
@@ -980,7 +980,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T13:20:00+05:0")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T13:20:00+05:0")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_080_69de952053_Result" name="feel-date-and-time-function_ErrorCase_080_69de952053" id="_jF6_iPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_080_69de952053_Result" name="feel-date-and-time-function_ErrorCase_080_69de952053" id="_jF6_iPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_hvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T13:20:00+05:0")</text>
         </literalExpression>
@@ -989,7 +989,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T13:20:00+5:00")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T13:20:00+5:00")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_081_e063215a7c_Result" name="feel-date-and-time-function_ErrorCase_081_e063215a7c" id="_jF6_jPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_081_e063215a7c_Result" name="feel-date-and-time-function_ErrorCase_081_e063215a7c" id="_jF6_jPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_ivUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T13:20:00+5:00")</text>
         </literalExpression>
@@ -998,7 +998,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T13:20:00+5")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T13:20:00+5")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_082_5b6ed4e801_Result" name="feel-date-and-time-function_ErrorCase_082_5b6ed4e801" id="_jF6_kPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_082_5b6ed4e801_Result" name="feel-date-and-time-function_ErrorCase_082_5b6ed4e801" id="_jF6_kPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_jvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T13:20:00+5")</text>
         </literalExpression>
@@ -1007,7 +1007,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T13:20:00+02:00@Europe/Paris")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T13:20:00+02:00@Europe/Paris")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_083_4f41731f2a_Result" name="feel-date-and-time-function_ErrorCase_083_4f41731f2a" id="_jF6_lPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_083_4f41731f2a_Result" name="feel-date-and-time-function_ErrorCase_083_4f41731f2a" id="_jF6_lPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_kvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T13:20:00+02:00@Europe/Paris")</text>
         </literalExpression>
@@ -1016,7 +1016,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T7:20")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T7:20")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_084_c633b01603_Result" name="feel-date-and-time-function_ErrorCase_084_c633b01603" id="_jF6_mPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_084_c633b01603_Result" name="feel-date-and-time-function_ErrorCase_084_c633b01603" id="_jF6_mPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_lvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T7:20")</text>
         </literalExpression>
@@ -1025,7 +1025,7 @@
         <description>Tests FEEL expression: 'date and time("2017-12-31T07:2")' and expects result: 'null (date and time)'</description>
         <question>Result of FEEL expression 'date and time("2017-12-31T07:2")'?</question>
         <allowedAnswers>null (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_085_a604a1bc80_Result" name="feel-date-and-time-function_ErrorCase_085_a604a1bc80" id="_jF6_nPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_085_a604a1bc80_Result" name="feel-date-and-time-function_ErrorCase_085_a604a1bc80" id="_jF6_nPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jF6_mvUUEeesLuP4RHs4vA">
             <text>date and time("2017-12-31T07:2")</text>
         </literalExpression>
@@ -1034,7 +1034,7 @@
         <description>Tests FEEL expression: 'date and time(from:"2012-12-24T23:59:00")' and expects result: '2012-12-24T23:59:00 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(from:"2012-12-24T23:59:00")'?</question>
         <allowedAnswers>2012-12-24T23:59:00 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_086_12ca8ac1d3_Result" name="feel-date-and-time-function_086_12ca8ac1d3" id="_jGEI0vUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_086_12ca8ac1d3_Result" name="feel-date-and-time-function_086_12ca8ac1d3" id="_jGEI0vUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jGEI0PUUEeesLuP4RHs4vA">
             <text>date and time(from:"2012-12-24T23:59:00")</text>
         </literalExpression>
@@ -1043,7 +1043,7 @@
         <description>Tests FEEL expression: 'date and time(date:date("2017-01-01"),time:time("23:59:01"))' and expects result: '2017-01-01T23:59:01 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date:date("2017-01-01"),time:time("23:59:01"))'?</question>
         <allowedAnswers>2017-01-01T23:59:01 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_087_e9fd32063a_Result" name="feel-date-and-time-function_087_e9fd32063a" id="_jGEI1vUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_087_e9fd32063a_Result" name="feel-date-and-time-function_087_e9fd32063a" id="_jGEI1vUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jGEI1PUUEeesLuP4RHs4vA">
             <text>date and time(date:date("2017-01-01"),time:time("23:59:01"))</text>
         </literalExpression>
@@ -1052,7 +1052,7 @@
         <description>Tests FEEL expression: 'date and time(date:date and time("2017-01-01T00:00:00"),time:time("23:59:01"))' and expects result: '2017-01-01T23:59:01 (date and time)'</description>
         <question>Result of FEEL expression 'date and time(date:date and time("2017-01-01T00:00:00"),time:time("23:59:01"))'?</question>
         <allowedAnswers>2017-01-01T23:59:01 (date and time)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-date-and-time-function_088_1db0287718_Result" name="feel-date-and-time-function_088_1db0287718" id="_jGEI2vUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-date-and-time-function_088_1db0287718_Result" name="feel-date-and-time-function_088_1db0287718" id="_jGEI2vUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jGEI2PUUEeesLuP4RHs4vA">
             <text>date and time(date:date and time("2017-01-01T00:00:00"),time:time("23:59:01"))</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1120-feel-duration-function/1120-feel-duration-function.dmn
+++ b/TestCases/compliance-level-3/1120-feel-duration-function/1120-feel-duration-function.dmn
@@ -131,7 +131,7 @@
         <description>Tests FEEL expression: 'duration(null)' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration(null)'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_001_f2c6cd6866_Result" name="feel-duration-function_ErrorCase_001_f2c6cd6866" id="_jG2L9fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_001_f2c6cd6866_Result" name="feel-duration-function_ErrorCase_001_f2c6cd6866" id="_jG2L9fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG2L8_UUEeesLuP4RHs4vA">
             <text>duration(null)</text>
         </literalExpression>
@@ -140,7 +140,7 @@
         <description>Tests FEEL expression: 'duration()' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration()'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_002_ddca5756ca_Result" name="feel-duration-function_ErrorCase_002_ddca5756ca" id="_jG2L-fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_002_ddca5756ca_Result" name="feel-duration-function_ErrorCase_002_ddca5756ca" id="_jG2L-fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG2L9_UUEeesLuP4RHs4vA">
             <text>duration()</text>
         </literalExpression>
@@ -149,7 +149,7 @@
         <description>Tests FEEL expression: 'duration("P1D")' and expects result: 'P1D (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("P1D")'?</question>
         <allowedAnswers>P1D (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_003_951e1d1c31_Result" name="feel-duration-function_003_951e1d1c31" id="_jG2zA_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_003_951e1d1c31_Result" name="feel-duration-function_003_951e1d1c31" id="_jG2zA_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG2zAfUUEeesLuP4RHs4vA">
             <text>duration("P1D")</text>
         </literalExpression>
@@ -158,7 +158,7 @@
         <description>Tests FEEL expression: 'duration("PT2H")' and expects result: 'PT2H (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT2H")'?</question>
         <allowedAnswers>PT2H (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_004_6b31e7cde7_Result" name="feel-duration-function_004_6b31e7cde7" id="_jG2zB_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_004_6b31e7cde7_Result" name="feel-duration-function_004_6b31e7cde7" id="_jG2zB_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG2zBfUUEeesLuP4RHs4vA">
             <text>duration("PT2H")</text>
         </literalExpression>
@@ -167,7 +167,7 @@
         <description>Tests FEEL expression: 'duration("PT3M")' and expects result: 'PT3M (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT3M")'?</question>
         <allowedAnswers>PT3M (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_005_202d863d07_Result" name="feel-duration-function_005_202d863d07" id="_jG2zC_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_005_202d863d07_Result" name="feel-duration-function_005_202d863d07" id="_jG2zC_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG2zCfUUEeesLuP4RHs4vA">
             <text>duration("PT3M")</text>
         </literalExpression>
@@ -176,7 +176,7 @@
         <description>Tests FEEL expression: 'duration("PT4S")' and expects result: 'PT4S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT4S")'?</question>
         <allowedAnswers>PT4S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_006_a885f926d9_Result" name="feel-duration-function_006_a885f926d9" id="_jG2zD_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_006_a885f926d9_Result" name="feel-duration-function_006_a885f926d9" id="_jG2zD_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG2zDfUUEeesLuP4RHs4vA">
             <text>duration("PT4S")</text>
         </literalExpression>
@@ -185,7 +185,7 @@
         <description>Tests FEEL expression: 'duration("PT0.999S")' and expects result: 'PT0.999S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT0.999S")'?</question>
         <allowedAnswers>PT0.999S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_007_2f0ad399f3_Result" name="feel-duration-function_007_2f0ad399f3" id="_jG3aEPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_007_2f0ad399f3_Result" name="feel-duration-function_007_2f0ad399f3" id="_jG3aEPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG2zEfUUEeesLuP4RHs4vA">
             <text>duration("PT0.999S")</text>
         </literalExpression>
@@ -194,7 +194,7 @@
         <description>Tests FEEL expression: 'duration("P1DT2H3M4.123456789S")' and expects result: 'P1DT2H3M4.123456789S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("P1DT2H3M4.123456789S")'?</question>
         <allowedAnswers>P1DT2H3M4.123456789S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_008_747f56743d_Result" name="feel-duration-function_008_747f56743d" id="_jG3aFPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_008_747f56743d_Result" name="feel-duration-function_008_747f56743d" id="_jG3aFPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG3aEvUUEeesLuP4RHs4vA">
             <text>duration("P1DT2H3M4.123456789S")</text>
         </literalExpression>
@@ -203,7 +203,7 @@
         <description>Tests FEEL expression: 'duration("PT0S")' and expects result: 'PT0S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT0S")'?</question>
         <allowedAnswers>PT0S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_009_cef3c1ed26_Result" name="feel-duration-function_009_cef3c1ed26" id="_jG3aGPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_009_cef3c1ed26_Result" name="feel-duration-function_009_cef3c1ed26" id="_jG3aGPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG3aFvUUEeesLuP4RHs4vA">
             <text>duration("PT0S")</text>
         </literalExpression>
@@ -212,7 +212,7 @@
         <description>Tests FEEL expression: 'duration("PT0.000S")' and expects result: 'PT0S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT0.000S")'?</question>
         <allowedAnswers>PT0S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_010_5b452a4975_Result" name="feel-duration-function_010_5b452a4975" id="_jG3aHPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_010_5b452a4975_Result" name="feel-duration-function_010_5b452a4975" id="_jG3aHPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG3aGvUUEeesLuP4RHs4vA">
             <text>duration("PT0.000S")</text>
         </literalExpression>
@@ -221,7 +221,7 @@
         <description>Tests FEEL expression: 'duration("PT0.S")' and expects result: 'PT0S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT0.S")'?</question>
         <allowedAnswers>PT0S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_011_2169615b94_Result" name="feel-duration-function_011_2169615b94" id="_jG3aIPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_011_2169615b94_Result" name="feel-duration-function_011_2169615b94" id="_jG3aIPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG3aHvUUEeesLuP4RHs4vA">
             <text>duration("PT0.S")</text>
         </literalExpression>
@@ -230,7 +230,7 @@
         <description>Tests FEEL expression: 'duration("PT0M")' and expects result: 'PT0S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT0M")'?</question>
         <allowedAnswers>PT0S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_012_2affe6d169_Result" name="feel-duration-function_012_2affe6d169" id="_jG4BIvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_012_2affe6d169_Result" name="feel-duration-function_012_2affe6d169" id="_jG4BIvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4BIPUUEeesLuP4RHs4vA">
             <text>duration("PT0M")</text>
         </literalExpression>
@@ -239,7 +239,7 @@
         <description>Tests FEEL expression: 'duration("PT0H")' and expects result: 'PT0S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT0H")'?</question>
         <allowedAnswers>PT0S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_013_0e8e26513c_Result" name="feel-duration-function_013_0e8e26513c" id="_jG4BJvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_013_0e8e26513c_Result" name="feel-duration-function_013_0e8e26513c" id="_jG4BJvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4BJPUUEeesLuP4RHs4vA">
             <text>duration("PT0H")</text>
         </literalExpression>
@@ -248,7 +248,7 @@
         <description>Tests FEEL expression: 'duration("P0D")' and expects result: 'PT0S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("P0D")'?</question>
         <allowedAnswers>PT0S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_014_598ba6fabd_Result" name="feel-duration-function_014_598ba6fabd" id="_jG4BKvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_014_598ba6fabd_Result" name="feel-duration-function_014_598ba6fabd" id="_jG4BKvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4BKPUUEeesLuP4RHs4vA">
             <text>duration("P0D")</text>
         </literalExpression>
@@ -257,7 +257,7 @@
         <description>Tests FEEL expression: 'duration("-PT1H2M")' and expects result: '-PT1H2M (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("-PT1H2M")'?</question>
         <allowedAnswers>-PT1H2M (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_015_ce2cb09830_Result" name="feel-duration-function_015_ce2cb09830" id="_jG4BLvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_015_ce2cb09830_Result" name="feel-duration-function_015_ce2cb09830" id="_jG4BLvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4BLPUUEeesLuP4RHs4vA">
             <text>duration("-PT1H2M")</text>
         </literalExpression>
@@ -266,7 +266,7 @@
         <description>Tests FEEL expression: 'duration("PT1000M")' and expects result: 'PT16H40M (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT1000M")'?</question>
         <allowedAnswers>PT16H40M (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_016_af3e37fdbd_Result" name="feel-duration-function_016_af3e37fdbd" id="_jG4oMvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_016_af3e37fdbd_Result" name="feel-duration-function_016_af3e37fdbd" id="_jG4oMvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4oMPUUEeesLuP4RHs4vA">
             <text>duration("PT1000M")</text>
         </literalExpression>
@@ -275,7 +275,7 @@
         <description>Tests FEEL expression: 'duration("PT1000M0.999999999S")' and expects result: 'PT16H40M0.999999999S (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT1000M0.999999999S")'?</question>
         <allowedAnswers>PT16H40M0.999999999S (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_017_4f4549fda4_Result" name="feel-duration-function_017_4f4549fda4" id="_jG4oNvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_017_4f4549fda4_Result" name="feel-duration-function_017_4f4549fda4" id="_jG4oNvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4oNPUUEeesLuP4RHs4vA">
             <text>duration("PT1000M0.999999999S")</text>
         </literalExpression>
@@ -284,7 +284,7 @@
         <description>Tests FEEL expression: 'duration("PT555M")' and expects result: 'PT9H15M (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT555M")'?</question>
         <allowedAnswers>PT9H15M (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_018_f5ec776811_Result" name="feel-duration-function_018_f5ec776811" id="_jG4oOvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_018_f5ec776811_Result" name="feel-duration-function_018_f5ec776811" id="_jG4oOvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4oOPUUEeesLuP4RHs4vA">
             <text>duration("PT555M")</text>
         </literalExpression>
@@ -293,7 +293,7 @@
         <description>Tests FEEL expression: 'duration("PT61M")' and expects result: 'PT1H1M (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT61M")'?</question>
         <allowedAnswers>PT1H1M (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_019_2e6885755a_Result" name="feel-duration-function_019_2e6885755a" id="_jG4oPvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_019_2e6885755a_Result" name="feel-duration-function_019_2e6885755a" id="_jG4oPvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4oPPUUEeesLuP4RHs4vA">
             <text>duration("PT61M")</text>
         </literalExpression>
@@ -302,7 +302,7 @@
         <description>Tests FEEL expression: 'duration("PT24H")' and expects result: 'P1D (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT24H")'?</question>
         <allowedAnswers>P1D (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_020_af58b3766e_Result" name="feel-duration-function_020_af58b3766e" id="_jG4oQvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_020_af58b3766e_Result" name="feel-duration-function_020_af58b3766e" id="_jG4oQvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG4oQPUUEeesLuP4RHs4vA">
             <text>duration("PT24H")</text>
         </literalExpression>
@@ -311,7 +311,7 @@
         <description>Tests FEEL expression: 'duration("PT240H")' and expects result: 'P10D (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT240H")'?</question>
         <allowedAnswers>P10D (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_021_e48e70ad4e_Result" name="feel-duration-function_021_e48e70ad4e" id="_jG5PQvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_021_e48e70ad4e_Result" name="feel-duration-function_021_e48e70ad4e" id="_jG5PQvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG5PQPUUEeesLuP4RHs4vA">
             <text>duration("PT240H")</text>
         </literalExpression>
@@ -320,7 +320,7 @@
         <description>Tests FEEL expression: 'duration("P2DT100M")' and expects result: 'P2DT1H40M (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("P2DT100M")'?</question>
         <allowedAnswers>P2DT1H40M (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_022_668f24bed7_Result" name="feel-duration-function_022_668f24bed7" id="_jG5PRvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_022_668f24bed7_Result" name="feel-duration-function_022_668f24bed7" id="_jG5PRvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG5PRPUUEeesLuP4RHs4vA">
             <text>duration("P2DT100M")</text>
         </literalExpression>
@@ -329,7 +329,7 @@
         <description>Tests FEEL expression: 'duration("PT3600S")' and expects result: 'PT1H (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("PT3600S")'?</question>
         <allowedAnswers>PT1H (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_023_6fc32087db_Result" name="feel-duration-function_023_6fc32087db" id="_jG5PSvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_023_6fc32087db_Result" name="feel-duration-function_023_6fc32087db" id="_jG5PSvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG5PSPUUEeesLuP4RHs4vA">
             <text>duration("PT3600S")</text>
         </literalExpression>
@@ -338,7 +338,7 @@
         <description>Tests FEEL expression: 'duration("P2DT274M")' and expects result: 'P2DT4H34M (days and time duration)'</description>
         <question>Result of FEEL expression 'duration("P2DT274M")'?</question>
         <allowedAnswers>P2DT4H34M (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_024_fd7000d72f_Result" name="feel-duration-function_024_fd7000d72f" id="_jG5PTvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_024_fd7000d72f_Result" name="feel-duration-function_024_fd7000d72f" id="_jG5PTvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG5PTPUUEeesLuP4RHs4vA">
             <text>duration("P2DT274M")</text>
         </literalExpression>
@@ -347,7 +347,7 @@
         <description>Tests FEEL expression: 'duration("P1Y2M")' and expects result: 'P1Y2M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P1Y2M")'?</question>
         <allowedAnswers>P1Y2M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_025_f8ffbd8658_Result" name="feel-duration-function_025_f8ffbd8658" id="_jG5PUvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_025_f8ffbd8658_Result" name="feel-duration-function_025_f8ffbd8658" id="_jG5PUvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG5PUPUUEeesLuP4RHs4vA">
             <text>duration("P1Y2M")</text>
         </literalExpression>
@@ -356,7 +356,7 @@
         <description>Tests FEEL expression: 'duration("P1Y")' and expects result: 'P1Y (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P1Y")'?</question>
         <allowedAnswers>P1Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_026_e6c47f0cae_Result" name="feel-duration-function_026_e6c47f0cae" id="_jG52UvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_026_e6c47f0cae_Result" name="feel-duration-function_026_e6c47f0cae" id="_jG52UvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG52UPUUEeesLuP4RHs4vA">
             <text>duration("P1Y")</text>
         </literalExpression>
@@ -365,7 +365,7 @@
         <description>Tests FEEL expression: 'duration("P0Y")' and expects result: 'P0M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P0Y")'?</question>
         <allowedAnswers>P0M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_027_33b7fb8704_Result" name="feel-duration-function_027_33b7fb8704" id="_jG52VvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_027_33b7fb8704_Result" name="feel-duration-function_027_33b7fb8704" id="_jG52VvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG52VPUUEeesLuP4RHs4vA">
             <text>duration("P0Y")</text>
         </literalExpression>
@@ -374,7 +374,7 @@
         <description>Tests FEEL expression: 'duration("P0M")' and expects result: 'P0M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P0M")'?</question>
         <allowedAnswers>P0M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_028_971b94f16d_Result" name="feel-duration-function_028_971b94f16d" id="_jG52WvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_028_971b94f16d_Result" name="feel-duration-function_028_971b94f16d" id="_jG52WvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG52WPUUEeesLuP4RHs4vA">
             <text>duration("P0M")</text>
         </literalExpression>
@@ -383,7 +383,7 @@
         <description>Tests FEEL expression: 'duration("-P1Y")' and expects result: '-P1Y (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("-P1Y")'?</question>
         <allowedAnswers>-P1Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_029_1a12a226cc_Result" name="feel-duration-function_029_1a12a226cc" id="_jG52XvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_029_1a12a226cc_Result" name="feel-duration-function_029_1a12a226cc" id="_jG52XvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG52XPUUEeesLuP4RHs4vA">
             <text>duration("-P1Y")</text>
         </literalExpression>
@@ -392,7 +392,7 @@
         <description>Tests FEEL expression: 'duration("P26M")' and expects result: 'P2Y2M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P26M")'?</question>
         <allowedAnswers>P2Y2M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_030_afac0f2062_Result" name="feel-duration-function_030_afac0f2062" id="_jG6dY_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_030_afac0f2062_Result" name="feel-duration-function_030_afac0f2062" id="_jG6dY_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG6dYfUUEeesLuP4RHs4vA">
             <text>duration("P26M")</text>
         </literalExpression>
@@ -401,7 +401,7 @@
         <description>Tests FEEL expression: 'duration("P1Y27M")' and expects result: 'P3Y3M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P1Y27M")'?</question>
         <allowedAnswers>P3Y3M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_031_1ddad718b9_Result" name="feel-duration-function_031_1ddad718b9" id="_jG6dZ_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_031_1ddad718b9_Result" name="feel-duration-function_031_1ddad718b9" id="_jG6dZ_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG6dZfUUEeesLuP4RHs4vA">
             <text>duration("P1Y27M")</text>
         </literalExpression>
@@ -410,7 +410,7 @@
         <description>Tests FEEL expression: 'duration("P100M")' and expects result: 'P8Y4M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P100M")'?</question>
         <allowedAnswers>P8Y4M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_032_72c46a9ec9_Result" name="feel-duration-function_032_72c46a9ec9" id="_jG6da_UUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_032_72c46a9ec9_Result" name="feel-duration-function_032_72c46a9ec9" id="_jG6da_UUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG6dafUUEeesLuP4RHs4vA">
             <text>duration("P100M")</text>
         </literalExpression>
@@ -419,7 +419,7 @@
         <description>Tests FEEL expression: 'duration("-P100M")' and expects result: '-P8Y4M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("-P100M")'?</question>
         <allowedAnswers>-P8Y4M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_033_5d1540abaf_Result" name="feel-duration-function_033_5d1540abaf" id="_jG7EcvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_033_5d1540abaf_Result" name="feel-duration-function_033_5d1540abaf" id="_jG7EcvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7EcPUUEeesLuP4RHs4vA">
             <text>duration("-P100M")</text>
         </literalExpression>
@@ -428,7 +428,7 @@
         <description>Tests FEEL expression: 'duration("P999999999M")' and expects result: 'P83333333Y3M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P999999999M")'?</question>
         <allowedAnswers>P83333333Y3M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_034_aa9cbb21a6_Result" name="feel-duration-function_034_aa9cbb21a6" id="_jG7EdvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_034_aa9cbb21a6_Result" name="feel-duration-function_034_aa9cbb21a6" id="_jG7EdvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7EdPUUEeesLuP4RHs4vA">
             <text>duration("P999999999M")</text>
         </literalExpression>
@@ -437,7 +437,7 @@
         <description>Tests FEEL expression: 'duration("-P999999999M")' and expects result: '-P83333333Y3M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("-P999999999M")'?</question>
         <allowedAnswers>-P83333333Y3M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_035_93eef01ae7_Result" name="feel-duration-function_035_93eef01ae7" id="_jG7EevUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_035_93eef01ae7_Result" name="feel-duration-function_035_93eef01ae7" id="_jG7EevUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7EePUUEeesLuP4RHs4vA">
             <text>duration("-P999999999M")</text>
         </literalExpression>
@@ -446,7 +446,7 @@
         <description>Tests FEEL expression: 'duration("P99999999Y")' and expects result: 'P99999999Y (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("P99999999Y")'?</question>
         <allowedAnswers>P99999999Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_036_5f2775875e_Result" name="feel-duration-function_036_5f2775875e" id="_jG7EfvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_036_5f2775875e_Result" name="feel-duration-function_036_5f2775875e" id="_jG7EfvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7EfPUUEeesLuP4RHs4vA">
             <text>duration("P99999999Y")</text>
         </literalExpression>
@@ -455,7 +455,7 @@
         <description>Tests FEEL expression: 'duration("-P99999999Y")' and expects result: '-P99999999Y (years and months duration)'</description>
         <question>Result of FEEL expression 'duration("-P99999999Y")'?</question>
         <allowedAnswers>-P99999999Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_037_8c9ea9c0e6_Result" name="feel-duration-function_037_8c9ea9c0e6" id="_jG7rgPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_037_8c9ea9c0e6_Result" name="feel-duration-function_037_8c9ea9c0e6" id="_jG7rgPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7EgPUUEeesLuP4RHs4vA">
             <text>duration("-P99999999Y")</text>
         </literalExpression>
@@ -464,7 +464,7 @@
         <description>Tests FEEL expression: 'duration(from:"P1Y")' and expects result: 'P1Y (years and months duration)'</description>
         <question>Result of FEEL expression 'duration(from:"P1Y")'?</question>
         <allowedAnswers>P1Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_038_67dc4c254c_Result" name="feel-duration-function_038_67dc4c254c" id="_jG7rhPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_038_67dc4c254c_Result" name="feel-duration-function_038_67dc4c254c" id="_jG7rhPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7rgvUUEeesLuP4RHs4vA">
             <text>duration(from:"P1Y")</text>
         </literalExpression>
@@ -473,7 +473,7 @@
         <description>Tests FEEL expression: 'duration(from:"PT24H")' and expects result: 'P1D (days and time duration)'</description>
         <question>Result of FEEL expression 'duration(from:"PT24H")'?</question>
         <allowedAnswers>P1D (days and time duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_039_4aa0b67804_Result" name="feel-duration-function_039_4aa0b67804" id="_jG7riPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_039_4aa0b67804_Result" name="feel-duration-function_039_4aa0b67804" id="_jG7riPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7rhvUUEeesLuP4RHs4vA">
             <text>duration(from:"PT24H")</text>
         </literalExpression>
@@ -482,7 +482,7 @@
         <description>Tests FEEL expression: 'duration(from:"P26M")' and expects result: 'P2Y2M (years and months duration)'</description>
         <question>Result of FEEL expression 'duration(from:"P26M")'?</question>
         <allowedAnswers>P2Y2M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_040_7d8eae461f_Result" name="feel-duration-function_040_7d8eae461f" id="_jG7rjPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_040_7d8eae461f_Result" name="feel-duration-function_040_7d8eae461f" id="_jG7rjPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7rivUUEeesLuP4RHs4vA">
             <text>duration(from:"P26M")</text>
         </literalExpression>
@@ -491,7 +491,7 @@
         <description>Tests FEEL expression: 'duration("")' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration("")'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_041_264bc9d682_Result" name="feel-duration-function_ErrorCase_041_264bc9d682" id="_jG7rkPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_041_264bc9d682_Result" name="feel-duration-function_ErrorCase_041_264bc9d682" id="_jG7rkPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7rjvUUEeesLuP4RHs4vA">
             <text>duration("")</text>
         </literalExpression>
@@ -500,7 +500,7 @@
         <description>Tests FEEL expression: 'duration(2017)' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration(2017)'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_042_59a0000245_Result" name="feel-duration-function_ErrorCase_042_59a0000245" id="_jG7rlPUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_042_59a0000245_Result" name="feel-duration-function_ErrorCase_042_59a0000245" id="_jG7rlPUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG7rkvUUEeesLuP4RHs4vA">
             <text>duration(2017)</text>
         </literalExpression>
@@ -509,7 +509,7 @@
         <description>Tests FEEL expression: 'duration("2012T-12-2511:00:00Z")' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration("2012T-12-2511:00:00Z")'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_043_253815dc6c_Result" name="feel-duration-function_ErrorCase_043_253815dc6c" id="_jG8SkvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_043_253815dc6c_Result" name="feel-duration-function_ErrorCase_043_253815dc6c" id="_jG8SkvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG8SkPUUEeesLuP4RHs4vA">
             <text>duration("2012T-12-2511:00:00Z")</text>
         </literalExpression>
@@ -518,7 +518,7 @@
         <description>Tests FEEL expression: 'duration([])' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration([])'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_044_f3b338d877_Result" name="feel-duration-function_ErrorCase_044_f3b338d877" id="_jG8SlvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_044_f3b338d877_Result" name="feel-duration-function_ErrorCase_044_f3b338d877" id="_jG8SlvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG8SlPUUEeesLuP4RHs4vA">
             <text>duration([])</text>
         </literalExpression>
@@ -527,7 +527,7 @@
         <description>Tests FEEL expression: 'duration("P")' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration("P")'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_045_2ffcc37801_Result" name="feel-duration-function_ErrorCase_045_2ffcc37801" id="_jG8SmvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_045_2ffcc37801_Result" name="feel-duration-function_ErrorCase_045_2ffcc37801" id="_jG8SmvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG8SmPUUEeesLuP4RHs4vA">
             <text>duration("P")</text>
         </literalExpression>
@@ -536,7 +536,7 @@
         <description>Tests FEEL expression: 'duration("P0")' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration("P0")'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_046_eb637de5f6_Result" name="feel-duration-function_ErrorCase_046_eb637de5f6" id="_jG8SnvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_046_eb637de5f6_Result" name="feel-duration-function_ErrorCase_046_eb637de5f6" id="_jG8SnvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG8SnPUUEeesLuP4RHs4vA">
             <text>duration("P0")</text>
         </literalExpression>
@@ -545,7 +545,7 @@
         <description>Tests FEEL expression: 'duration("1Y")' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration("1Y")'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_047_3210c46a5a_Result" name="feel-duration-function_ErrorCase_047_3210c46a5a" id="_jG8SovUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_047_3210c46a5a_Result" name="feel-duration-function_ErrorCase_047_3210c46a5a" id="_jG8SovUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG8SoPUUEeesLuP4RHs4vA">
             <text>duration("1Y")</text>
         </literalExpression>
@@ -554,7 +554,7 @@
         <description>Tests FEEL expression: 'duration("1D")' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration("1D")'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_048_ab6244f767_Result" name="feel-duration-function_ErrorCase_048_ab6244f767" id="_jG85ovUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_048_ab6244f767_Result" name="feel-duration-function_ErrorCase_048_ab6244f767" id="_jG85ovUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG85oPUUEeesLuP4RHs4vA">
             <text>duration("1D")</text>
         </literalExpression>
@@ -563,7 +563,7 @@
         <description>Tests FEEL expression: 'duration("P1H")' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration("P1H")'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_049_2225b503a0_Result" name="feel-duration-function_ErrorCase_049_2225b503a0" id="_jG85pvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_049_2225b503a0_Result" name="feel-duration-function_ErrorCase_049_2225b503a0" id="_jG85pvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG85pPUUEeesLuP4RHs4vA">
             <text>duration("P1H")</text>
         </literalExpression>
@@ -572,7 +572,7 @@
         <description>Tests FEEL expression: 'duration("P1S")' and expects result: 'null (null)'</description>
         <question>Result of FEEL expression 'duration("P1S")'?</question>
         <allowedAnswers>null (null)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-duration-function_050_dd2ef33bbd_Result" name="feel-duration-function_ErrorCase_050_dd2ef33bbd" id="_jG85qvUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-duration-function_050_dd2ef33bbd_Result" name="feel-duration-function_ErrorCase_050_dd2ef33bbd" id="_jG85qvUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jG85qPUUEeesLuP4RHs4vA">
             <text>duration("P1S")</text>
         </literalExpression>

--- a/TestCases/compliance-level-3/1121-feel-years-and-months-duration-function/1121-feel-years-and-months-duration-function.dmn
+++ b/TestCases/compliance-level-3/1121-feel-years-and-months-duration-function/1121-feel-years-and-months-duration-function.dmn
@@ -113,7 +113,7 @@
         <description>Tests FEEL expression: 'years and months duration(null)' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(null)'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_001_b24a0c91f2_Result" name="feel-years-and-months-duration-function_ErrorCase_001_b24a0c91f2" id="_jHaMpfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_001_b24a0c91f2_Result" name="feel-years-and-months-duration-function_ErrorCase_001_b24a0c91f2" id="_jHaMpfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMo_UUEeesLuP4RHs4vA">
             <text>years and months duration(null)</text>
         </literalExpression>
@@ -122,7 +122,7 @@
         <description>Tests FEEL expression: 'years and months duration(null,null)' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(null,null)'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_002_4e7651ae0e_Result" name="feel-years-and-months-duration-function_ErrorCase_002_4e7651ae0e" id="_jHaMqfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_002_4e7651ae0e_Result" name="feel-years-and-months-duration-function_ErrorCase_002_4e7651ae0e" id="_jHaMqfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMp_UUEeesLuP4RHs4vA">
             <text>years and months duration(null,null)</text>
         </literalExpression>
@@ -131,7 +131,7 @@
         <description>Tests FEEL expression: 'years and months duration(date("2017-08-11"),null)' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date("2017-08-11"),null)'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_003_0886738d31_Result" name="feel-years-and-months-duration-function_ErrorCase_003_0886738d31" id="_jHaMrfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_003_0886738d31_Result" name="feel-years-and-months-duration-function_ErrorCase_003_0886738d31" id="_jHaMrfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMq_UUEeesLuP4RHs4vA">
             <text>years and months duration(date("2017-08-11"),null)</text>
         </literalExpression>
@@ -140,7 +140,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2017-12-31T13:00:00"),null)' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2017-12-31T13:00:00"),null)'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_004_1bdfef922b_Result" name="feel-years-and-months-duration-function_ErrorCase_004_1bdfef922b" id="_jHaMsfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_004_1bdfef922b_Result" name="feel-years-and-months-duration-function_ErrorCase_004_1bdfef922b" id="_jHaMsfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMr_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2017-12-31T13:00:00"),null)</text>
         </literalExpression>
@@ -149,7 +149,7 @@
         <description>Tests FEEL expression: 'years and months duration(null,date("2017-08-11"))' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(null,date("2017-08-11"))'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_005_d0a077da4e_Result" name="feel-years-and-months-duration-function_ErrorCase_005_d0a077da4e" id="_jHaMtfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_005_d0a077da4e_Result" name="feel-years-and-months-duration-function_ErrorCase_005_d0a077da4e" id="_jHaMtfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMs_UUEeesLuP4RHs4vA">
             <text>years and months duration(null,date("2017-08-11"))</text>
         </literalExpression>
@@ -158,7 +158,7 @@
         <description>Tests FEEL expression: 'years and months duration(null,date and time("2019-10-01T12:32:59"))' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(null,date and time("2019-10-01T12:32:59"))'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_006_f20de28d3f_Result" name="feel-years-and-months-duration-function_ErrorCase_006_f20de28d3f" id="_jHaMufUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_006_f20de28d3f_Result" name="feel-years-and-months-duration-function_ErrorCase_006_f20de28d3f" id="_jHaMufUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMt_UUEeesLuP4RHs4vA">
             <text>years and months duration(null,date and time("2019-10-01T12:32:59"))</text>
         </literalExpression>
@@ -167,7 +167,7 @@
         <description>Tests FEEL expression: 'years and months duration()' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration()'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_007_0921c3d61a_Result" name="feel-years-and-months-duration-function_ErrorCase_007_0921c3d61a" id="_jHaMvfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_007_0921c3d61a_Result" name="feel-years-and-months-duration-function_ErrorCase_007_0921c3d61a" id="_jHaMvfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMu_UUEeesLuP4RHs4vA">
             <text>years and months duration()</text>
         </literalExpression>
@@ -176,7 +176,7 @@
         <description>Tests FEEL expression: 'years and months duration(date("2011-12-22"),date("2013-08-24"))' and expects result: 'P1Y8M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date("2011-12-22"),date("2013-08-24"))'?</question>
         <allowedAnswers>P1Y8M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_008_015d35b442_Result" name="feel-years-and-months-duration-function_008_015d35b442" id="_jHaMwfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_008_015d35b442_Result" name="feel-years-and-months-duration-function_008_015d35b442" id="_jHaMwfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMv_UUEeesLuP4RHs4vA">
             <text>years and months duration(date("2011-12-22"),date("2013-08-24"))</text>
         </literalExpression>
@@ -185,7 +185,7 @@
         <description>Tests FEEL expression: 'years and months duration(date("2013-08-24"),date("2011-12-22"))' and expects result: '-P1Y8M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date("2013-08-24"),date("2011-12-22"))'?</question>
         <allowedAnswers>-P1Y8M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_009_635028a5d8_Result" name="feel-years-and-months-duration-function_009_635028a5d8" id="_jHaMxfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_009_635028a5d8_Result" name="feel-years-and-months-duration-function_009_635028a5d8" id="_jHaMxfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMw_UUEeesLuP4RHs4vA">
             <text>years and months duration(date("2013-08-24"),date("2011-12-22"))</text>
         </literalExpression>
@@ -194,7 +194,7 @@
         <description>Tests FEEL expression: 'years and months duration(date("2015-01-21"),date("2016-01-21"))' and expects result: 'P1Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date("2015-01-21"),date("2016-01-21"))'?</question>
         <allowedAnswers>P1Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_010_caaa2e5002_Result" name="feel-years-and-months-duration-function_010_caaa2e5002" id="_jHaMyfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_010_caaa2e5002_Result" name="feel-years-and-months-duration-function_010_caaa2e5002" id="_jHaMyfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMx_UUEeesLuP4RHs4vA">
             <text>years and months duration(date("2015-01-21"),date("2016-01-21"))</text>
         </literalExpression>
@@ -203,7 +203,7 @@
         <description>Tests FEEL expression: 'years and months duration(date("2016-01-21"),date("2015-01-21"))' and expects result: '-P1Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date("2016-01-21"),date("2015-01-21"))'?</question>
         <allowedAnswers>-P1Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_011_3fac022eb0_Result" name="feel-years-and-months-duration-function_011_3fac022eb0" id="_jHaMzfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_011_3fac022eb0_Result" name="feel-years-and-months-duration-function_011_3fac022eb0" id="_jHaMzfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMy_UUEeesLuP4RHs4vA">
             <text>years and months duration(date("2016-01-21"),date("2015-01-21"))</text>
         </literalExpression>
@@ -212,7 +212,7 @@
         <description>Tests FEEL expression: 'years and months duration(date("2016-01-01"),date("2016-01-01"))' and expects result: 'P0M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date("2016-01-01"),date("2016-01-01"))'?</question>
         <allowedAnswers>P0M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_012_331ef38ce0_Result" name="feel-years-and-months-duration-function_012_331ef38ce0" id="_jHaM0fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_012_331ef38ce0_Result" name="feel-years-and-months-duration-function_012_331ef38ce0" id="_jHaM0fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaMz_UUEeesLuP4RHs4vA">
             <text>years and months duration(date("2016-01-01"),date("2016-01-01"))</text>
         </literalExpression>
@@ -221,7 +221,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2017-12-31T13:00:00"), date and time("2017-12-31T12:00:00"))' and expects result: 'P0M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2017-12-31T13:00:00"), date and time("2017-12-31T12:00:00"))'?</question>
         <allowedAnswers>P0M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_013_2f3cc46d9d_Result" name="feel-years-and-months-duration-function_013_2f3cc46d9d" id="_jHaM1fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_013_2f3cc46d9d_Result" name="feel-years-and-months-duration-function_013_2f3cc46d9d" id="_jHaM1fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM0_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2017-12-31T13:00:00"), date and time("2017-12-31T12:00:00"))</text>
         </literalExpression>
@@ -230,7 +230,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2016-09-30T23:25:00"), date and time("2017-12-28T12:12:12"))' and expects result: 'P1Y2M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2016-09-30T23:25:00"), date and time("2017-12-28T12:12:12"))'?</question>
         <allowedAnswers>P1Y2M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_014_1fadbba7cd_Result" name="feel-years-and-months-duration-function_014_1fadbba7cd" id="_jHaM2fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_014_1fadbba7cd_Result" name="feel-years-and-months-duration-function_014_1fadbba7cd" id="_jHaM2fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM1_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2016-09-30T23:25:00"), date and time("2017-12-28T12:12:12"))</text>
         </literalExpression>
@@ -239,7 +239,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2010-05-30T03:55:58"), date and time("2017-12-15T00:59:59"))' and expects result: 'P7Y6M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2010-05-30T03:55:58"), date and time("2017-12-15T00:59:59"))'?</question>
         <allowedAnswers>P7Y6M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_015_0e496f94fc_Result" name="feel-years-and-months-duration-function_015_0e496f94fc" id="_jHaM3fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_015_0e496f94fc_Result" name="feel-years-and-months-duration-function_015_0e496f94fc" id="_jHaM3fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM2_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2010-05-30T03:55:58"), date and time("2017-12-15T00:59:59"))</text>
         </literalExpression>
@@ -248,7 +248,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2014-12-31T23:59:59"), date and time("2019-10-01T12:32:59"))' and expects result: 'P4Y9M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2014-12-31T23:59:59"), date and time("2019-10-01T12:32:59"))'?</question>
         <allowedAnswers>P4Y9M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_016_b38662aa93_Result" name="feel-years-and-months-duration-function_016_b38662aa93" id="_jHaM4fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_016_b38662aa93_Result" name="feel-years-and-months-duration-function_016_b38662aa93" id="_jHaM4fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM3_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2014-12-31T23:59:59"), date and time("2019-10-01T12:32:59"))</text>
         </literalExpression>
@@ -257,7 +257,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("-2016-01-30T09:05:00"), date and time("-2017-02-28T02:02:02"))' and expects result: '-P11M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("-2016-01-30T09:05:00"), date and time("-2017-02-28T02:02:02"))'?</question>
         <allowedAnswers>-P11M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_017_86744b9a54_Result" name="feel-years-and-months-duration-function_017_86744b9a54" id="_jHaM5fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_017_86744b9a54_Result" name="feel-years-and-months-duration-function_017_86744b9a54" id="_jHaM5fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM4_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("-2016-01-30T09:05:00"), date and time("-2017-02-28T02:02:02"))</text>
         </literalExpression>
@@ -266,7 +266,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2014-12-31T23:59:59"), date and time("-2019-10-01T12:32:59"))' and expects result: '-P4033Y2M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2014-12-31T23:59:59"), date and time("-2019-10-01T12:32:59"))'?</question>
         <allowedAnswers>-P4033Y2M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_018_8a9ed1d66d_Result" name="feel-years-and-months-duration-function_018_8a9ed1d66d" id="_jHaM6fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_018_8a9ed1d66d_Result" name="feel-years-and-months-duration-function_018_8a9ed1d66d" id="_jHaM6fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM5_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2014-12-31T23:59:59"), date and time("-2019-10-01T12:32:59"))</text>
         </literalExpression>
@@ -275,7 +275,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2017-09-05T10:20:00-01:00"), date and time("-2019-10-01T12:32:59+02:00"))' and expects result: '-P4035Y11M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2017-09-05T10:20:00-01:00"), date and time("-2019-10-01T12:32:59+02:00"))'?</question>
         <allowedAnswers>-P4035Y11M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_019_90c2084588_Result" name="feel-years-and-months-duration-function_019_90c2084588" id="_jHaM7fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_019_90c2084588_Result" name="feel-years-and-months-duration-function_019_90c2084588" id="_jHaM7fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM6_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2017-09-05T10:20:00-01:00"), date and time("-2019-10-01T12:32:59+02:00"))</text>
         </literalExpression>
@@ -284,7 +284,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2017-09-05T10:20:00+05:00"), date and time("2019-10-01T12:32:59"))' and expects result: 'P2Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2017-09-05T10:20:00+05:00"), date and time("2019-10-01T12:32:59"))'?</question>
         <allowedAnswers>P2Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_020_8ead9a0377_Result" name="feel-years-and-months-duration-function_020_8ead9a0377" id="_jHaM8fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_020_8ead9a0377_Result" name="feel-years-and-months-duration-function_020_8ead9a0377" id="_jHaM8fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM7_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2017-09-05T10:20:00+05:00"), date and time("2019-10-01T12:32:59"))</text>
         </literalExpression>
@@ -293,7 +293,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2016-08-25T15:20:59+02:00"), date and time("2017-08-10T10:20:00@Europe/Paris"))' and expects result: 'P11M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2016-08-25T15:20:59+02:00"), date and time("2017-08-10T10:20:00@Europe/Paris"))'?</question>
         <allowedAnswers>P11M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_021_8a7d311ae9_Result" name="feel-years-and-months-duration-function_021_8a7d311ae9" id="_jHaM9fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_021_8a7d311ae9_Result" name="feel-years-and-months-duration-function_021_8a7d311ae9" id="_jHaM9fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM8_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2016-08-25T15:20:59+02:00"), date and time("2017-08-10T10:20:00@Europe/Paris"))</text>
         </literalExpression>
@@ -302,7 +302,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2011-12-31T10:15:30@Etc/UTC"), date and time("2017-08-10T10:20:00@Europe/Paris"))' and expects result: 'P5Y7M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2011-12-31T10:15:30@Etc/UTC"), date and time("2017-08-10T10:20:00@Europe/Paris"))'?</question>
         <allowedAnswers>P5Y7M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_022_87e369773b_Result" name="feel-years-and-months-duration-function_022_87e369773b" id="_jHaM-fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_022_87e369773b_Result" name="feel-years-and-months-duration-function_022_87e369773b" id="_jHaM-fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM9_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2011-12-31T10:15:30@Etc/UTC"), date and time("2017-08-10T10:20:00@Europe/Paris"))</text>
         </literalExpression>
@@ -311,7 +311,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2017-09-05T10:20:00@Etc/UTC"), date and time("2018-10-01T23:59:59"))' and expects result: 'P1Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2017-09-05T10:20:00@Etc/UTC"), date and time("2018-10-01T23:59:59"))'?</question>
         <allowedAnswers>P1Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_023_6385c7a83e_Result" name="feel-years-and-months-duration-function_023_6385c7a83e" id="_jHaM_fUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_023_6385c7a83e_Result" name="feel-years-and-months-duration-function_023_6385c7a83e" id="_jHaM_fUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM-_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2017-09-05T10:20:00@Etc/UTC"), date and time("2018-10-01T23:59:59"))</text>
         </literalExpression>
@@ -320,7 +320,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2011-08-25T15:59:59@Europe/Paris"), date and time("2015-08-25T15:20:59+02:00"))' and expects result: 'P4Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2011-08-25T15:59:59@Europe/Paris"), date and time("2015-08-25T15:20:59+02:00"))'?</question>
         <allowedAnswers>P4Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_024_e96d1bd93a_Result" name="feel-years-and-months-duration-function_024_e96d1bd93a" id="_jHaNAfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_024_e96d1bd93a_Result" name="feel-years-and-months-duration-function_024_e96d1bd93a" id="_jHaNAfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaM__UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2011-08-25T15:59:59@Europe/Paris"), date and time("2015-08-25T15:20:59+02:00"))</text>
         </literalExpression>
@@ -329,7 +329,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2015-12-31T23:59:59.9999999"), date and time("2018-10-01T12:32:59.111111"))' and expects result: 'P2Y9M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2015-12-31T23:59:59.9999999"), date and time("2018-10-01T12:32:59.111111"))'?</question>
         <allowedAnswers>P2Y9M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_025_161f6fca54_Result" name="feel-years-and-months-duration-function_025_161f6fca54" id="_jHaNBfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_025_161f6fca54_Result" name="feel-years-and-months-duration-function_025_161f6fca54" id="_jHaNBfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNA_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2015-12-31T23:59:59.9999999"), date and time("2018-10-01T12:32:59.111111"))</text>
         </literalExpression>
@@ -338,7 +338,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2016-09-05T22:20:55.123456+05:00"), date and time("2019-10-01T12:32:59.32415645"))' and expects result: 'P3Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2016-09-05T22:20:55.123456+05:00"), date and time("2019-10-01T12:32:59.32415645"))'?</question>
         <allowedAnswers>P3Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_026_fcc906b375_Result" name="feel-years-and-months-duration-function_026_fcc906b375" id="_jHaNCfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_026_fcc906b375_Result" name="feel-years-and-months-duration-function_026_fcc906b375" id="_jHaNCfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNB_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2016-09-05T22:20:55.123456+05:00"), date and time("2019-10-01T12:32:59.32415645"))</text>
         </literalExpression>
@@ -347,7 +347,7 @@
         <description>Tests FEEL expression: 'years and months duration(date(""),date(""))' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date(""),date(""))'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_027_3374dd86c6_Result" name="feel-years-and-months-duration-function_ErrorCase_027_3374dd86c6" id="_jHaNDfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_027_3374dd86c6_Result" name="feel-years-and-months-duration-function_ErrorCase_027_3374dd86c6" id="_jHaNDfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNC_UUEeesLuP4RHs4vA">
             <text>years and months duration(date(""),date(""))</text>
         </literalExpression>
@@ -356,7 +356,7 @@
         <description>Tests FEEL expression: 'years and months duration(2017)' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(2017)'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_028_77600e7b35_Result" name="feel-years-and-months-duration-function_ErrorCase_028_77600e7b35" id="_jHaNEfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_028_77600e7b35_Result" name="feel-years-and-months-duration-function_ErrorCase_028_77600e7b35" id="_jHaNEfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaND_UUEeesLuP4RHs4vA">
             <text>years and months duration(2017)</text>
         </literalExpression>
@@ -365,7 +365,7 @@
         <description>Tests FEEL expression: 'years and months duration("2012T-12-2511:00:00Z")' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration("2012T-12-2511:00:00Z")'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_029_15a0d0d9c1_Result" name="feel-years-and-months-duration-function_ErrorCase_029_15a0d0d9c1" id="_jHaNFfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_029_15a0d0d9c1_Result" name="feel-years-and-months-duration-function_ErrorCase_029_15a0d0d9c1" id="_jHaNFfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNE_UUEeesLuP4RHs4vA">
             <text>years and months duration("2012T-12-2511:00:00Z")</text>
         </literalExpression>
@@ -374,7 +374,7 @@
         <description>Tests FEEL expression: 'years and months duration([],[])' and expects result: 'null (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration([],[])'?</question>
         <allowedAnswers>null (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_030_ec16878596_Result" name="feel-years-and-months-duration-function_ErrorCase_030_ec16878596" id="_jHaNGfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_030_ec16878596_Result" name="feel-years-and-months-duration-function_ErrorCase_030_ec16878596" id="_jHaNGfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNF_UUEeesLuP4RHs4vA">
             <text>years and months duration([],[])</text>
         </literalExpression>
@@ -383,7 +383,7 @@
         <description>Tests FEEL expression: 'years and months duration(date("2013-08-24"), date and time("2017-12-15T00:59:59"))' and expects result: 'P4Y3M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date("2013-08-24"), date and time("2017-12-15T00:59:59"))'?</question>
         <allowedAnswers>P4Y3M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_031_4fd9c09d89_Result" name="feel-years-and-months-duration-function_031_4fd9c09d89" id="_jHaNHfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_031_4fd9c09d89_Result" name="feel-years-and-months-duration-function_031_4fd9c09d89" id="_jHaNHfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNG_UUEeesLuP4RHs4vA">
             <text>years and months duration(date("2013-08-24"), date and time("2017-12-15T00:59:59"))</text>
         </literalExpression>
@@ -392,7 +392,7 @@
         <description>Tests FEEL expression: 'years and months duration(date and time("2017-02-28T23:59:59"), date("2019-07-23") )' and expects result: 'P2Y4M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(date and time("2017-02-28T23:59:59"), date("2019-07-23") )'?</question>
         <allowedAnswers>P2Y4M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_032_2a09ac80d0_Result" name="feel-years-and-months-duration-function_032_2a09ac80d0" id="_jHaNIfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_032_2a09ac80d0_Result" name="feel-years-and-months-duration-function_032_2a09ac80d0" id="_jHaNIfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNH_UUEeesLuP4RHs4vA">
             <text>years and months duration(date and time("2017-02-28T23:59:59"), date("2019-07-23") )</text>
         </literalExpression>
@@ -401,7 +401,7 @@
         <description>Tests FEEL expression: 'years and months duration(from:date and time("2016-12-31T00:00:01"),to:date and time("2017-12-31T23:59:59"))' and expects result: 'P1Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(from:date and time("2016-12-31T00:00:01"),to:date and time("2017-12-31T23:59:59"))'?</question>
         <allowedAnswers>P1Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_033_7333eca866_Result" name="feel-years-and-months-duration-function_033_7333eca866" id="_jHaNJfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_033_7333eca866_Result" name="feel-years-and-months-duration-function_033_7333eca866" id="_jHaNJfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNI_UUEeesLuP4RHs4vA">
             <text>years and months duration(from:date and time("2016-12-31T00:00:01"),to:date and time("2017-12-31T23:59:59"))</text>
         </literalExpression>
@@ -410,7 +410,7 @@
         <description>Tests FEEL expression: 'years and months duration(from:date and time("2014-12-31T23:59:59"),to:date and time("2016-12-31T00:00:01"))' and expects result: 'P2Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(from:date and time("2014-12-31T23:59:59"),to:date and time("2016-12-31T00:00:01"))'?</question>
         <allowedAnswers>P2Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_034_c2cc06724c_Result" name="feel-years-and-months-duration-function_034_c2cc06724c" id="_jHaNKfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_034_c2cc06724c_Result" name="feel-years-and-months-duration-function_034_c2cc06724c" id="_jHaNKfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNJ_UUEeesLuP4RHs4vA">
             <text>years and months duration(from:date and time("2014-12-31T23:59:59"),to:date and time("2016-12-31T00:00:01"))</text>
         </literalExpression>
@@ -419,7 +419,7 @@
         <description>Tests FEEL expression: 'years and months duration(from:date("2011-12-22"),to:date("2013-08-24"))' and expects result: 'P1Y8M (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(from:date("2011-12-22"),to:date("2013-08-24"))'?</question>
         <allowedAnswers>P1Y8M (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_035_dc05f9555d_Result" name="feel-years-and-months-duration-function_035_dc05f9555d" id="_jHaNLfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_035_dc05f9555d_Result" name="feel-years-and-months-duration-function_035_dc05f9555d" id="_jHaNLfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNK_UUEeesLuP4RHs4vA">
             <text>years and months duration(from:date("2011-12-22"),to:date("2013-08-24"))</text>
         </literalExpression>
@@ -428,7 +428,7 @@
         <description>Tests FEEL expression: 'years and months duration(from:date("2016-01-21"),to:date("2015-01-21"))' and expects result: '-P1Y (years and months duration)'</description>
         <question>Result of FEEL expression 'years and months duration(from:date("2016-01-21"),to:date("2015-01-21"))'?</question>
         <allowedAnswers>-P1Y (years and months duration)</allowedAnswers>
-        <variable typeRef="ns1:tfeel-years-and-months-duration-function_036_f8c8b02ba3_Result" name="feel-years-and-months-duration-function_036_f8c8b02ba3" id="_jHaNMfUUEeesLuP4RHs4vA"/>
+        <variable typeRef="tfeel-years-and-months-duration-function_036_f8c8b02ba3_Result" name="feel-years-and-months-duration-function_036_f8c8b02ba3" id="_jHaNMfUUEeesLuP4RHs4vA"/>
         <literalExpression id="_jHaNL_UUEeesLuP4RHs4vA">
             <text>years and months duration(from:date("2016-01-21"),to:date("2015-01-21"))</text>
         </literalExpression>

--- a/TestCases/non-compliant/0015-all-any/0015-all-any.dmn
+++ b/TestCases/non-compliant/0015-all-any/0015-all-any.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:tns="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" exporter="DMN Modeler; Method and Style trisofix.xslt" exporterVersion="5.0.34; 1.0" id="_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" name="and-or" namespace="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" triso:logoChoice="Default">
+<definitions xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:tns="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" exporter="DMN Modeler; Method and Style trisofix.xslt" exporterVersion="5.0.34; 1.0" id="_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" name="and-or" namespace="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" triso:logoChoice="Default">
 	<itemDefinition id="tBoolList" isCollection="true" name="tBoolList">
 		<typeRef>feel:boolean</typeRef>
 	</itemDefinition>
@@ -52,7 +52,7 @@
 		</literalExpression>
 	</decision>
 	<decision id="_065cfe42-f9c4-4218-801d-09a111945833" name="literalList">
-		<variable name="literalList" typeRef="tns:tBoolList"/>
+		<variable name="literalList" typeRef="tBoolList"/>
 		<informationRequirement>
 			<requiredInput href="#_efe62f90-4da2-45ff-9298-741d39b24e3b"/>
 		</informationRequirement>

--- a/TestCases/non-compliant/0015-all-any/0015-all-any.dmn
+++ b/TestCases/non-compliant/0015-all-any/0015-all-any.dmn
@@ -52,7 +52,7 @@
 		</literalExpression>
 	</decision>
 	<decision id="_065cfe42-f9c4-4218-801d-09a111945833" name="literalList">
-		<variable name="literalList" typeRef="tBoolList"/>
+		<variable name="literalList" typeRef="tns:tBoolList"/>
 		<informationRequirement>
 			<requiredInput href="#_efe62f90-4da2-45ff-9298-741d39b24e3b"/>
 		</informationRequirement>

--- a/TestCases/non-compliant/0015-all-any/0015-all-any.dmn
+++ b/TestCases/non-compliant/0015-all-any/0015-all-any.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:tns="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" exporter="DMN Modeler; Method and Style trisofix.xslt" exporterVersion="5.0.34; 1.0" id="_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" name="and-or" namespace="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" triso:logoChoice="Default">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:tns="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" exporter="DMN Modeler; Method and Style trisofix.xslt" exporterVersion="5.0.34; 1.0" id="_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" name="and-or" namespace="http://www.trisotech.com/definitions/_0b25a236-f7a2-4845-b41e-73ab3e5ebd41" triso:logoChoice="Default">
 	<itemDefinition id="tBoolList" isCollection="true" name="tBoolList">
 		<typeRef>feel:boolean</typeRef>
 	</itemDefinition>
@@ -52,7 +52,7 @@
 		</literalExpression>
 	</decision>
 	<decision id="_065cfe42-f9c4-4218-801d-09a111945833" name="literalList">
-		<variable name="literalList" typeRef="tBoolList"/>
+		<variable name="literalList" typeRef="tns:tBoolList"/>
 		<informationRequirement>
 			<requiredInput href="#_efe62f90-4da2-45ff-9298-741d39b24e3b"/>
 		</informationRequirement>

--- a/TestCases/non-compliant/0015-all-any/0015-all-any.dmn
+++ b/TestCases/non-compliant/0015-all-any/0015-all-any.dmn
@@ -52,7 +52,7 @@
 		</literalExpression>
 	</decision>
 	<decision id="_065cfe42-f9c4-4218-801d-09a111945833" name="literalList">
-		<variable name="literalList" typeRef="tns:tBoolList"/>
+		<variable name="literalList" typeRef="tBoolList"/>
 		<informationRequirement>
 			<requiredInput href="#_efe62f90-4da2-45ff-9298-741d39b24e3b"/>
 		</informationRequirement>

--- a/TestCases/non-compliant/0019-flight-rebooking/0019-flight-rebooking.dmn
+++ b/TestCases/non-compliant/0019-flight-rebooking/0019-flight-rebooking.dmn
@@ -2,9 +2,9 @@
 <definitions id="_0019_flight_rebooking" 
 	name="0019-flight-rebooking"
 	namespace="https://www.drools.org/kie-dmn"
-	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
 	xmlns:kie="https://www.drools.org/kie-dmn"
-	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+	xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/">
 	
 	<itemDefinition id="_tFlight" name="tFlight">
 		<itemComponent id="_tFlight_Flight" name="Flight Number">

--- a/TestCases/non-compliant/0019-flight-rebooking/0019-flight-rebooking.dmn
+++ b/TestCases/non-compliant/0019-flight-rebooking/0019-flight-rebooking.dmn
@@ -2,9 +2,9 @@
 <definitions id="_0019_flight_rebooking" 
 	name="0019-flight-rebooking"
 	namespace="https://www.drools.org/kie-dmn"
-	xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
 	xmlns:kie="https://www.drools.org/kie-dmn"
-	xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/">
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
 	
 	<itemDefinition id="_tFlight" name="tFlight">
 		<itemComponent id="_tFlight_Flight" name="Flight Number">


### PR DESCRIPTION
I believe initial DMNv1.2 migration missed to remove other spurious `tns:` prefixes, I failed to notice this when browsing the history of https://github.com/dmn-tck/tck/pull/191 originally