### PR TITLE
0091-local-hrefs

### DIFF
--- a/TestCases/compliance-level-3/0091-local-hrefs/0091-local-hrefs-test-01.xml
+++ b/TestCases/compliance-level-3/0091-local-hrefs/0091-local-hrefs-test-01.xml
@@ -13,7 +13,7 @@
     <testCase id="001">
         <description>qualified hrefs using model-local namespace</description>
         <inputNode name="input_001">
-            <value>input_001</value>
+            <value xsi:type="xsd:string">input_001</value>
         </inputNode>
         <resultNode name="decision_002" type="decision">
             <expected>

--- a/TestCases/compliance-level-3/0091-local-hrefs/0091-local-hrefs-test-01.xml
+++ b/TestCases/compliance-level-3/0091-local-hrefs/0091-local-hrefs-test-01.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>0091-local-hrefs.dmn</modelName>
+
+    <labels>
+        <label>Compliance Level 3</label>
+        <label>FEEL Paths</label>
+        <label>FEEL Qualified Hrefs</label>
+    </labels>
+
+    <testCase id="001">
+        <description>qualified hrefs using model-local namespace</description>
+        <inputNode name="input_001">
+            <value>input_001</value>
+        </inputNode>
+        <resultNode name="decision_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">decision_001 input_001 bkm_001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/0091-local-hrefs/0091-local-hrefs.dmn
+++ b/TestCases/compliance-level-3/0091-local-hrefs/0091-local-hrefs.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0091-local-hrefs"
+             name="0091-local-hrefs"
+             xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/">
+
+    <description>Local (non-imported) qualified hrefs</description>
+
+    <inputData name="input_001" id="_input_001">
+        <variable name="input_001"/>
+    </inputData>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001"/>
+        <literalExpression>
+            <text>"decision_001"</text>
+        </literalExpression>
+    </decision>
+
+    <businessKnowledgeModel name="bkm_001" id="_bkm_001">
+        <variable name="bkm_001"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>"bkm_001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <!-- requirements hrefs refer to elements in this model -->
+    <decision name="decision_002" id="_decision_002">
+        <variable name="decision_002"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/0091-local-hrefs#_decision_001"/>
+        </informationRequirement>
+        <informationRequirement>
+            <requiredInput href="http://www.montera.com.au/spec/DMN/0091-local-hrefs#_input_001"/>
+        </informationRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="http://www.montera.com.au/spec/DMN/0091-local-hrefs#_bkm_001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>decision_001 + " " + input_001 + " " + bkm_001()</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+


### PR DESCRIPTION
re PR of here:  https://github.com/dmn-tck/tck/pull/356

When an element reference href contains a namespace like this "http://mynamespace#decision001" is it tempting to immediately consider it as an import even though the given namespace may be the current model namespace.

This PR has a single test that asserts that if a qualified href whose namespace refers to the current model then the reference is considered model-local and is effectively the same as having no namespace - like #decision001" in the above example.

Comments welcome.

Greg.