### PR TITLE
0090-feel-paths

### DIFF
--- a/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths-test-01.xml
+++ b/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths-test-01.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=""  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>0090-feel-paths.dmn</modelName>
+    <labels>
+        <label>Compliance Level 3</label>
+        <label>FEEL Paths</label>
+        <label>FEEL Qualified Names</label>
+    </labels>
+
+    <testCase id="nested_list_001">
+        <description>Spec 'nested list' example - 1</description>
+        <resultNode name="nested_list_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="nested_list_002">
+        <description>Spec 'nested list' example - 2</description>
+        <resultNode name="nested_list_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths.dmn
+++ b/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths.dmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0090-feel-paths" name="0090-feel-paths" id="_i9fboPUUEeesLuP4RHs4vA" xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <description>FEEL path and qualified names</description>
+
+    <decision name="nested_list_001" id="_nested_list_001">
+        <description>Tests FEEL expression: 'string()' and expects result: 'null (string)'</description>
+        <question>Result of FEEL expression 'string()'?</question>
+        <allowedAnswers>null (string)</allowedAnswers>
+        <variable name="nested_list_001"/>
+        <literalExpression>
+            <text>
+                [{a: {b: 1}}, {a: {b: [2.1, 2.2]}}, {a: {b: 3}}, {a: {b: 4}}, {a: {b: 5}}].a.b =
+                [{b: 1}, {b: [2.1, 2.2]}, {b: 3}, {b: 4}, {b: 5}].b
+            </text>
+        </literalExpression>
+    </decision>
+
+    <decision name="nested_list_002" id="_nested_list_002">
+        <description>Tests FEEL expression: 'string()' and expects result: 'null (string)'</description>
+        <question>Result of FEEL expression 'string()'?</question>
+        <allowedAnswers>null (string)</allowedAnswers>
+        <variable name="nested_list_002"/>
+        <literalExpression>
+            <text>
+                [{b: 1}, {b: [2.1, 2.2]}, {b: 3}, {b: 4}, {b: 5}].b =
+                [1, [2.1, 2.2], 3, 4, 5]
+            </text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths.dmn
+++ b/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths.dmn
@@ -3,9 +3,6 @@
     <description>FEEL path and qualified names</description>
 
     <decision name="nested_list_001" id="_nested_list_001">
-        <description>Tests FEEL expression: 'string()' and expects result: 'null (string)'</description>
-        <question>Result of FEEL expression 'string()'?</question>
-        <allowedAnswers>null (string)</allowedAnswers>
         <variable name="nested_list_001"/>
         <literalExpression>
             <text>
@@ -16,9 +13,6 @@
     </decision>
 
     <decision name="nested_list_002" id="_nested_list_002">
-        <description>Tests FEEL expression: 'string()' and expects result: 'null (string)'</description>
-        <question>Result of FEEL expression 'string()'?</question>
-        <allowedAnswers>null (string)</allowedAnswers>
         <variable name="nested_list_002"/>
         <literalExpression>
             <text>


### PR DESCRIPTION
Initial commit to cover feel paths on nested lists.  Only two tests covering the 'nested lists' example in the spec with the v1.2 corrections requested here: https://issues.omg.org/issues/DMN13-133 and with amendments noted here: https://github.com/dmn-tck/tck/issues/285.

Hopefully not too controversial.

EDIT: And thanks @tarilabs for the correction on the spec example.  Man, I stared at that thing for _ages_ trying to figure out what was supposed to happen - it totally fried my brain.  It didn't occur to me it was v1.1 singleton array type equality.  Doh!  After the correction things were pretty straight forward.  Thanks again.