### PR TITLE
Small model cleanup

### DIFF
--- a/TestCases/compliance-level-3/0012-list-functions/0012-list-functions.dmn
+++ b/TestCases/compliance-level-3/0012-list-functions/0012-list-functions.dmn
@@ -434,10 +434,6 @@
                 <di:waypoint x="3220.0" y="331.0"/>
                 <di:waypoint x="3220.0" y="211.0"/>
             </dmndi:DMNEdge>
-            <dmndi:DMNEdge dmnElementRef="_883c9eb4-1f4f-4885-82c0-234f9ac9a1d7" id="_c0858816-af7b-40a1-8aa7-6e11b8761215_e30">
-                <di:waypoint x="2150.0" y="331.0"/>
-                <di:waypoint x="2150.0" y="211.0"/>
-            </dmndi:DMNEdge>
         </dmndi:DMNDiagram>
     </dmndi:DMNDI>
 </definitions>

--- a/TestCases/compliance-level-3/0086-import/0086-import.dmn
+++ b/TestCases/compliance-level-3/0086-import/0086-import.dmn
@@ -43,7 +43,6 @@
                         </inputExpression>
                     </input>
                     <output id="_22740ea7-5a3a-45a2-ba08-95f0f0d98eea"/>
-                    <annotation/>
                     <rule id="_5f3dad91-e3b0-483f-a259-c855a0e6d7d6">
                         <inputEntry id="_6fe43313-b225-4b78-aac1-bf90794b80fd">
                             <text>&lt;=30</text>
@@ -51,9 +50,6 @@
                         <outputEntry id="_25a3221c-9ee1-4b01-9b80-1553d376527e">
                             <text>normal greeting</text>
                         </outputEntry>
-                        <annotationEntry>
-                            <text></text>
-                        </annotationEntry>
                     </rule>
                     <rule id="_b73ea436-a867-43c7-b164-222bc5d65ae3">
                         <inputEntry id="_c4f6a141-36c6-4e4c-b737-3dcafee8c60b">
@@ -62,9 +58,6 @@
                         <outputEntry id="_28977b5a-e0ba-4266-957d-dad963e4c7cf">
                             <text>"Respectfully, "+normal greeting</text>
                         </outputEntry>
-                        <annotationEntry>
-                            <text></text>
-                        </annotationEntry>
                     </rule>
                 </decisionTable>
             </contextEntry>

--- a/TestCases/compliance-level-3/0088-no-decision-logic/0088-no-decision-logic.dmn
+++ b/TestCases/compliance-level-3/0088-no-decision-logic/0088-no-decision-logic.dmn
@@ -18,7 +18,7 @@
           <text>Grade</text>
         </inputExpression>
       </input>
-      <output id="_5F1FEDAD-C742-445A-B194-47B0112573B8" typeRef="string"/>
+      <output id="_5F1FEDAD-C742-445A-B194-47B0112573B8"/>
       <rule id="_967C2799-CC1E-45C5-9F6B-BF3C2F5BCF36">
         <inputEntry id="_47B77F78-DE9F-4CF3-A78D-AD274A951078">
           <text>"A"</text>


### PR DESCRIPTION
Happy new year all. 

Some small correctness changes to models.   No big deal - they just get caught in our verifier.  Let me know if I'm wrong.

0012-list-functions - diagram with an edge referencing an unknown id.  Edge Removed.

0086-import - DT annotation column with no name.  In xsd as optional but spec says in "8.3.2 Decision Table Input and Output metamodel" .. "A RuleAnnotationClause SHALL have a name".  I removed the annotations.

0088-no-decision-logic - Table 31 - "The OutputClause of a single output decision table SHALL NOT specify a typeRef".  Typeref is removed.

Greg.