### PR TITLE
0086-imports

### DIFF
--- a/TestCases/compliance-level-3/0086-imports/0086-imports-02.dmn
+++ b/TestCases/compliance-level-3/0086-imports/0086-imports-02.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0086-imports"
+             name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <description>Imports 01</description>
+
+    <import name="i"
+            namespace="http://montera.com.au/imports"
+            locationURI="02/import1.dmn"
+            importType="http://www.omg.org/spec/DMN/20180521/MODEL/"/>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://montera.com.au/imports#_decision_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"0 -> " + i.decision_001</text>
+        </literalExpression>
+    </decision>
+
+</definitions>

--- a/TestCases/compliance-level-3/0086-imports/0086-imports-test-01.xml
+++ b/TestCases/compliance-level-3/0086-imports/0086-imports-test-01.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <modelName>0086-imports.dmn</modelName>
+    <labels>
+        <label>Compliance Level 3</label>
+        <label>Imports</label>
+    </labels>
+
+    <testCase id="001">
+        <description>Decision can reference an imported decision</description>
+        <resultNode name="decision_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">decision_001 in import1</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>Decision can reference an imported BKM</description>
+        <resultNode name="decision_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">foo</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+<!--    <testCase id="003">
+        <description>Reference an imported inputData</description>
+        <inputNode name="import1.inputData_001">
+            <value xsi:type="xsd:string">foo</value>
+        </inputNode>
+        <resultNode name="decision_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">foo</value>
+            </expected>
+        </resultNode>
+    </testCase>-->
+
+    <testCase id="004">
+        <description>Decision can reference an imported decisionService</description>
+        <!-- note that the imported DS uses a outputDecision ref for an id that exists both in the
+        imported AND importing model.  We expect the DS to use the 'local' decision  -->
+        <resultNode name="decision_004" type="decision">
+            <expected>
+                <component name="decision_001">
+                    <value xsi:type="xsd:string">decision_001 in import1</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005">
+        <description>Decision can reference an imported decisionService passing param by name/positional</description>
+        <resultNode name="decision_005" type="decision">
+            <expected>
+                <component name="i.decision_002">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="006">
+        <description>BKM can reference an imported BKM</description>
+        <resultNode name="decision_006" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">foo</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="007">
+        <description>BKM can reference an imported Decision Service</description>
+        <resultNode name="decision_007" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">decision_001 in import1</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="008">
+        <description>Decision can reference an imported typeRef</description>
+        <!-- imported type is a string list and the decision returns a string - so we're
+        expecting coercion -->
+        <resultNode name="decision_008" type="decision">
+            <expected>
+                <list>
+                    <item>
+                        <value xsi:type="xsd:string">foo</value>
+                    </item>
+                </list>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="009">
+        <description>Item definition can reference an imported typeRef</description>
+        <!-- imported type is a string list and the decision returns a string - so we're
+        expecting coercion -->
+        <resultNode name="decision_009" type="decision">
+            <expected>
+                <list>
+                    <item>
+                        <value xsi:type="xsd:string">foo</value>
+                    </item>
+                </list>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/0086-imports/0086-imports-test-02.xml
+++ b/TestCases/compliance-level-3/0086-imports/0086-imports-test-02.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <modelName>0086-imports-02.dmn</modelName>
+    <labels>
+        <label>Compliance Level 3</label>
+        <label>Imports</label>
+    </labels>
+
+    <testCase id="001">
+        <description>Deeply reference imported decisions</description>
+        <resultNode name="decision_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">0 -> i1 -> i2 -> i3</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/0086-imports/0086-imports.dmn
+++ b/TestCases/compliance-level-3/0086-imports/0086-imports.dmn
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0086-imports"
+             name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <description>Imports 01</description>
+
+    <import name="i"
+            namespace="http://montera.com.au/imports"
+            locationURI="01/import1.dmn"
+            importType="http://www.omg.org/spec/DMN/20180521/MODEL/"/>
+
+    <itemDefinition name="fooType" id="_fooType">
+        <typeRef>i.tStringList</typeRef>
+    </itemDefinition>
+
+    <!-- A decision using an imported decision -->
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://montera.com.au/imports#_decision_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>i.decision_001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- *************************** -->
+
+    <!-- A decision using an imported BKM -->
+
+    <decision name="decision_002" id="_decision_002">
+        <variable name="decision_002" typeRef="string"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="http://montera.com.au/imports#_bkm_001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>i.bkm_001("foo")</text>
+        </literalExpression>
+    </decision>
+
+    <!-- *************************** -->
+
+    <!-- A decision using an imported InputData -->
+
+<!--
+    <decision name="decision_003" id="_decision_003">
+        <variable name="decision_003" typeRef="string"/>
+        <informationRequirement>
+            <requiredInput href="http://montera.com.au/imports#_inputData_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>i.inputData_001</text>
+        </literalExpression>
+    </decision>
+-->
+
+    <!-- *************************** -->
+
+    <!-- A decision using an imported Decision Service -->
+
+    <decision name="decision_004" id="_decision_004">
+        <variable name="decision_004"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="http://montera.com.au/imports#_decisionService_001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>i.decisionService_001()</text>
+        </literalExpression>
+    </decision>
+
+    <!-- *************************** -->
+
+    <!-- A DS using an imported decision pass a param by name -->
+
+    <decisionService name="decisionService_005" id="_decisionService_005">
+        <variable name="decisionService_005"/>
+        <outputDecision href="http://montera.com.au/imports#_decision_002"/>
+        <encapsulatedDecision href="http://montera.com.au/imports#_decision_002"/>
+        <inputDecision href="http://montera.com.au/imports#_decision_003"/>
+    </decisionService>
+
+    <decision name="decision_005" id="_decision_005">
+        <variable name="decision_005"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_005"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decisionService_005(i.decision_003: "foo")</text>
+        </literalExpression>
+    </decision>
+
+    <!-- *************************** -->
+
+    <!-- a BKM that using an imported BKM -->
+
+    <businessKnowledgeModel name="bkm_006" id="_bkm_006">
+        <variable name="bkm_006" typeRef="string"/>
+        <encapsulatedLogic>
+            <formalParameter typeRef="string" name="val"/>
+            <literalExpression>
+                <text>i.bkm_001(val)</text>
+            </literalExpression>
+        </encapsulatedLogic>
+        <knowledgeRequirement>
+            <requiredKnowledge href="http://montera.com.au/imports#_bkm_001"/>
+        </knowledgeRequirement>
+    </businessKnowledgeModel>
+
+    <decision name="decision_006" id="_decision_006">
+        <variable name="decision_006" typeRef="string"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_006"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <!-- calls a BKM, that calls an imported BKM -->
+            <text>bkm_006("foo")</text>
+        </literalExpression>
+    </decision>
+
+    <!-- *************************** -->
+
+    <!-- a BKM using an imported DS -->
+
+    <businessKnowledgeModel name="bkm_007" id="_bkm_007">
+        <variable name="bkm_007" typeRef="string"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>i.decisionService_001().decision_001</text>
+            </literalExpression>
+        </encapsulatedLogic>
+        <knowledgeRequirement>
+            <requiredKnowledge href="http://montera.com.au/imports#_decisionService_001"/>
+        </knowledgeRequirement>
+    </businessKnowledgeModel>
+
+    <decision name="decision_007" id="_decision_007">
+        <variable name="decision_007" typeRef="string"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_007"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <!-- calls a no-args BKM, that calls an imported (no-args) DS -->
+            <text>bkm_007()</text>
+        </literalExpression>
+    </decision>
+
+    <!-- *************************** -->
+
+    <!-- a Decision using an imported typeRef -->
+
+    <decision name="decision_008" id="_decision_008">
+        <variable name="decision_008" typeRef="i.tStringList"/>
+        <literalExpression>
+            <text>"foo"</text>
+        </literalExpression>
+    </decision>
+
+
+    <!-- *************************** -->
+
+    <!-- a Decision using a (local) typeRef that, in turn, uses imported typeRef -->
+
+    <decision name="decision_009" id="_decision_009">
+        <variable name="decision_009" typeRef="fooType"/>
+        <literalExpression>
+            <text>"foo"</text>
+        </literalExpression>
+    </decision>
+
+
+
+</definitions>

