### PR TITLE
Update jackson-databind

### DIFF
--- a/runners/dmn-tck-marshaller/pom.xml
+++ b/runners/dmn-tck-marshaller/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tck.schema.basedir>../../TestCases</tck.schema.basedir>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.9.1</jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Although of limited concern due to the nature of this project, clear out alerts for CVE-2019-12814