### PR TITLE
0085-decision-services

### DIFF
--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <modelName>0085-decision-services.dmn</modelName>
+    <labels>
+        <label>Compliance Level 3</label>
+        <label>Decision Services</label>
+    </labels>
+
+    <testCase id="001">
+        <description>Direct invocation: with no params</description>
+        <resultNode name="decisionService_001" type="decisionService">
+            <expected>
+                <component name="decision_001">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>Direct invocation: with an input decision</description>
+        <!-- we expect the input param value to 'override' the actual impl of 'decision_002_input' -->
+        <inputNode name="decision_002_input">
+            <value xsi:type="xsd:string">baz</value>
+        </inputNode>
+        <resultNode name="decisionService_002" type="decisionService">
+            <expected>
+                <component name="decision_002">
+                    <value xsi:type="xsd:string">foo baz</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <!-- note: we can't test invoking decision service directly passing a input data param as the param
+    and the global input data will actually have the same value - so a little difficult to assert where input data value
+    came from - param or global input -->
+
+    <testCase id="002_a">
+        <description>Direct invocation:  with an input decision but supplying no param</description>
+        <!-- requires decision_002_input but we're not providing it-->
+        <resultNode name="decisionService_002" type="decisionService" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002_b">
+        <description>Direct invocation: with an input decision - but supplying a null value</description>
+        <inputNode name="decision_002_input">
+            <value xsi:nil="true"/>
+        </inputNode>
+        <!-- errorResult is true because of the string + null operation -->
+        <resultNode name="decisionService_002" type="decisionService" errorResult="true">
+            <expected>
+                <component name="decision_002">
+                    <value xsi:nil="true"/>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002_c">
+        <description>Direct invocation: with an input decision - but supplying an incorrect param type</description>
+        <!-- decision_002_input is a string type but we're providing a number so we expect it to be null-coerced -->
+        <inputNode name="decision_002_input">
+            <value xsi:type="xsd:decimal">1234</value>
+        </inputNode>
+        <resultNode name="decisionService_002" type="decisionService" errorResult="true">
+            <expected>
+                <component name="decision_002">
+                    <value xsi:nil="true"/>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>Direct invocation: with two input decisions and an input data</description>
+        <!-- positive test -->
+        <inputNode name="decision_003_input_1">
+            <value xsi:type="xsd:string">B</value>
+        </inputNode>
+        <inputNode name="decision_003_input_2">
+            <value xsi:type="xsd:string">C</value>
+        </inputNode>
+        <inputNode name="inputData_003">
+            <value xsi:type="xsd:string">D</value>
+        </inputNode>
+        <resultNode name="decisionService_003" type="decisionService">
+            <expected>
+                <component name="decision_003">
+                    <value xsi:type="xsd:string">A B C D</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="004">
+        <description>with no params</description>
+        <!-- positive test -->
+        <resultNode name="decision_004_1" type="decision">
+            <expected>
+                <component name="decision_004_2">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="005">
+        <description>passing a param when DS has no params</description>
+        <resultNode name="decision_005_1" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="006">
+        <description>passing a single input decision param</description>
+        <!-- positive test -->
+        <resultNode name="decision_006_1" type="decision">
+            <expected>
+                <component name="decision_006_2">
+                    <value xsi:type="xsd:string">foo bar</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="007">
+        <description>passing a single input decision param with incorrect type</description>
+        <resultNode name="decision_007_1" type="decision" errorResult="true">
+            <expected>
+                <component name="decision_007_2">
+                    <value xsi:type="xsd:boolean">true</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="008">
+        <description>passing no param when DS expects one</description>
+        <resultNode name="decision_008_1" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="009">
+        <description>passing named param</description>
+        <!-- positive test -->
+        <resultNode name="decision_009_1" type="decision">
+            <expected>
+                <component name="decision_009_2">
+                    <value xsi:type="xsd:string">foo bar</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="010">
+        <description>passing badly named param</description>
+        <resultNode name="decision_010_1" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="011">
+        <description>input param order: two input decisions and two inputData </description>
+        <!-- positive test -->
+        <resultNode name="decision_011_1" type="decision">
+            <expected>
+                <component name="decision_011_2">
+                    <value xsi:type="xsd:string">A B C D</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="012">
+        <description>input named param order: two input decisions and two inputData </description>
+        <!-- positive test -->
+        <resultNode name="decision_012_1" type="decision">
+            <expected>
+                <component name="decision_012_2">
+                    <value xsi:type="xsd:string">A B C D</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="013">
+        <description>decision service input decision and data do not affect global decision and data</description>
+        <!-- positive test -->
+        <inputNode name="inputData_013_1">
+            <value xsi:type="xsd:string">C</value>
+        </inputNode>
+        <resultNode name="decision_013_1" type="decision">
+            <expected>
+                <component name="decisionService_013">
+                    <component name="decision_013_2">
+                        <value xsi:type="xsd:string">A B</value>
+                    </component>
+                </component>
+                <component name="inputData_013_1">
+                    <value xsi:type="xsd:string">C</value>
+                </component>
+                <component name="decision_013_3">
+                    <value xsi:type="xsd:string">D</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <!-- as per 013, but order of execution swapped so that global decision/input used first, rather than DS input/decision used first -->
+    <testCase id="014">
+        <description>decision service input decision and data do not affect global decision and data</description>
+        <!-- positive test -->
+        <inputNode name="inputData_014_1">
+            <value xsi:type="xsd:string">C</value>
+        </inputNode>
+        <resultNode name="decision_014_1" type="decision">
+            <expected>
+                <component name="inputData_014_1">
+                    <value xsi:type="xsd:string">C</value>
+                </component>
+                <component name="decision_014_3">
+                    <value xsi:type="xsd:string">D</value>
+                </component>
+                <component name="decisionService_014">
+                    <component name="decision_014_2">
+                        <value xsi:type="xsd:string">A B</value>
+                    </component>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
@@ -166,7 +166,9 @@
         <description>passing badly named param</description>
         <resultNode name="decision_010_1" type="decision" errorResult="true">
             <expected>
