### PR TITLE
non-compliant: 0088-recursion

### DIFF
--- a/TestCases/non-compliant/0088-recursion/0088-recursion-test-01.xml
+++ b/TestCases/non-compliant/0088-recursion/0088-recursion-test-01.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=""  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <modelName>0088-recursion.dmn</modelName>
+    <labels>
+        <label>Recursion</label>
+    </labels>
+
+    <testCase id="001">
+        <description>fibonacci sequence fn(10)</description>
+        <resultNode name="fibonacci_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">55</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+    <testCase id="002">
+        <description>input data tree traversal using self referencing datatype</description>
+        <inputNode name="treeData">
+            <component name="children">
+                <list>
+                    <item>
+                        <component name="children">
+                            <list>
+                                <item>
+                                    <component name="children">
+                                        <list></list>
+                                    </component>
+                                    <component name="value">
+                                        <value xsi:type="xsd:decimal">4</value>
+                                    </component>
+                                </item>
+                                <item>
+                                    <component name="children">
+                                        <list></list>
+                                    </component>
+                                    <component name="value">
+                                        <value xsi:type="xsd:decimal">5</value>
+                                    </component>
+                                </item>
+                            </list>
+                        </component>
+                        <component name="value">
+                            <value xsi:type="xsd:decimal">2</value>
+                        </component>
+                    </item>
+                    <item>
+                        <component name="children">
+                            <list>
+                                <item>
+                                    <component name="children">
+                                        <list></list>
+                                    </component>
+                                    <component name="value">
+                                        <value xsi:type="xsd:decimal">6</value>
+                                    </component>
+                                </item>
+                                <item>
+                                    <component name="children">
+                                        <list></list>
+                                    </component>
+                                    <component name="value">
+                                        <value xsi:type="xsd:decimal">7</value>
+                                    </component>
+                                </item>
+                            </list>
+                        </component>
+                        <component name="value">
+                            <value xsi:type="xsd:decimal">3</value>
+                        </component>
+                    </item>
+                </list>
+            </component>
+            <component name="value">
+                <value xsi:type="xsd:decimal">1</value>
+            </component>
+        </inputNode>
+        <resultNode name="tree_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">28</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/non-compliant/0088-recursion/0088-recursion.dmn
+++ b/TestCases/non-compliant/0088-recursion/0088-recursion.dmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0088-reursion" name="0088-reursion" id="_i9fboPUUEeesLuP4RHs4vA" xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <description>Recursion</description>
+
+    <itemDefinition name="iTreeNode">
+        <itemComponent name="children" isCollection="true">
+            <!-- self reference type -->
+            <typeRef>iTreeNode</typeRef>
+        </itemComponent>
+        <itemComponent name="value">
+            <typeRef>number</typeRef>
+        </itemComponent>
+    </itemDefinition>
+
+    <businessKnowledgeModel name="fibonacci" id="_fibonacci">
+        <variable name="fibonacci"/>
+        <encapsulatedLogic>
+            <formalParameter name="num" typeRef="number"/>
+            <literalExpression>
+                <text>if (num &lt; 2) then num else (fibonacci(num - 1) + fibonacci(num - 2))</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="fibonacci_001" id="_fibonacci_001">
+        <variable name="fibonacci_001"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_fibonacci"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>fibonacci(10)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- ***************** -->
+
+    <businessKnowledgeModel name="scanTree" id="_scanTree">
+        <variable name="scanTree"/>
+        <encapsulatedLogic>
+            <formalParameter name="node" typeRef="iTreeNode"/>
+            <literalExpression>
+                <text>if (count(node.children) = 0)
+                    then
+                        node.value
+                    else
+                        node.value + sum(for n in node.children return scanTree(n))</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <inputData name="treeData" id="_treeData">
+        <variable name="treeData" typeRef="iTreeNode"/>
+    </inputData>
+
+    <decision name="tree_001" id="_tree_001">
+        <variable name="tree_001"/>
+        <informationRequirement>
+            <requiredInput href="#_treeData"/>
+        </informationRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_scanTree"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>scanTree(treeData)</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+


### PR DESCRIPTION
All, though the rebooking model in non-compliant exercises recursion, I thought it best to put in some specific tests.

The recursion here is in two flavours.  

One is a basic fibonacci test.  

The other is a little more interesting: it is recursive to depth-first traverse a tree structure, but also defines a typeRef that is 'self referencing' to create a tree type has children of the same type as itself.

The spec does not provide a 'well-formed' definition for ItemDefinition nor contains any references that I could find to it being acyclic so I am pretty sure a self-referencing structure is legal.

Comments welcome.