### PR TITLE
0012-list-functions

### DIFF
--- a/TestCases/compliance-level-3/0012-list-functions/0012-list-functions-test-01.xml
+++ b/TestCases/compliance-level-3/0012-list-functions/0012-list-functions-test-01.xml
@@ -443,18 +443,8 @@
 				</item>
 			</list>
 		</inputNode>
-		<inputNode name="list2">
-			<list>
-				<item>
-					<value>x</value>
-				</item>
-				<item>
-					<value>y</value>
-				</item>
-				<item>
-					<value>z</value>
-				</item>
-			</list>
+		<inputNode name="string1">
+			<value>x</value>
 		</inputNode>
 		<resultNode name="appendListItem" type="decision">
 			<expected>
@@ -469,17 +459,7 @@
 						<value>c</value>
 					</item>
 					<item>
-						<list>
-							<item>
-								<value>x</value>
-							</item>
-							<item>
-								<value>y</value>
-							</item>
-							<item>
-								<value>z</value>
-							</item>
-						</list>
+						<value>x</value>
 					</item>
 				</list>
 			</expected>

--- a/TestCases/compliance-level-3/0012-list-functions/0012-list-functions.dmn
+++ b/TestCases/compliance-level-3/0012-list-functions/0012-list-functions.dmn
@@ -61,7 +61,7 @@
         </literalExpression>
     </decision>
     <inputData name="numList" id="_b894ee22-f795-46f7-b713-77d69d07ae22">
-        <variable name="numList"/>
+        <variable typeRef="tNumList" name="numList"/>
     </inputData>
     <decision name="sum1" id="_d6b2c4a0-a147-44a1-a9f4-3575f1bb5695">
         <variable typeRef="number" name="sum1"/>
@@ -106,7 +106,7 @@
         </literalExpression>
     </decision>
     <decision name="sublist12" id="_95e0ad53-c08f-46af-baa0-9c36d69002f5">
-        <variable name="sublist12"/>
+        <variable typeRef="tStringList" name="sublist12"/>
         <informationRequirement id="a29945fa-45fe-4464-8d07-3e37c37f7069">
             <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
         </informationRequirement>
@@ -115,7 +115,7 @@
         </literalExpression>
     </decision>
     <decision name="sublistLast" id="_85f6330f-dcaa-47ca-96bb-1c0228da911f">
-        <variable name="sublistLast"/>
+        <variable typeRef="tStringList" name="sublistLast"/>
         <informationRequirement id="b3c894ac-a211-4265-991b-86ea9dc02101">
             <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
         </informationRequirement>
@@ -124,7 +124,7 @@
         </literalExpression>
     </decision>
     <decision name="append1" id="_845ea241-587e-43d8-a563-a1dd18693afe">
-        <variable name="append1"/>
+        <variable typeRef="tNumList" name="append1"/>
         <informationRequirement id="_2856a9f4-86e6-427c-8a12-74be070a9d7a">
             <requiredInput href="#_b894ee22-f795-46f7-b713-77d69d07ae22"/>
         </informationRequirement>

--- a/TestCases/compliance-level-3/0012-list-functions/0012-list-functions.dmn
+++ b/TestCases/compliance-level-3/0012-list-functions/0012-list-functions.dmn
@@ -1,10 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <definitions exporter="DMN Modeler; Method and Style trisofix.xslt" exporterVersion="5.0.33.1; 1.0" namespace="http://www.trisotech.com/definitions/_c0858816-af7b-40a1-8aa7-6e11b8761215" name="listFunctions" triso:logoChoice="Default" id="_c0858816-af7b-40a1-8aa7-6e11b8761215" xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <itemDefinition isCollection="true" name="tStringList" id="tStringList">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+    <itemDefinition isCollection="true" name="tNumList" id="tNumList">
+        <typeRef>number</typeRef>
+    </itemDefinition>
+    <itemDefinition isCollection="true" name="tListOfLists" id="tListOfLists">
+        <typeRef>tStringList</typeRef>
+    </itemDefinition>
     <inputData name="list1" id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
-        <variable name="list1"/>
+        <variable typeRef="tStringList" name="list1"/>
     </inputData>
     <inputData name="list2" id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
-        <variable name="list2"/>
+        <variable typeRef="tStringList" name="list2"/>
     </inputData>
     <inputData name="string1" id="_1bbe9689-bd70-45d4-ab30-f3887cf46b28">
         <variable typeRef="string" name="string1"/>