-                <value xsi:nil="true"/>
+                <component name="decision_010_2">
+                    <value xsi:nil="true"/>
+                </component>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
@@ -9,7 +9,7 @@
         <label>Decision Services</label>
     </labels>
 
-    <testCase id="001" decisionServiceName="decisionService_001" type="decisionService">
+    <testCase id="001" invocableName="decisionService_001" type="decisionService">
         <description>Direct invocation: with no params</description>
         <resultNode name="decision_001">
             <expected>
@@ -18,7 +18,7 @@
         </resultNode>
     </testCase>
 
-    <testCase id="002" decisionServiceName="decisionService_002" type="decisionService">
+    <testCase id="002" invocableName="decisionService_002" type="decisionService">
         <description>Direct invocation: with an input decision</description>
         <!-- we expect the input param value to 'override' the actual impl of 'decision_002_input' -->
         <inputNode name="decision_002_input">
@@ -35,7 +35,7 @@
     and the global input data will actually have the same value - so a little difficult to assert where input data value
     came from - param or global input -->
 
-    <testCase id="002_a" decisionServiceName="decisionService_002" type="decisionService" >
+    <testCase id="002_a" invocableName="decisionService_002" type="decisionService" >
         <description>Direct invocation:  with an input decision but supplying no param</description>
         <!-- requires decision_002_input but we're not providing it-->
         <resultNode name="decision_002" errorResult="true">
@@ -45,7 +45,7 @@
         </resultNode>
     </testCase>
 
-    <testCase id="002_b" decisionServiceName="decisionService_002" type="decisionService" >
+    <testCase id="002_b" invocableName="decisionService_002" type="decisionService" >
         <description>Direct invocation: with an input decision - but supplying a null value</description>
         <inputNode name="decision_002_input">
             <value xsi:nil="true"/>
@@ -58,7 +58,7 @@
         </resultNode>
     </testCase>
 
-    <testCase id="002_c" decisionServiceName="decisionService_002" type="decisionService" >
+    <testCase id="002_c" invocableName="decisionService_002" type="decisionService" >
         <description>Direct invocation: with an input decision - but supplying an incorrect param type</description>
         <!-- decision_002_input is a string type but we're providing a number so we expect it to be null-coerced -->
         <inputNode name="decision_002_input">
@@ -71,7 +71,7 @@
         </resultNode>
     </testCase>
 
