### PR TITLE
0085-decision-services

### DIFF
--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <modelName>0085-decision-services.dmn</modelName>
+    <labels>
+        <label>Compliance Level 3</label>
+        <label>Decision Services</label>
+    </labels>
+
+    <testCase id="001">
+        <description>Will output decision result</description>
+        <resultNode name="decisionService_001" type="decisionService">
+            <expected>
+                <component name="decision_001">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>Decision can invoke a decision service as function call</description>
+        <resultNode name="decision_002" type="decision">
+            <expected>
+                <component name="decision_001">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>Will output decision results only for output decision</description>
+        <resultNode name="decisionService_002" type="decisionService">
+            <expected>
+                <component name="decision_001">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+                <component name="decision_003">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
@@ -30,6 +30,15 @@
         </resultNode>
     </testCase>
 
+    <testCase id="002_a">
+        <description>Pass a param to a decision service invocation will return null</description>
+        <resultNode errorResult="true" name="decision_002_a" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
     <testCase id="003">
         <description>Will output decision results only for output decision</description>
         <resultNode name="decisionService_002" type="decisionService">

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0085-decision-services" name="0085-decision-services" id="_i9fboPUUEeesLuP4RHs4vA" xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <description>Decision Services</description>
+
+    <decisionService name="decisionService_001" id="_decisionService_001">
+        <variable name="decisionService_001"/>
+        <outputDecision href="#_decision_001"/>
+    </decisionService>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001"/>
+        <literalExpression>
+            <text>"foo"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- decision invoking a decision service -->
+    <decision name="decision_002" id="_decision_002">
+        <variable name="decision_002"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_001()</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_003" id="_decision_003">
+        <variable name="decision_003"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_002"/>
+        </informationRequirement>
+        <literalExpression>
+            <!-- decision_002 returns a context as a result of calling decisionService_001 -->
+            <text>decision_002.decision_001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- two output decisions and one encapsulatedDecision.  The encapsulatedDecision is never
+    invoked directly here, but is invoked indirectly via decision_003 -->
+    <decisionService name="decisionService_002" id="_decisionService_002">
+        <variable name="decisionService_002"/>
+        <outputDecision href="#_decision_001"/>
+        <outputDecision href="#_decision_003"/>
+        <encapsulatedDecision href="#_decision_002"/>
+    </decisionService>
+
+</definitions>

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
@@ -3,7 +3,6 @@
     <description>Decision Services</description>
 
     <decisionService name="decisionService_001" id="_decisionService_001">
-        <variable name="decisionService_001"/>
         <outputDecision href="#_decision_001"/>
     </decisionService>
 
@@ -25,6 +24,17 @@
         </literalExpression>
     </decision>
 
+    <!-- decision invoking a decision service with a param (which is illegal)-->
+    <decision name="decision_002_a" id="_decision_002_a">
+        <variable name="decision_002_a"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_001("foo")</text>
+        </literalExpression>
+    </decision>
+
     <decision name="decision_003" id="_decision_003">
         <variable name="decision_003"/>
         <informationRequirement>
@@ -39,7 +49,6 @@
     <!-- two output decisions and one encapsulatedDecision.  The encapsulatedDecision is never
     invoked directly here, but is invoked indirectly via decision_003 -->
     <decisionService name="decisionService_002" id="_decisionService_002">
-        <variable name="decisionService_002"/>
         <outputDecision href="#_decision_001"/>
         <outputDecision href="#_decision_003"/>
         <encapsulatedDecision href="#_decision_002"/>


### PR DESCRIPTION
A few tests around Decision Services.  Not really sure what kind of tests here but it seems not too many.  Just covering outputDecisions and invoke-ability really.   Spec calls for function semantics with decision services but it has no formal params properties, so I have just asserted that it can be called as a function with no params.

I have also added another test into `0082-fell-coercion` to decision table 'null coercion'. 

Can anybody think of any more tests we could do here?

All comments welcome.