@@ -130,7 +139,7 @@
         </literalExpression>
     </decision>
     <decision name="concatenate1" id="_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9">
-        <variable name="concatenate1"/>
+        <variable typeRef="tStringList" name="concatenate1"/>
         <informationRequirement id="_11e474f0-81c2-46d1-af6a-8003a07af3af">
             <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
         </informationRequirement>
@@ -142,7 +151,7 @@
         </literalExpression>
     </decision>
     <decision name="insertBefore1" id="_2064fd78-72aa-4851-9813-8d56674b3936">
-        <variable name="insertBefore1"/>
+        <variable typeRef="tStringList" name="insertBefore1"/>
         <informationRequirement id="cae9c51a-b8fd-4f39-81e5-46ae70f43d8f">
             <requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
         </informationRequirement>
@@ -154,7 +163,7 @@
         </literalExpression>
     </decision>
     <decision name="remove2nd" id="_ffd2b93c-2bca-4979-9a65-357ca8ba92ff">
-        <variable name="remove2nd"/>
+        <variable typeRef="tStringList" name="remove2nd"/>
         <informationRequirement id="fc58a8c9-b83d-4df6-a63b-4fe1fda6ca38">
             <requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
         </informationRequirement>
@@ -163,7 +172,7 @@
         </literalExpression>
     </decision>
     <decision name="reverse1" id="_673c3497-f8e7-4340-827d-99d8d08664db">
-        <variable name="reverse1"/>
+        <variable typeRef="tStringList" name="reverse1"/>
         <informationRequirement id="f5aa6eb4-f77b-4f33-b256-e26db5d7a6a4">
             <requiredDecision href="#_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9"/>
         </informationRequirement>
@@ -172,19 +181,19 @@
         </literalExpression>
     </decision>
     <decision name="appendListItem" id="_d12d9a82-b182-4c15-9fce-d22cdc53dbc4">
-        <variable name="appendListItem"/>
+        <variable typeRef="tStringList" name="appendListItem"/>
         <informationRequirement id="cacbbbb5-5e23-4089-a48d-af62e0c605b9">
             <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
         </informationRequirement>
         <informationRequirement id="_6ea238a4-45e4-42f1-bbc3-a6032c3ee89e">
-            <requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
+            <requiredInput href="#_1bbe9689-bd70-45d4-ab30-f3887cf46b28"/>
         </informationRequirement>
         <literalExpression>
-            <text>append(list1,list2)</text>
+            <text>append(list1,string1)</text>
         </literalExpression>
     </decision>
     <decision name="indexOf1" id="_3c7aef83-002c-4c61-9297-e822a7d4e829">
-        <variable name="indexOf1"/>
+        <variable typeRef="tNumList" name="indexOf1"/>
         <informationRequirement id="cbf43b3f-1452-4a47-95e7-6b4f0f80651a">
             <requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
         </informationRequirement>
@@ -196,7 +205,7 @@
         </literalExpression>
     </decision>
     <decision name="union1" id="_0dee9e3c-ef4e-4853-b182-bdf8bff1d20b">
-        <variable name="union1"/>
+        <variable typeRef="tStringList" name="union1"/>
         <informationRequirement id="_27a059d8-41a3-4dbf-b1d3-e5f38a7dfa88">
             <requiredDecision href="#_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9"/>
         </informationRequirement>
@@ -208,7 +217,7 @@
         </literalExpression>
     </decision>
     <decision name="distinctVals" id="_0bbaa2a8-b265-49d4-9540-28b1bddac540">
-        <variable name="distinctVals"/>
+        <variable typeRef="tStringList" name="distinctVals"/>
         <informationRequirement id="c9bc506f-643e-4d68-bdd4-f2a2bab981c1">
             <requiredDecision href="#_2064fd78-72aa-4851-9813-8d56674b3936"/>
         </informationRequirement>
@@ -217,12 +226,15 @@
         </literalExpression>
     </decision>
     <decision name="flatten1" id="_ef7d1df2-8a1c-47cf-ae2e-928f71e2c460">
