### PR TITLE
Test has invalid type "tFnInvocationResult"

### DIFF
--- a/TestCases/compliance-level-3/0031-user-defined-functions/0031-user-defined-functions.dmn
+++ b/TestCases/compliance-level-3/0031-user-defined-functions/0031-user-defined-functions.dmn
@@ -86,7 +86,7 @@
         <informationRequirement id="_1080c15e-bc84-4473-99f3-1b8ea7d12e61">
             <requiredInput href="#_5eBhQH6PEeePe9Zmt-encA"/>
         </informationRequirement>
-        <context typeRef="tFnInvocationResult" id="_JvSJQX6QEeePe9Zmt-encA">
+        <context id="_JvSJQX6QEeePe9Zmt-encA">
             <contextEntry>
                 <variable name="sumResult" id="_TEHYYH6VEeePe9Zmt-encA"/>
                 <literalExpression id="_TEHYYX6VEeePe9Zmt-encA">
@@ -159,7 +159,7 @@
         <knowledgeRequirement id="_548a994a-9a94-4df4-8245-eaefde56cb58">
             <requiredKnowledge href="#_8xmTAIDNEee-MeWXoLgrYg"/>
         </knowledgeRequirement>
-        <context typeRef="tFnInvocationResult" id="_eA6AcYDiEee-MeWXoLgrYg">
+        <context id="_eA6AcYDiEee-MeWXoLgrYg">
             <contextEntry>
                 <variable name="functionInvocationInParameter" id="_eA6Aj4DiEee-MeWXoLgrYg"/>
                 <literalExpression id="_eA6AkYDiEee-MeWXoLgrYg">


### PR DESCRIPTION
Test had typeRef="tFnInvocationResult" in two places.  tFnInvocationResult in not defined in the model.  I had a flag to relax this stuff as I was working but, truth be told, it should not pass and is not a valid model.

The test is not a test for types so I have just removed the typeRefs.