### PR TITLE
0086a-imports-input

### DIFF
--- a/TestCases/compliance-level-3/0086a-imports-input/0086a-imports-input-test-01.xml
+++ b/TestCases/compliance-level-3/0086a-imports-input/0086a-imports-input-test-01.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <modelName>0086a-imports-input.dmn</modelName>
+    <labels>
+        <label>Compliance Level 3</label>
+        <label>Imports</label>
+    </labels>
+
+    <testCase id="001">
+        <description>
+            Model 'A' with a local decision with a local inputData and
+            references a decision in model 'B', that also has a local input and
+            references a decision in model 'C' that also has a local input.
+            Model A imports Model B with name 'i' and model B imports model C with name 'i'.
+            Model A _also_ imports Model C directly with name 'x' and references it.
+        </description>
+        <inputNode name="input_001">
+            <value xsi:type="xsd:string">modelA</value>
+        </inputNode>
+        <inputNode name="i.input_001">
+            <value xsi:type="xsd:string">modelB</value>
+        </inputNode>
+        <inputNode name="i.i.input_001">
+            <value xsi:type="xsd:string">modelC</value>
+        </inputNode>
+        <inputNode name="x.input_001">
+            <value xsi:type="xsd:string">x.modelC</value>
+        </inputNode>
+        <resultNode name="decision_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">modelA modelB modelB modelC modelC, x.modelC x.modelC</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/0086a-imports-input/0086a-imports-input.dmn
+++ b/TestCases/compliance-level-3/0086a-imports-input/0086a-imports-input.dmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0086-imports"
+             name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <description>Model 'A'</description>
+
+    <import name="i"
+            namespace="http://montera.com.au/imports"
+            locationURI="modelB.dmn"
+            importType="http://www.omg.org/spec/DMN/20180521/MODEL/"/>
+
+    <import name="x"
+            namespace="http://montera.com.au/import_c"
+            locationURI="modelC.dmn"
+            importType="http://www.omg.org/spec/DMN/20180521/MODEL/"/>
+
+    <inputData name="input_001" id="_input_001">
+        <variable name="input_001"/>
+    </inputData>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <informationRequirement>
+            <requiredInput href="#_input_001"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="http://montera.com.au/imports#_input_001"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="http://montera.com.au/import_c#_input_001"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredDecision href="http://montera.com.au/imports#_decision_001"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredDecision href="http://montera.com.au/import_c#_decision_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input_001 + " " + i.input_001 + " " + i.decision_001 + ", " + x.input_001 + " " + x.decision_001</text>
+        </literalExpression>
+    </decision>
+
+</definitions>

--- a/TestCases/compliance-level-3/0086a-imports-input/modelB.dmn
+++ b/TestCases/compliance-level-3/0086a-imports-input/modelB.dmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0086-imports"
+             name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <description>Model 'B'</description>
+
+    <import name="i"
+            namespace="http://montera.com.au/imports"
+            locationURI="modelC.dmn"
+            importType="http://www.omg.org/spec/DMN/20180521/MODEL/"/>
+
+    <inputData name="input_001" id="_input_001">
+        <variable name="input_001"/>
+    </inputData>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <informationRequirement>
+            <requiredInput href="#_input_001"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="http://montera.com.au/imports#_input_001"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredDecision href="http://montera.com.au/imports#_decision_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input_001 + " " + i.input_001 + " " + i.decision_001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>

--- a/TestCases/compliance-level-3/0086a-imports-input/modelC.dmn
+++ b/TestCases/compliance-level-3/0086a-imports-input/modelC.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0086-imports"
+             name="0085-decision-services"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <description>Model 'C'</description>
+
+    <inputData name="input_001" id="_input_001">
+        <variable name="input_001"/>
+    </inputData>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001" typeRef="string"/>
+        <informationRequirement>
+            <requiredInput href="#_input_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input_001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>


### PR DESCRIPTION
An import input data test to cover what is discussed over here: https://github.com/dmn-tck/tck/issues/274.

This suite is pretty compact - it is actually only one test.  It has three models A, B and C.  A imports B as 'i', and B imports C as 'i'.  A _also_ imports C directly as 'x'.

A has a decision that uses a local inputData and also the a decision/inputData from B.  That decision in B also uses a 'local' inputData and the a decision/inputData in C.  The decision in C uses a 'local' inputData.

The decision in A _also_ uses the decision/inputData and decision from C directly.

The inputNode to the test is structured to support that.

Phew.   