--- a/TestCases/compliance-level-3/0086-imports/01/import1.dmn
+++ b/TestCases/compliance-level-3/0086-imports/01/import1.dmn
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="https://github.com/agilepro/dmn-tck"
+             name="0001-input-data-string"
+             id="_0001-input-data-string"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <itemDefinition name="tStringList" isCollection="true">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <literalExpression>
+            <text>"decision_001 in import1"</text>
+        </literalExpression>
+    </decision>
+
+    <businessKnowledgeModel name="bkm_001" id="_bkm_001">
+        <variable name="bkm_001" typeRef="string"/>
+        <encapsulatedLogic>
+            <formalParameter typeRef="string" name="val"/>
+            <literalExpression>
+                <text>val</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <inputData name="inputData_001" id="_inputData_001">
+        <variable name="inputData_001" typeRef="string"/>
+    </inputData>
+
+    <decisionService name="decisionService_001" id="_decisionService_001">
+        <variable name="decisionService_001"/>
+        <outputDecision href="#_decision_001"/>
+        <encapsulatedDecision href="#_decision_001"/>
+    </decisionService>
+
+    <!-- ********************** -->
+
+    <decision name="decision_002" id="_decision_002">
+        <variable name="decision_002" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_003"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision_003</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_003" id="_decision_003">
+        <variable name="decision_003" typeRef="string"/>
+        <literalExpression>
+            <text>"bar"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/0086-imports/02/import1.dmn
+++ b/TestCases/compliance-level-3/0086-imports/02/import1.dmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0086-imports"
+             name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <description>Import 01</description>
+
+    <import name="i"
+            namespace="http://montera.com.au/imports"
+            locationURI="import2.dmn"
+            importType="http://www.omg.org/spec/DMN/20180521/MODEL/"/>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://montera.com.au/imports#_decision_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"i1 -> " + i.decision_001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>