-    <testCase id="003" decisionServiceName="decisionService_003" type="decisionService">
+    <testCase id="003" invocableName="decisionService_003" type="decisionService">
         <description>Direct invocation: with two input decisions and an input data</description>
         <!-- positive test -->
         <inputNode name="decision_003_input_1">

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
@@ -9,28 +9,24 @@
         <label>Decision Services</label>
     </labels>
 
-    <testCase id="001">
+    <testCase id="001" decisionServiceName="decisionService_001" type="decisionService">
         <description>Direct invocation: with no params</description>
-        <resultNode name="decisionService_001" type="decisionService">
+        <resultNode name="decision_001">
             <expected>
-                <component name="decision_001">
                     <value xsi:type="xsd:string">foo</value>
-                </component>
             </expected>
         </resultNode>
     </testCase>
 
-    <testCase id="002">
+    <testCase id="002" decisionServiceName="decisionService_002" type="decisionService">
         <description>Direct invocation: with an input decision</description>
         <!-- we expect the input param value to 'override' the actual impl of 'decision_002_input' -->
         <inputNode name="decision_002_input">
             <value xsi:type="xsd:string">baz</value>
         </inputNode>
-        <resultNode name="decisionService_002" type="decisionService">
+        <resultNode name="decision_002">
             <expected>
-                <component name="decision_002">
                     <value xsi:type="xsd:string">foo baz</value>
-                </component>
             </expected>
         </resultNode>
     </testCase>
@@ -39,47 +35,43 @@
     and the global input data will actually have the same value - so a little difficult to assert where input data value
     came from - param or global input -->
 
-    <testCase id="002_a">
+    <testCase id="002_a" decisionServiceName="decisionService_002" type="decisionService" >
         <description>Direct invocation:  with an input decision but supplying no param</description>
         <!-- requires decision_002_input but we're not providing it-->
-        <resultNode name="decisionService_002" type="decisionService" errorResult="true">
+        <resultNode name="decision_002" errorResult="true">
             <expected>
                 <value xsi:nil="true"/>
             </expected>
         </resultNode>
     </testCase>
 
-    <testCase id="002_b">
+    <testCase id="002_b" decisionServiceName="decisionService_002" type="decisionService" >
         <description>Direct invocation: with an input decision - but supplying a null value</description>
         <inputNode name="decision_002_input">
             <value xsi:nil="true"/>
         </inputNode>
         <!-- errorResult is true because of the string + null operation -->
-        <resultNode name="decisionService_002" type="decisionService" errorResult="true">
+        <resultNode name="decision_002" errorResult="true">
             <expected>
-                <component name="decision_002">
                     <value xsi:nil="true"/>
-                </component>
             </expected>
         </resultNode>
     </testCase>
 
-    <testCase id="002_c">
+    <testCase id="002_c" decisionServiceName="decisionService_002" type="decisionService" >
         <description>Direct invocation: with an input decision - but supplying an incorrect param type</description>
         <!-- decision_002_input is a string type but we're providing a number so we expect it to be null-coerced -->
         <inputNode name="decision_002_input">
             <value xsi:type="xsd:decimal">1234</value>
         </inputNode>
-        <resultNode name="decisionService_002" type="decisionService" errorResult="true">
+        <resultNode name="decision_002" errorResult="true">
             <expected>
-                <component name="decision_002">
                     <value xsi:nil="true"/>
-                </component>
             </expected>
         </resultNode>
     </testCase>
 
-    <testCase id="003">
+    <testCase id="003" decisionServiceName="decisionService_003" type="decisionService">
         <description>Direct invocation: with two input decisions and an input data</description>
         <!-- positive test -->
         <inputNode name="decision_003_input_1">
@@ -91,11 +83,9 @@
         <inputNode name="inputData_003">
             <value xsi:type="xsd:string">D</value>
         </inputNode>
-        <resultNode name="decisionService_003" type="decisionService">
+        <resultNode name="decision_003">
             <expected>
-                <component name="decision_003">
                     <value xsi:type="xsd:string">A B C D</value>
-                </component>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
@@ -10,6 +10,7 @@
     <!-- Direct invocation: no params -->
 
     <decisionService name="decisionService_001" id="_decisionService_001">
