### PR TITLE
Add JDK 11 related dependencies to Drools runner

### DIFF
--- a/runners/dmn-tck-runner-drools/pom.xml
+++ b/runners/dmn-tck-runner-drools/pom.xml
@@ -1,15 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
   <groupId>org.omg.dmn</groupId>
   <artifactId>tck-runner-drools</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <name>DMN :: TCK :: jUnit Runner :: Drools</name>
-
   <properties>
     <drools.version>7.17.0.Final</drools.version>
   </properties>
-
   <repositories>
     <repository>
       <id>jboss-public-repository-group</id>
@@ -26,7 +23,6 @@
       </snapshots>
     </repository>
   </repositories>
-
   <dependencies>
     <dependency>
       <groupId>org.omg.dmn</groupId>
@@ -37,6 +33,28 @@
       <groupId>org.omg.dmn</groupId>
       <artifactId>tck-runner</artifactId>
       <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+
+    <!-- JDK 11+ dependencies -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <version>1.2.0</version>
     </dependency>
 
     <!-- log dependencies -->
@@ -51,14 +69,12 @@
       <version>1.1.3</version>
       <scope>test</scope>
     </dependency>
-
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
     </dependency>
-
     <!-- Drools dependencies -->
     <dependency>
       <groupId>org.kie</groupId>
@@ -71,7 +87,6 @@
       <version>${drools.version}</version>
     </dependency>
   </dependencies>
-
   <build>
     <plugins>
       <plugin>
@@ -84,5 +99,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>


### PR DESCRIPTION
@tarilabs @etirelli could you please review? This enables running Drools runner with jdk11+. 