--- a/TestCases/compliance-level-3/0086-imports/02/import2.dmn
+++ b/TestCases/compliance-level-3/0086-imports/02/import2.dmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0086-imports"
+             name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <description>Import 02</description>
+
+    <import name="i"
+            namespace="http://montera.com.au/imports"
+            locationURI="import3.dmn"
+            importType="http://www.omg.org/spec/DMN/20180521/MODEL/"/>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://montera.com.au/imports#_decision_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"i2 -> " + i.decision_001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>

--- a/TestCases/compliance-level-3/0086-imports/02/import3.dmn
+++ b/TestCases/compliance-level-3/0086-imports/02/import3.dmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0086-imports"
+             name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <description>Import 03</description>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <literalExpression>
+            <text>"i3"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>


### PR DESCRIPTION
All, some initial tests for imports covering much of the basics - with some notable exceptions that I will raise an issue on - namely on importing 'InputData'.

Apols in advance for the lots-of-words here.

In reading these tests, or indeed, trying to get to grips with the imports spec there is one key factor in it all and it is important I think to understand this from the start:

> the spec only defines uniqueness to _within_ a given model, not _across_ models.  

Such that:

* id's are unique to a model only.  So imported models can have elements with the same ids as the importing model or other sibling imported models or their own imports. 
* names are unique to model only, so same applies as with ids.

And _very_ importantly I feel:

> an import element namespace and name are only relevant _inside_ the model it is defined in.
  
That is, say, a model `A.dmn` can have an import element like the following to import (say) model `B.dmn`:

`<import namespace="http://foo" name="i" locationURI="B.dmn" importType="...etc"/>`

And the `namespace` and `name` are what model A uses to refer to stuff in model B. 

**however**, model `B.dmn` is permitted to have the following to import (say) `C.dmn`:

`<import namespace="http://foo" name="i" locationURI="C.dmn" importType="...etc"/>`

And the `namespace` and `name` are what model B uses to refer to stuff in model C.

But note that namespace/name they may also be the _same_ amongst models - so they are also 'model local'.  The spec says an import namespace - _should_ be globally unique, but there is no way to guarantee it of course.  Actually, the spec says in "12.3.1 Document Structure":

> "Each file SHALL declare a “namespace” that MAY differ between multiple files of one model."

So, treating the namespace of a dmn as unique across models is not a great idea.

Also important to note is the `locationURI` property on the import element is optional - but, for the sake of these tests, imports use a locationURI.

So, taking all the above into account, these tests use duplicate name in models and also duplicate import namespace and names.  This is not to complicate things, but it purposeful in order to help flesh out issues with how a runtime may identify and use drg elements.

The thing that is not tested here as yet is how to deal with InputData in imported models, and the InputData from their imported models, and their imports in turn and so on.   I'll raise an issue to discuss.

All comments welcome.