+        <variable name="decisionService_001"/>
         <outputDecision href="#_decision_001"/>
         <encapsulatedDecision href="#_decision_001"/>
     </decisionService>
@@ -24,6 +25,7 @@
     <!-- Direct invocation: an input decision param -->
 
     <decisionService name="decisionService_002" id="_decisionService_002">
+        <variable name="decisionService_002"/>
         <outputDecision href="#_decision_002"/>
         <encapsulatedDecision href="#_decision_002"/>
         <inputDecision href="#_decision_002_input"/>
@@ -49,6 +51,7 @@
     <!-- Direct invocation: with multiple input decision params and an input data -->
 
     <decisionService name="decisionService_003" id="_decisionService_003">
+        <variable name="decisionService_003"/>
         <outputDecision href="#_decision_003"/>
         <encapsulatedDecision href="#_decision_003"/>
         <inputDecision href="#_decision_003_input_1"/>
@@ -93,6 +96,7 @@
     <!-- with no params, when none are expected -->
 
     <decisionService name="decisionService_004" id="_decisionService_004">
+        <variable name="decisionService_004"/>
         <outputDecision href="#_decision_004_2"/>
         <encapsulatedDecision href="#_decision_004_2"/>
     </decisionService>
@@ -117,6 +121,7 @@
     <!-- passing a param when DS accepts none -->
 
     <decisionService name="decisionService_005" id="_decisionService_005">
+        <variable name="decisionService_005"/>
         <outputDecision href="#_decision_005_2"/>
         <encapsulatedDecision href="#_decision_005_2"/>
     </decisionService>
@@ -141,6 +146,7 @@
     <!-- passing a single input decision param -->
 
     <decisionService name="decisionService_006" id="_decisionService_006">
+        <variable name="decisionService_006"/>
         <outputDecision href="#_decision_006_2"/>
         <encapsulatedDecision href="#_decision_006_2"/>
         <inputDecision href="#_decision_006_3"/>
@@ -178,6 +184,7 @@
     <!-- passing an incorrect type value as single input decision param -->
 
     <decisionService name="decisionService_007" id="_decisionService_007">
+        <variable name="decisionService_007"/>
         <outputDecision href="#_decision_007_2"/>
         <encapsulatedDecision href="#_decision_007_2"/>
         <inputDecision href="#_decision_007_3"/>
@@ -215,6 +222,7 @@
     <!-- passing no params when expects a single param -->
 
     <decisionService name="decisionService_008" id="_decisionService_008">
+        <variable name="decisionService_008"/>
         <outputDecision href="#_decision_008_2"/>
         <encapsulatedDecision href="#_decision_008_2"/>
         <inputDecision href="#_decision_008_3"/>
@@ -251,6 +259,7 @@
     <!-- passing named param -->
 
     <decisionService name="decisionService_009" id="_decisionService_009">
+        <variable name="decisionService_009"/>
         <outputDecision href="#_decision_009_2"/>
         <encapsulatedDecision href="#_decision_009_2"/>
         <inputDecision href="#_decision_009_3"/>
@@ -287,6 +296,7 @@
     <!-- passing badly named param -->
 
     <decisionService name="decisionService_010" id="_decisionService_010">
+        <variable name="decisionService_010"/>
         <outputDecision href="#_decision_010_2"/>
         <encapsulatedDecision href="#_decision_010_2"/>
         <inputDecision href="#_decision_010_3"/>
@@ -323,6 +333,7 @@
     <!-- verify params accepted in correct order : passing two input decision and two input data -->
 
     <decisionService name="decisionService_011" id="_decisionService_011">
+        <variable name="decisionService_011"/>
         <outputDecision href="#_decision_011_2"/>
         <encapsulatedDecision href="#_decision_011_2"/>
         <inputDecision href="#_decision_011_3"/>
@@ -389,6 +400,7 @@
     <!-- verify named params accepted in correct order : passing two input decision and two input data -->
 
     <decisionService name="decisionService_012" id="_decisionService_012">
+        <variable name="decisionService_012"/>
         <outputDecision href="#_decision_012_2"/>
         <encapsulatedDecision href="#_decision_012_2"/>
         <inputDecision href="#_decision_012_3"/>
