### PR TITLE
Augment 0090-feel-paths with spec example from DMN13-133

### DIFF
--- a/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths-test-01.xml
+++ b/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths-test-01.xml
@@ -25,5 +25,23 @@
             </expected>
         </resultNode>
     </testCase>
+    
+    <testCase id="nested_list_003">
+        <description>Spec 'nested list' example - DMN13-133</description>
+        <resultNode name="nested_list_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="nested_list_004">
+        <description>Spec 'nested list' example - DMN13-133</description>
+        <resultNode name="nested_list_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
 
 </testCases>

--- a/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths.dmn
+++ b/TestCases/compliance-level-3/0090-feel-paths/0090-feel-paths.dmn
@@ -21,6 +21,26 @@
             </text>
         </literalExpression>
     </decision>
+    
+    <decision name="nested_list_003" id="_nested_list_003">
+        <variable name="nested_list_003"/>
+        <literalExpression>
+            <text>
+                [{a: {b: [1]}}, {a: {b: [2.1, 2.2]}}, {a: {b: [3]}}, {a: {b: [4, 5]}}].a.b =
+                [{b: [1]}, {b: [2.1,2.2]}, {b: [3]}, {b: [4, 5]}].b 
+            </text>
+        </literalExpression>
+    </decision>
+
+    <decision name="nested_list_004" id="_nested_list_004">
+        <variable name="nested_list_004"/>
+        <literalExpression>
+            <text>
+                [{b: [1]}, {b: [2.1,2.2]}, {b: [3]}, {b: [4, 5]}].b =
+                [[1], [2.1, 2.2], [3], [4, 5]]
+            </text>
+        </literalExpression>
+    </decision>
 
 </definitions>
 


### PR DESCRIPTION
The actual balloted/approved proposal for DMN13-133 involves a different example which will end up in the new release of the spec. Augmenting the original test case with the actual example.

please note @StrayAlien original test do remain valid nevertheless, thanks again.