-        <variable name="flatten1"/>
-        <informationRequirement id="_883c9eb4-1f4f-4885-82c0-234f9ac9a1d7">
-            <requiredDecision href="#_d12d9a82-b182-4c15-9fce-d22cdc53dbc4"/>
+        <variable typeRef="tStringList" name="flatten1"/>
+        <informationRequirement>
+            <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
         </informationRequirement>
         <literalExpression>
-            <text>flatten(appendListItem)</text>
+            <text>flatten(append(list1, list2))</text>
         </literalExpression>
     </decision>
     <dmndi:DMNDI>

--- a/TestCases/compliance-level-3/0012-list-functions/0012-list-functions.dmn
+++ b/TestCases/compliance-level-3/0012-list-functions/0012-list-functions.dmn
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <definitions exporter="DMN Modeler; Method and Style trisofix.xslt" exporterVersion="5.0.33.1; 1.0" namespace="http://www.trisotech.com/definitions/_c0858816-af7b-40a1-8aa7-6e11b8761215" name="listFunctions" triso:logoChoice="Default" id="_c0858816-af7b-40a1-8aa7-6e11b8761215" xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <itemDefinition isCollection="true" name="tStringList" id="tStringList">
-        <typeRef>string</typeRef>
-    </itemDefinition>
-    <itemDefinition isCollection="true" name="tNumList" id="tNumList">
-        <typeRef>number</typeRef>
-    </itemDefinition>
-    <itemDefinition isCollection="true" name="tListOfLists" id="tListOfLists">
-        <typeRef>tStringList</typeRef>
-    </itemDefinition>
     <inputData name="list1" id="_86f5e710-a139-4cd5-8ac4-90b4671a75b8">
-        <variable typeRef="tStringList" name="list1"/>
+        <variable name="list1"/>
     </inputData>
     <inputData name="list2" id="_82d66f50-2d47-4849-b5fd-da179e0fec66">
-        <variable typeRef="tStringList" name="list2"/>
+        <variable name="list2"/>
     </inputData>
     <inputData name="string1" id="_1bbe9689-bd70-45d4-ab30-f3887cf46b28">
         <variable typeRef="string" name="string1"/>
@@ -61,7 +52,7 @@
         </literalExpression>
     </decision>
     <inputData name="numList" id="_b894ee22-f795-46f7-b713-77d69d07ae22">
-        <variable typeRef="tNumList" name="numList"/>
+        <variable name="numList"/>
     </inputData>
     <decision name="sum1" id="_d6b2c4a0-a147-44a1-a9f4-3575f1bb5695">
         <variable typeRef="number" name="sum1"/>
@@ -106,7 +97,7 @@
         </literalExpression>
     </decision>
     <decision name="sublist12" id="_95e0ad53-c08f-46af-baa0-9c36d69002f5">
-        <variable typeRef="tStringList" name="sublist12"/>
+        <variable name="sublist12"/>
         <informationRequirement id="a29945fa-45fe-4464-8d07-3e37c37f7069">
             <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
         </informationRequirement>
@@ -115,7 +106,7 @@
         </literalExpression>
     </decision>
     <decision name="sublistLast" id="_85f6330f-dcaa-47ca-96bb-1c0228da911f">
-        <variable typeRef="tStringList" name="sublistLast"/>
+        <variable name="sublistLast"/>
         <informationRequirement id="b3c894ac-a211-4265-991b-86ea9dc02101">
             <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
         </informationRequirement>
@@ -124,7 +115,7 @@
         </literalExpression>
     </decision>
     <decision name="append1" id="_845ea241-587e-43d8-a563-a1dd18693afe">
-        <variable typeRef="tNumList" name="append1"/>
+        <variable name="append1"/>
         <informationRequirement id="_2856a9f4-86e6-427c-8a12-74be070a9d7a">
             <requiredInput href="#_b894ee22-f795-46f7-b713-77d69d07ae22"/>
         </informationRequirement>
@@ -139,7 +130,7 @@
         </literalExpression>
     </decision>
     <decision name="concatenate1" id="_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9">
-        <variable typeRef="tStringList" name="concatenate1"/>
+        <variable name="concatenate1"/>
         <informationRequirement id="_11e474f0-81c2-46d1-af6a-8003a07af3af">
             <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
         </informationRequirement>
@@ -151,7 +142,7 @@
         </literalExpression>
     </decision>
     <decision name="insertBefore1" id="_2064fd78-72aa-4851-9813-8d56674b3936">