@@ -460,6 +472,7 @@
     on the global usage, and the other way around - global first to assert it had no effect on DS usage. -->
 
     <decisionService name="decisionService_013" id="_decisionService_013">
+        <variable name="decisionService_013"/>
         <outputDecision href="#_decision_013_2"/>
         <encapsulatedDecision href="#_decision_013_2"/>
         <inputDecision href="#_decision_013_3"/>
@@ -528,6 +541,7 @@
 
     <!-- same as 013 but with order of execution of DS /glocal reversed -->
     <decisionService name="decisionService_014" id="_decisionService_014">
+        <variable name="decisionService_014"/>
         <outputDecision href="#_decision_014_2"/>
         <encapsulatedDecision href="#_decision_014_2"/>
         <inputDecision href="#_decision_014_3"/>

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
@@ -87,7 +87,7 @@
     </decision>
 
     <inputData name="inputData_003" id="_inputData_003">
-        <variable name="inputData_003"/>
+        <variable name="inputData_003" typeRef="string"/>
     </inputData>
 
     <!-- with no params, when none are expected -->

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
@@ -1,0 +1,597 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0085-decision-services" name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA" xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <description>Decision Services</description>
+
+    <!-- Direct invocation: no params -->
+
+    <decisionService name="decisionService_001" id="_decisionService_001">
+        <outputDecision href="#_decision_001"/>
+        <encapsulatedDecision href="#_decision_001"/>
+    </decisionService>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001"/>
+        <literalExpression>
+            <text>"foo"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- Direct invocation: an input decision param -->
+
+    <decisionService name="decisionService_002" id="_decisionService_002">
+        <outputDecision href="#_decision_002"/>
+        <encapsulatedDecision href="#_decision_002"/>
+        <inputDecision href="#_decision_002_input"/>
+    </decisionService>
+
+    <decision name="decision_002" id="_decision_002">
+        <variable name="decision_002"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_002_input"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"foo " + decision_002_input</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_002_input" id="_decision_002_input">
+        <variable name="decision_002_input"/>
+        <literalExpression>
+            <text>"bar"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- Direct invocation: with multiple input decision params and an input data -->
+
+    <decisionService name="decisionService_003" id="_decisionService_003">
+        <outputDecision href="#_decision_003"/>
+        <encapsulatedDecision href="#_decision_003"/>
+        <inputDecision href="#_decision_003_input_1"/>
+        <inputDecision href="#_decision_003_input_2"/>
+        <inputData href="#_inputData_003"/>
+    </decisionService>
+
+    <decision name="decision_003" id="_decision_003">
+        <variable name="decision_003"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_003_input_1"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredDecision href="#_decision_003_input_2"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_003"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"A " + decision_003_input_1 + " " + decision_003_input_2 + " " + inputData_003</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_003_input_1" id="_decision_003_input_1">
+        <variable name="decision_003_input_1"/>
+        <literalExpression>
+            <text>"d3_1"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_003_input_2" id="_decision_003_input_2">
+        <variable name="decision_003_input_2"/>
+        <literalExpression>
+            <text>"d3_2"</text>
+        </literalExpression>
+    </decision>
+
+    <inputData name="inputData_003" id="_inputData_003">
+        <variable name="inputData_003"/>
+    </inputData>
+
+    <!-- with no params, when none are expected -->
+
+    <decisionService name="decisionService_004" id="_decisionService_004">
+        <outputDecision href="#_decision_004_2"/>
+        <encapsulatedDecision href="#_decision_004_2"/>
+    </decisionService>
+
+    <decision name="decision_004_1" id="_decision_004_1">
+        <variable name="decision_004_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_004"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_004()</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_004_2" id="_decision_004_2">
+        <variable name="decision_004_2"/>
+        <literalExpression>
+            <text>"foo"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- passing a param when DS accepts none -->
+
+    <decisionService name="decisionService_005" id="_decisionService_005">
+        <outputDecision href="#_decision_005_2"/>
+        <encapsulatedDecision href="#_decision_005_2"/>
+    </decisionService>
+
+    <decision name="decision_005_1" id="_decision_005_1">
+        <variable name="decision_005_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_005"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_005("bar")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_005_2" id="_decision_005_2">
+        <variable typeRef="string" name="decision_005_2"/>
+        <literalExpression>
+            <text>"foo"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- passing a single input decision param -->
+
+    <decisionService name="decisionService_006" id="_decisionService_006">
+        <outputDecision href="#_decision_006_2"/>
+        <encapsulatedDecision href="#_decision_006_2"/>
+        <inputDecision href="#_decision_006_3"/>
+    </decisionService>
+
+    <decision name="decision_006_1" id="_decision_006_1">
+        <variable name="decision_006_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_006"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_006("bar")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_006_2" id="_decision_006_2">
+        <variable name="decision_006_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_006_3"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"foo " + decision_006_3</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_006_3" id="_decision_006_3">
+        <variable typeRef="string" name="decision_006_3"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+
+    <!-- passing an incorrect type value as single input decision param -->
+
+    <decisionService name="decisionService_007" id="_decisionService_007">
+        <outputDecision href="#_decision_007_2"/>
+        <encapsulatedDecision href="#_decision_007_2"/>
+        <inputDecision href="#_decision_007_3"/>
+    </decisionService>
+
+    <decision name="decision_007_1" id="_decision_007_1">
+        <variable name="decision_007_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_007"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_007(123)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_007_2" id="_decision_007_2">
+        <variable name="decision_007_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_007_3"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision_007_3 = null</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_007_3" id="_decision_007_3">
+        <variable typeRef="string" name="decision_007_3"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+
+    <!-- passing no params when expects a single param -->
+
+    <decisionService name="decisionService_008" id="_decisionService_008">
+        <outputDecision href="#_decision_008_2"/>
+        <encapsulatedDecision href="#_decision_008_2"/>
+        <inputDecision href="#_decision_008_3"/>
+    </decisionService>
+
+    <decision name="decision_008_1" id="_decision_008_1">
+        <variable name="decision_008_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_008"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_008()</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_008_2" id="_decision_008_2">
+        <variable name="decision_008_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_008_3"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision_008_3 = null</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_008_3" id="_decision_008_3">
+        <variable typeRef="string" name="decision_008_3"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- passing named param -->
+
+    <decisionService name="decisionService_009" id="_decisionService_009">
+        <outputDecision href="#_decision_009_2"/>
+        <encapsulatedDecision href="#_decision_009_2"/>
+        <inputDecision href="#_decision_009_3"/>
+    </decisionService>
+
+    <decision name="decision_009_1" id="_decision_009_1">
+        <variable name="decision_009_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_009"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_009(decision_009_3: "bar")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_009_2" id="_decision_009_2">
+        <variable name="decision_009_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_009_3"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"foo " + decision_009_3</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_009_3" id="_decision_009_3">
+        <variable typeRef="string" name="decision_009_3"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- passing badly named param -->
+
+    <decisionService name="decisionService_010" id="_decisionService_010">
+        <outputDecision href="#_decision_010_2"/>
+        <encapsulatedDecision href="#_decision_010_2"/>
+        <inputDecision href="#_decision_010_3"/>
+    </decisionService>
+
+    <decision name="decision_010_1" id="_decision_010_1">
+        <variable name="decision_010_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_010"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_010(foo: "bar")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_010_2" id="_decision_010_2">
+        <variable name="decision_010_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_010_3"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"foo " + decision_010_3</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_010_3" id="_decision_010_3">
+        <variable typeRef="string" name="decision_010_3"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- verify params accepted in correct order : passing two input decision and two input data -->
+
+    <decisionService name="decisionService_011" id="_decisionService_011">
+        <outputDecision href="#_decision_011_2"/>
+        <encapsulatedDecision href="#_decision_011_2"/>
+        <inputDecision href="#_decision_011_3"/>
+        <inputDecision href="#_decision_011_4"/>
+        <inputData href="#_inputData_011_1"/>
+        <inputData href="#_inputData_011_2"/>
+    </decisionService>
+
+    <decision name="decision_011_1" id="_decision_011_1">
+        <variable name="decision_011_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_011"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_011("A", "B", "C", "D")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_011_2" id="_decision_011_2">
+        <variable typeRef="string" name="decision_011_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_011_3"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredDecision href="#_decision_011_4"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_011_1"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_011_2"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>inputData_011_1 + " " + inputData_011_2 + " " + decision_011_3 + " " + decision_011_4</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_011_3" id="_decision_011_3">
+        <variable typeRef="string" name="decision_011_3"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_011_4" id="_decision_011_4">
+        <variable typeRef="string" name="decision_011_4"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <inputData name="inputData_011_1" id="_inputData_011_1">
+        <variable name="inputData_011_1" typeRef="string"/>
+    </inputData>
+
+    <!-- provided as input, so never gets invoked -->
+    <inputData name="inputData_011_2" id="_inputData_011_2">
+        <variable name="inputData_011_2" typeRef="string"/>
+    </inputData>
+
+    <!-- verify named params accepted in correct order : passing two input decision and two input data -->
+
+    <decisionService name="decisionService_012" id="_decisionService_012">
+        <outputDecision href="#_decision_012_2"/>
+        <encapsulatedDecision href="#_decision_012_2"/>
+        <inputDecision href="#_decision_012_3"/>
+        <inputDecision href="#_decision_012_4"/>
+        <inputData href="#_inputData_012_1"/>
+        <inputData href="#_inputData_012_2"/>
+    </decisionService>
+
+    <decision name="decision_012_1" id="_decision_012_1">
+        <variable name="decision_012_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_012"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_012(decision_012_3: "C", inputData_012_1: "A", decision_012_4: "D", inputData_012_2: "B")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_012_2" id="_decision_012_2">
+        <variable typeRef="string" name="decision_012_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_012_3"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredDecision href="#_decision_012_4"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_012_1"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_012_2"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>inputData_012_1 + " " + inputData_012_2 + " " + decision_012_3 + " " + decision_012_4</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_012_3" id="_decision_012_3">
+        <variable typeRef="string" name="decision_012_3"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <decision name="decision_012_4" id="_decision_012_4">
+        <variable typeRef="string" name="decision_012_4"/>
+        <literalExpression>
+            <text>"I never get invoked"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- provided as input, so never gets invoked -->
+    <inputData name="inputData_012_1" id="_inputData_012_1">
+        <variable name="inputData_012_1" typeRef="string"/>
+    </inputData>
+
+    <!-- provided as input, so never gets invoked -->
+    <inputData name="inputData_012_2" id="_inputData_012_2">
+        <variable name="inputData_012_2" typeRef="string"/>
+    </inputData>
+
+    <!-- verify input decision or data has no bearing on 'global' usage of same decision or input.
+    That is, the usage of input decision and data is 'scoped' to within the DS.  To show this
+    we'll pass input decision and data to DS AND we'll also use them outside of the DS -->
+
+    <!-- We'll do two similar tests for this.  One that executes the DS first to assert it had no effect
+    on the global usage, and the other way around - global first to assert it had no effect on DS usage. -->
+
+    <decisionService name="decisionService_013" id="_decisionService_013">
+        <outputDecision href="#_decision_013_2"/>
+        <encapsulatedDecision href="#_decision_013_2"/>
+        <inputDecision href="#_decision_013_3"/>
+        <inputData href="#_inputData_013_1"/>
+    </decisionService>
+
+    <!-- invoke DS using input decision and data, then also use same decision and input _outside_ of the DS -->
+    <decision name="decision_013_1" id="_decision_013_1">
+        <variable name="decision_013_1"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_013_3"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_013_1"/>
+        </informationRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_013"/>
+        </knowledgeRequirement>
+        <context>
+            <contextEntry>
+                <variable name="decisionService_013"/>
+                <literalExpression>
+                    <text>decisionService_013("A", "B")</text>
+                </literalExpression>
+            </contextEntry>
+            <contextEntry>
+                <variable name="inputData_013_1"/>
+                <literalExpression>
+                    <text>inputData_013_1</text>
+                </literalExpression>
+            </contextEntry>
+            <contextEntry>
+                <variable name="decision_013_3"/>
+                <literalExpression>
+                    <text>decision_013_3</text>
+                </literalExpression>
+            </contextEntry>
+        </context>
+    </decision>
+
+    <!-- invoked from DS with input decicion and data -->
+    <decision name="decision_013_2" id="_decision_013_2">
+        <variable typeRef="string" name="decision_013_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_013_3"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_013_1"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>inputData_013_1 + " " + decision_013_3</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_013_3" id="_decision_013_3">
+        <variable typeRef="string" name="decision_013_3"/>
+        <literalExpression>
+            <text>"D"</text>
+        </literalExpression>
+    </decision>
+
+    <inputData name="inputData_013_1" id="_inputData_013_1">
+        <variable name="inputData_013_1" typeRef="string"/>
+    </inputData>
+
+
+    <!-- same as 013 but with order of execution of DS /glocal reversed -->
+    <decisionService name="decisionService_014" id="_decisionService_014">
+        <outputDecision href="#_decision_014_2"/>
+        <encapsulatedDecision href="#_decision_014_2"/>
+        <inputDecision href="#_decision_014_3"/>
+        <inputData href="#_inputData_014_1"/>
+    </decisionService>
+
+    <!-- invoke DS using input decision and data, then also use same decision and input _outside_ of the DS -->
+    <decision name="decision_014_1" id="_decision_014_1">
+        <variable name="decision_014_1"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_014_3"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_014_1"/>
+        </informationRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_014"/>
+        </knowledgeRequirement>
+        <context>
+            <contextEntry>
+                <variable name="inputData_014_1"/>
+                <literalExpression>
+                    <text>inputData_014_1</text>
+                </literalExpression>
+            </contextEntry>
+            <contextEntry>
+                <variable name="decision_014_3"/>
+                <literalExpression>
+                    <text>decision_014_3</text>
+                </literalExpression>
+            </contextEntry>
+            <contextEntry>
+                <variable name="decisionService_014"/>
+                <literalExpression>
+                    <text>decisionService_014("A", "B")</text>
+                </literalExpression>
+            </contextEntry>
+        </context>
+    </decision>
+
+    <!-- invoked from DS with input decision and data -->
+    <decision name="decision_014_2" id="_decision_014_2">
+        <variable typeRef="string" name="decision_014_2"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_014_3"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="#_inputData_014_1"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>inputData_014_1 + " " + decision_014_3</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_014_3" id="_decision_014_3">
+        <variable typeRef="string" name="decision_014_3"/>
+        <literalExpression>
+            <text>"D"</text>
+        </literalExpression>
+    </decision>
+
+    <inputData name="inputData_014_1" id="_inputData_014_1">
+        <variable name="inputData_014_1" typeRef="string"/>
+    </inputData>
+
+
+</definitions>


