### PR TITLE
Align to DMN13-125 Disambiguation for Modulo / Remainder function

### DIFF
--- a/TestCases/compliance-level-3/0056-feel-modulo-function/0056-feel-modulo-function-test-01.xml
+++ b/TestCases/compliance-level-3/0056-feel-modulo-function/0056-feel-modulo-function-test-01.xml
@@ -21,7 +21,7 @@
         <description>Assert on negative divisor</description>
         <resultNode name="decision001_a" type="decision">
             <expected>
-                <value xsi:type="xsd:decimal">2</value>
+                <value xsi:type="xsd:decimal">-2</value>
             </expected>
         </resultNode>
     </testCase>
@@ -29,7 +29,7 @@
         <description>Assert on negative dividend</description>
         <resultNode name="decision002" type="decision">
             <expected>
-                <value xsi:type="xsd:decimal">-2</value>
+                <value xsi:type="xsd:decimal">2</value>
             </expected>
         </resultNode>
     </testCase>
@@ -169,5 +169,68 @@
             </expected>
         </resultNode>
     </testCase>
-
+    <testCase id="016a">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <resultNode name="decision016a" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">2</value>
+            </expected>
+        </resultNode>
+    </testCase>
+    <testCase id="016b">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <resultNode name="decision016b" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">3</value>
+            </expected>
+        </resultNode>
+    </testCase>
+    <testCase id="016c">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <resultNode name="decision016c" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">-3</value>
+            </expected>
+        </resultNode>
+    </testCase>
+    <testCase id="016d">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <resultNode name="decision016d" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">-2</value>
+            </expected>
+        </resultNode>
+    </testCase>
+    <testCase id="017a">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <resultNode name="decision017a" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">1.1</value>
+            </expected>
+        </resultNode>
+    </testCase>
+    <testCase id="017b">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <resultNode name="decision017b" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">3.4</value>
+            </expected>
+        </resultNode>
+    </testCase>
+    <testCase id="017c">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <resultNode name="decision017c" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">-3.4</value>
+            </expected>
+        </resultNode>
+    </testCase>
+    <testCase id="017d">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <resultNode name="decision017d" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">-1.1</value>
+            </expected>
+        </resultNode>
+    </testCase>
 </testCases>

--- a/TestCases/compliance-level-3/0056-feel-modulo-function/0056-feel-modulo-function.dmn
+++ b/TestCases/compliance-level-3/0056-feel-modulo-function/0056-feel-modulo-function.dmn
@@ -11,18 +11,18 @@
         </literalExpression>
     </decision>
     <decision name="decision001_a" id="_decision001_a">
-        <description>Tests FEEL expression: 'modulo(10, -4)' and expects result: '2 (number)'</description>
+        <description>Tests FEEL expression: 'modulo(10, -4)' and expects result: '-2 (number)'</description>
         <question>Result of FEEL expression 'modulo(10, -4)'?</question>
-        <allowedAnswers>2 (number)</allowedAnswers>
+        <allowedAnswers>-2 (number)</allowedAnswers>
         <variable typeRef="number" name="decision001_a"/>
         <literalExpression>
             <text>modulo(10, -4)</text>
         </literalExpression>
     </decision>
     <decision name="decision002" id="_decision002">
-        <description>Tests FEEL expression: 'modulo(-10, 4)' and expects result: '-2 (number)'</description>
+        <description>Tests FEEL expression: 'modulo(-10, 4)' and expects result: '2 (number)'</description>
         <question>Result of FEEL expression 'modulo(v)'?</question>
-        <allowedAnswers>-2 (number)</allowedAnswers>
+        <allowedAnswers>2 (number)</allowedAnswers>
         <variable typeRef="number" name="decision002"/>
         <literalExpression>
             <text>modulo(-10, 4)</text>
@@ -181,5 +181,62 @@
             <text>modulo(date and time("2018-12-06T00:00:00"), 4)</text>
         </literalExpression>
     </decision>
+    <decision name="decision016a" id="_decision016a">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <variable typeRef="number" name="decision016a"/>
+        <literalExpression>
+            <text>modulo(12, 5)</text>
+        </literalExpression>
+    </decision>
+    <decision name="decision016b" id="_decision016b">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <variable typeRef="number" name="decision016b"/>
+        <literalExpression>
+            <text>modulo(-12, 5)</text>
+        </literalExpression>
+    </decision>
+    <decision name="decision016c" id="_decision016c">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <variable typeRef="number" name="decision016c"/>
+        <literalExpression>
+            <text>modulo(12, -5)</text>
+        </literalExpression>
+    </decision>
+    <decision name="decision016d" id="_decision016d">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <variable typeRef="number" name="decision016d"/>
+        <literalExpression>
+            <text>modulo(-12, -5)</text>
+        </literalExpression>
+    </decision>
+    <decision name="decision017a" id="_decision017a">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <variable typeRef="number" name="decision017a"/>
+        <literalExpression>
+            <text>modulo(10.1, 4.5)</text>
+        </literalExpression>
+    </decision>
+    <decision name="decision017b" id="_decision017b">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <variable typeRef="number" name="decision017b"/>
+        <literalExpression>
+            <text>modulo(-10.1, 4.5)</text>
+        </literalExpression>
+    </decision>
+    <decision name="decision017c" id="_decision017c">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <variable typeRef="number" name="decision017c"/>
+        <literalExpression>
+            <text>modulo(10.1, -4.5)</text>
+        </literalExpression>
+    </decision>
+    <decision name="decision017d" id="_decision017d">
+        <description>Example from the DMN Specification, ref DMN13-125</description>
+        <variable typeRef="number" name="decision017d"/>
+        <literalExpression>
+            <text>modulo(-10.1, -4.5)</text>
+        </literalExpression>
+    </decision>
+    
 </definitions>
 


### PR DESCRIPTION
I am proposing the following alignments, and new tests, following DMN13-125. 

In short: align modulo function results for negative/non-integer with Spreadsheet-like system.

My perspective is that DMN13-125 clarifies behavior, even on DMNv1.2, for an unclear part of the spec. Hence I am raising this test cases now, in order to align with DMN13-125 clarifications.