### PR TITLE
Update com.fasterxml.jackson.core:jackson-databind to 2.9.9

### DIFF
--- a/runners/dmn-tck-marshaller/pom.xml
+++ b/runners/dmn-tck-marshaller/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tck.schema.basedir>../../TestCases</tck.schema.basedir>
-    <jackson.version>2.8.11.3</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Addresses CVE-2019-12086 although of moderate risk for this project