### PR DESCRIPTION
Re-done DS tests!  I really didn't quite 'get it' last time I submitted tests.  Hopefully this time I do.  :-)   

I have tested for both 'direct' invocation (calling it directly from the test suite like it was a 'microservice'), as well as 'indirect' (which is calling it from another DRG element - in this case, decisions).   The 'direct' tests are fairly separate in case this causes issues.  

... but, I think it is really worth asserting that a DS can be called as a root level element like a decision.  Hopefully that causes no issues with people's tests runners - mine required no alteration so hopefully others are the same.

I have asserted on similar stuff to normal BKM/functions, like correct params, no params, named params, badly-name params, too many params, incorrect type params. etc.

I have also asserted on param _order_ as this comes from the DS inputs, not from formal params.  Positional and named params both get tests to assert params are interprested in the correct order as per "Semantics of Decision Services".

Param types also gets asserted as the formal params for a DS get their types from input decision/data.

I have added two tests to assert no 'bleed through' occurs for DS params and their 'global' counterparts.  That is, even though a DS is invoked with (say) a input decision value, the actual decision can still be used outside of a DS normally.  And vice versa.  These tests are really to assert that a DS 'scopes' its input decisions/data params and they have no influence on the actual decisions/data.  

As this stuff can be confusing to follow through in XML I have kept the tests as simple as I can and completely isolated from each other. 

Comments welcome.  If you can think of any more tests that might be relevant, let me know.

Greg.

PS, thanks @opatrascoiu and @tarilabs for the assistance in getting my head around it. The clincher was realising that `encapsulatedDecisions` represents every decision in the _entire_ DS call tree.

PPS.  We really ought to consider a 'DMN validation' tool to verify correctness beyond just schema conformance. 