-        <variable typeRef="tStringList" name="insertBefore1"/>
+        <variable name="insertBefore1"/>
         <informationRequirement id="cae9c51a-b8fd-4f39-81e5-46ae70f43d8f">
             <requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
         </informationRequirement>
@@ -163,7 +154,7 @@
         </literalExpression>
     </decision>
     <decision name="remove2nd" id="_ffd2b93c-2bca-4979-9a65-357ca8ba92ff">
-        <variable typeRef="tStringList" name="remove2nd"/>
+        <variable name="remove2nd"/>
         <informationRequirement id="fc58a8c9-b83d-4df6-a63b-4fe1fda6ca38">
             <requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
         </informationRequirement>
@@ -172,7 +163,7 @@
         </literalExpression>
     </decision>
     <decision name="reverse1" id="_673c3497-f8e7-4340-827d-99d8d08664db">
-        <variable typeRef="tStringList" name="reverse1"/>
+        <variable name="reverse1"/>
         <informationRequirement id="f5aa6eb4-f77b-4f33-b256-e26db5d7a6a4">
             <requiredDecision href="#_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9"/>
         </informationRequirement>
@@ -181,7 +172,7 @@
         </literalExpression>
     </decision>
     <decision name="appendListItem" id="_d12d9a82-b182-4c15-9fce-d22cdc53dbc4">
-        <variable typeRef="tListOfLists" name="appendListItem"/>
+        <variable name="appendListItem"/>
         <informationRequirement id="cacbbbb5-5e23-4089-a48d-af62e0c605b9">
             <requiredInput href="#_86f5e710-a139-4cd5-8ac4-90b4671a75b8"/>
         </informationRequirement>
@@ -193,7 +184,7 @@
         </literalExpression>
     </decision>
     <decision name="indexOf1" id="_3c7aef83-002c-4c61-9297-e822a7d4e829">
-        <variable typeRef="tNumList" name="indexOf1"/>
+        <variable name="indexOf1"/>
         <informationRequirement id="cbf43b3f-1452-4a47-95e7-6b4f0f80651a">
             <requiredInput href="#_82d66f50-2d47-4849-b5fd-da179e0fec66"/>
         </informationRequirement>
@@ -205,7 +196,7 @@
         </literalExpression>
     </decision>
     <decision name="union1" id="_0dee9e3c-ef4e-4853-b182-bdf8bff1d20b">
-        <variable typeRef="tStringList" name="union1"/>
+        <variable name="union1"/>
         <informationRequirement id="_27a059d8-41a3-4dbf-b1d3-e5f38a7dfa88">
             <requiredDecision href="#_c0c13a64-ef12-4e04-8e3f-fe9193bd72b9"/>
         </informationRequirement>
@@ -217,7 +208,7 @@
         </literalExpression>
     </decision>
     <decision name="distinctVals" id="_0bbaa2a8-b265-49d4-9540-28b1bddac540">
-        <variable typeRef="tStringList" name="distinctVals"/>
+        <variable name="distinctVals"/>
         <informationRequirement id="c9bc506f-643e-4d68-bdd4-f2a2bab981c1">
             <requiredDecision href="#_2064fd78-72aa-4851-9813-8d56674b3936"/>
         </informationRequirement>
@@ -226,7 +217,7 @@
         </literalExpression>
     </decision>
     <decision name="flatten1" id="_ef7d1df2-8a1c-47cf-ae2e-928f71e2c460">
-        <variable typeRef="tStringList" name="flatten1"/>
+        <variable name="flatten1"/>
         <informationRequirement id="_883c9eb4-1f4f-4885-82c0-234f9ac9a1d7">
             <requiredDecision href="#_d12d9a82-b182-4c15-9fce-d22cdc53dbc4"/>
         </informationRequirement>


### PR DESCRIPTION
Some type fixes to align with v1.2 types (another v1.1 'singleton array' thing).

The summary: the list results are of mixed types and not pure string lists as the dmn specifies.  Likely was okay with 'singleton array' code but, truth be told, they are not string lists anymore.

The purpose of the test suite is testing lists, not types, so, I have simply removed the offending types.   

This was originally in the big 'consolidated' PR but got lost when we split them up.

Mentioned here: https://github.com/dmn-tck/tck/pull/204#issuecomment-448089266

And some discussion here: https://github.com/dmn-tck/tck/pull/204#issuecomment-452887856