### PR TITLE
0092-feel-lambda

### DIFF
--- a/TestCases/compliance-level-3/0092-feel-lambda/0092-feel-lambda-test-01.xml
+++ b/TestCases/compliance-level-3/0092-feel-lambda/0092-feel-lambda-test-01.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>0092-feel-lambda.dmn</modelName>
+    <labels>
+        <label>Compliance Level 3</label>
+        <label>FEEL Functions: lambda</label>
+    </labels>
+
+    <testCase id="001">
+        <description>A decision may return a user-defined-function (UDF) lambda</description>
+        <resultNode name="decision_001_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">3</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>A decision may return a Function Definition lambda</description>
+        <resultNode name="decision_002_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">4</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>A BKM may return a UDF lambda</description>
+        <resultNode name="decision_003_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">5</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004">
+        <description>A BKM may return a Function Definition lambda</description>
+        <resultNode name="decision_004_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">6</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005">
+        <description>A BKM may return a UDF lambda with a closed over formal param</description>
+        <resultNode name="decision_005_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">20</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005">
+        <description>A BKM may return a Function Definition lambda with a closed over formal param</description>
+        <resultNode name="decision_006_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">30</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="007">
+        <description>A decision may return a UDF lambda with a closed over info requirement value</description>
+
+        <inputNode name="input_007_1">
+            <value xsi:type="xsd:double">20</value>
+        </inputNode>
+
+        <resultNode name="decision_007_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">100</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="008">
+        <description>A lambda's named params take precedence over scope values where the lambda is created</description>
+        <resultNode name="decision_008_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">6</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="009">
+        <description>A lambda's named params take precedence over scope values where the lambda is invoked</description>
+        <resultNode name="decision_009_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">200</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="010">
+        <description>lambdas (UDF) and closures may go more than one level deep - (currying)</description>
+        <resultNode name="decision_010_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">120</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="010_a">
+        <description>lambdas (func defn) and closures may go more than one level deep - (currying)</description>
+        <resultNode name="decision_010_1_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">120</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="011">
+        <description>lambdas (with closures) may be passed as params</description>
+
+        <inputNode name="input_011_1">
+            <value xsi:type="xsd:double">10</value>
+        </inputNode>
+
+        <resultNode name="decision_011_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">5000</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="012">
+        <description>BKM may be passed as lambda</description>
+        <resultNode name="decision_012_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">5000</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="013">
+        <description>Decision Service may be passed as lambda</description>
+        <resultNode name="decision_013_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">5000</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="014">
+        <description>Built-in function may be passed as lambda</description>
+        <resultNode name="decision_014_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">25</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="015">
+        <description>Overloaded built-in function may be passed as lambda</description>
+        <resultNode name="decision_015_1" type="decision">
+            <expected>
+                <value xsi:type="xsd:double">18</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="016">
+        <description>Invoking passed lambda with incorrect params still gives error</description>
+        <resultNode name="decision_016_1" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="017">
+        <description>Local decision scope values may be closed over and used in built-in func</description>
+        <inputNode name="input_017_1">
+            <value xsi:type="xsd:string">a</value>
+        </inputNode>
+        <resultNode name="decision_017_1" type="decision">
+            <expected>
+                <list>
+                    <item><value xsi:type="xsd:string">a</value></item>
+                    <item><value xsi:type="xsd:string">a</value></item>
+                    <item><value xsi:type="xsd:string">z</value></item>
+                    <item><value xsi:type="xsd:string">z</value></item>
+                </list>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="018">
+        <description>BKM may be passed to sort func</description>
+        <resultNode name="decision_018" type="decision">
+            <expected>
+                <list>
+                    <item><value xsi:type="xsd:string">a</value></item>
+                    <item><value xsi:type="xsd:string">a</value></item>
+                    <item><value xsi:type="xsd:string">z</value></item>
+                    <item><value xsi:type="xsd:string">z</value></item>
+                </list>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/0092-feel-lambda/0092-feel-lambda-test-01.xml
+++ b/TestCases/compliance-level-3/0092-feel-lambda/0092-feel-lambda-test-01.xml
@@ -52,7 +52,7 @@
         </resultNode>
     </testCase>
 
-    <testCase id="005">
+    <testCase id="006">
         <description>A BKM may return a Function Definition lambda with a closed over formal param</description>
         <resultNode name="decision_006_1" type="decision">
             <expected>

--- a/TestCases/compliance-level-3/0092-feel-lambda/0092-feel-lambda.dmn
+++ b/TestCases/compliance-level-3/0092-feel-lambda/0092-feel-lambda.dmn
@@ -416,7 +416,7 @@
             <formalParameter name="fn2"/>
             <literalExpression>
                 <!-- DS invocations - with param.  Each DS invocation returns a context -->
-                <text>fn1(5).decision_013_2*fn2(10).decision_013_2</text>
+                <text>fn1(5)*fn2(10)</text>
             </literalExpression>
         </encapsulatedLogic>
     </businessKnowledgeModel>

--- a/TestCases/compliance-level-3/0092-feel-lambda/0092-feel-lambda.dmn
+++ b/TestCases/compliance-level-3/0092-feel-lambda/0092-feel-lambda.dmn
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0092-feel-lambda"
+             name="0092-feel-lambda"
+             xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" >
+    <description>FEEL lambda</description>
+
+    <!-- decision returns a UDF lambda (no closures) -->
+    <decision name="decision_001_2" id="_decision_001_2">
+        <variable name="decision_001_2"/>
+        <literalExpression>
+            <text>function (a) 1 + a</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_001_1" id="_decision_001_1">
+        <variable name="decision_001_1"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_001_2"/>
+        </informationRequirement>
+        <!-- invokes a lambda supplied by another decision -->
+        <literalExpression>
+            <text>decision_001_2(2)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- decision returns a function definition lambda (no closures) -->
+    <decision name="decision_002_2" id="_decision_002_2">
+        <variable name="decision_002_2"/>
+        <functionDefinition>
+            <formalParameter name="a" typeRef="number"/>
+            <literalExpression>
+                <text>1 + a</text>
+            </literalExpression>
+        </functionDefinition>
+    </decision>
+
+    <decision name="decision_002_1" id="_decision_002_1">
+        <variable name="decision_002_1"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_002_2"/>
+        </informationRequirement>
+        <!-- invokes a lambda supplied by another decision -->
+        <literalExpression>
+            <text>decision_002_2(3)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM returns a UDF lambda (no closures) -->
+    <businessKnowledgeModel name="bkm_003_1" id="_bkm_003_1">
+        <variable name="bkm_003_1"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>function (a) 1 + a</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_003_1" id="_decision_003_1">
+        <variable name="decision_003_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_003_1"/>
+        </knowledgeRequirement>
+        <!-- invokes a lambda supplied by bkm -->
+        <literalExpression>
+            <text>bkm_003_1()(4)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM returns a Function Definition lambda (no closures) -->
+    <businessKnowledgeModel name="bkm_004_1" id="_bkm_004_1">
+        <variable name="bkm_004_1"/>
+        <encapsulatedLogic>
+            <functionDefinition>
+                <formalParameter name="a" typeRef="number"/>
+                <literalExpression>
+                    <text>1 + a</text>
+                </literalExpression>
+            </functionDefinition>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_004_1" id="_decision_004_1">
+        <variable name="decision_004_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_004_1"/>
+        </knowledgeRequirement>
+        <!-- invokes a lambda supplied by bkm -->
+        <literalExpression>
+            <text>bkm_004_1()(5)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM has a single param.  It returns a UDF lambda that uses that bkm param in closure -->
+    <businessKnowledgeModel name="bkm_005_1" id="_bkm_005_1">
+        <variable name="bkm_005_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="a" typeRef="number"/>
+            <literalExpression>
+                <text>function (b) a * b</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_005_1" id="_decision_005_1">
+        <variable name="decision_005_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_005_1"/>
+        </knowledgeRequirement>
+        <!-- invokes bkm.  The bkm returns a function with '10' closed over.   -->
+        <literalExpression>
+            <text>bkm_005_1(10)(2)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM has a single param.  It returns a func defn lambda that uses that bkm param in closure -->
+    <businessKnowledgeModel name="bkm_006_1" id="_bkm_006_1">
+        <variable name="bkm_006_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="a" typeRef="number"/>
+            <functionDefinition>
+                <formalParameter name="b" typeRef="number"/>
+                <literalExpression>
+                    <text>a * b</text>
+                </literalExpression>
+            </functionDefinition>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_006_1" id="_decision_006_1">
+        <variable name="decision_006_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_006_1"/>
+        </knowledgeRequirement>
+        <!-- invokes bkm.  The bkm returns a function with '10' closed over.   -->
+        <literalExpression>
+            <text>bkm_006_1(10)(3)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <inputData name="input_007_1" id="_input_007_1">
+        <variable name="input_007_1"/>
+    </inputData>
+
+    <!-- decision returns a UDF lambda that closes over an info requirement input data value -->
+    <decision name="decision_007_2" id="_decision_007_2">
+        <variable name="decision_007_2"/>
+        <informationRequirement>
+            <requiredInput href="#_input_007_1"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>function (a: number) a * input_007_1</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_007_1" id="_decision_007_1">
+        <variable name="decision_007_1"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_007_2"/>
+        </informationRequirement>
+        <!-- invokes a lambda that has the value of input_007_1 closed over -->
+        <literalExpression>
+            <text>decision_007_2(5)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM has a param.  It returns a UDF lambda that has the same name as one of its own params -->
+    <businessKnowledgeModel name="bkm_008_1" id="_bkm_008_1">
+        <variable name="bkm_008_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="a" typeRef="number"/>
+            <literalExpression>
+                <text>function (a, b) a * b</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_008_1" id="_decision_008_1">
+        <variable name="decision_008_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_008_1"/>
+        </knowledgeRequirement>
+        <!-- invokes lambda passing 10 as param 'a', but as lambda has an 'a' param the 10 is not closed over -->
+        <literalExpression>
+            <text>bkm_008_1(10)(2, 3)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM returns a UDF with a closed over 'a' -->
+    <businessKnowledgeModel name="bkm_009_1" id="_bkm_009_1">
+        <variable name="bkm_009_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="a" typeRef="number"/>
+            <literalExpression>
+                <text>function (b) a * b</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_009_1" id="_decision_009_1">
+        <variable name="decision_009_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_009_1"/>
+        </knowledgeRequirement>
+        <context>
+            <contextEntry>
+                <!-- var 'a' in scope for expression below -->
+                <variable name="a"/>
+                <literalExpression>
+                    <text>10</text>
+                </literalExpression>
+            </contextEntry>
+            <contextEntry>
+                <!-- lambda from bkm has 'a' closed over with value 100 - so it gets used, not the 10 from context
+                var above -->
+                <literalExpression>
+                    <text>bkm_009_1(100)(2)</text>
+                </literalExpression>
+            </contextEntry>
+        </context>
+    </decision>
+
+    <!-- -->
+
+    <!-- bkm has UDF lambda that has a currying-like multiple levels of closure -->
+    <businessKnowledgeModel name="bkm_010_1" id="_bkm_010_1">
+        <variable name="bkm_010_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="a" typeRef="number"/>
+            <literalExpression>
+                <text>function (b) function(c) function(d) a*b*c*d</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_010_2" id="_decision_010_2">
+        <variable name="decision_010_2"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_010_1"/>
+        </knowledgeRequirement>
+        <!-- invokes lambda passing param that close over multiple levels, but last level is not invoked
+        so expression result is actually the final nested lambda -->
+        <literalExpression>
+            <text>bkm_010_1(2)(3)(4)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_010_1" id="_decision_010_1">
+        <variable name="decision_010_1"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_010_2"/>
+        </informationRequirement>
+        <!-- invokes lambda passing param that close over multiple levels -->
+        <literalExpression>
+            <text>decision_010_2(5)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- bkm has function definition lambda that a currying-like multiple levels of closure -->
+    <businessKnowledgeModel name="bkm_010_1_a" id="_bkm_010_1_a">
+        <variable name="bkm_010_1_a"/>
+        <encapsulatedLogic>
+            <formalParameter name="a" typeRef="number"/>
+            <functionDefinition>
+                <formalParameter name="b" typeRef="number"/>
+                <functionDefinition>
+                    <formalParameter name="c" typeRef="number"/>
+                    <functionDefinition>
+                        <formalParameter name="d" typeRef="number"/>
+                        <literalExpression>
+                            <text>a*b*c*d</text>
+                        </literalExpression>
+                    </functionDefinition>
+                </functionDefinition>
+            </functionDefinition>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_010_2_a" id="_decision_010_2_a">
+        <variable name="decision_010_2_a"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_010_1_a"/>
+        </knowledgeRequirement>
+        <!-- invokes lambda passing param that close over multiple levels, but last level is not invoked
+        so expression result is actually the final nested lambda -->
+        <literalExpression>
+            <text>bkm_010_1_a(2)(3)(4)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_010_1_a" id="_decision_010_1_a">
+        <variable name="decision_010_1_a"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision_010_2_a"/>
+        </informationRequirement>
+        <!-- invokes lambda passing param that close over multiple levels -->
+        <literalExpression>
+            <text>decision_010_2_a(5)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM take two lambda params -->
+    <businessKnowledgeModel name="bkm_011_1" id="_bkm_011_1">
+        <variable name="bkm_011_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="fn1"/>
+            <formalParameter name="fn2"/>
+            <literalExpression>
+                <text>fn1(5)*fn2(10)</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <inputData name="input_011_1" id="_input_011_1">
+        <variable name="input_011_1"/>
+    </inputData>
+
+    <decision name="decision_011_1" id="_decision_011_1">
+        <variable name="decision_011_1"/>
+        <informationRequirement>
+            <requiredInput href="#_input_011_1"/>
+        </informationRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_011_1"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <!-- two UDF lambdas are passed to bkm_011_1 -->
+            <text>bkm_011_1(function (a) input_011_1 * a, function (b) input_011_1 * b)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM take two lambda params -->
+    <businessKnowledgeModel name="bkm_012_1" id="_bkm_012_1">
+        <variable name="bkm_012_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="fn1"/>
+            <formalParameter name="fn2"/>
+            <literalExpression>
+                <text>fn1(5)*fn2(10)</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <businessKnowledgeModel name="bkm_012_2" id="_bkm_012_2">
+        <variable name="bkm_012_2"/>
+        <encapsulatedLogic>
+            <formalParameter name="a"/>
+            <literalExpression>
+                <text>a * 10</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_012_1" id="_decision_012_1">
+        <variable name="decision_012_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_012_1"/>
+        </knowledgeRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_012_2"/>
+        </knowledgeRequirement>
+        <!-- bkm_012_2 is not executed here but is passed on to bkm_012_1 -->
+        <literalExpression>
+            <text>bkm_012_1(bkm_012_2, bkm_012_2)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <inputData name="input_013_1" id="_input_013_1">
+        <variable name="input_013_1" typeRef="number"/>
+    </inputData>
+
+    <decisionService name="decisionService_013_1" id="_decisionService_013_1">
+        <variable name="decisionService_013_1"/>
+        <outputDecision href="#_decision_013_2"/>
+        <inputData href="#_input_013_1"/>
+    </decisionService>
+
+    <decision name="decision_013_2" id="_decision_013_2">
+        <variable name="decision_013_2"/>
+        <informationRequirement>
+            <requiredInput href="#_input_013_1"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input_013_1 * 10</text>
+        </literalExpression>
+    </decision>
+
+    <!-- BKM take two DS lambda params (each DS returns a context)-->
+    <businessKnowledgeModel name="bkm_013_1" id="_bkm_013_1">
+        <variable name="bkm_013_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="fn1"/>
+            <formalParameter name="fn2"/>
+            <literalExpression>
+                <!-- DS invocations - with param.  Each DS invocation returns a context -->
+                <text>fn1(5).decision_013_2*fn2(10).decision_013_2</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_013_1" id="_decision_013_1">
+        <variable name="decision_013_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_013_1"/>
+        </knowledgeRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_decisionService_013_1"/>
+        </knowledgeRequirement>
+        <!-- decisionService_013_1 is not executed here but is passed on to bkm_013_1 -->
+        <literalExpression>
+            <text>bkm_013_1(decisionService_013_1, decisionService_013_1)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <!-- BKM take two lambda params -->
+    <businessKnowledgeModel name="bkm_014_1" id="_bkm_014_1">
+        <variable name="bkm_014_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="fn1"/>
+            <formalParameter name="fn2"/>
+            <literalExpression>
+                <text>fn1(-5)*fn2(25)</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_014_1" id="_decision_014_1">
+        <variable name="decision_014_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_014_1"/>
+        </knowledgeRequirement>
+        <!-- passed built-in functions as params  -->
+        <literalExpression>
+            <text>bkm_014_1(abs, sqrt)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <businessKnowledgeModel name="bkm_015_1" id="_bkm_015_1">
+        <variable name="bkm_015_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="fn1"/>
+            <literalExpression>
+                <!-- pass in 'sum' func is used both in sum(list) and sum(list..) modes -->
+                <text>fn1([1,2,3])*fn1(1,2)</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_015_1" id="_decision_015_1">
+        <variable name="decision_015_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_015_1"/>
+        </knowledgeRequirement>
+        <!-- passed overloadable built-in function as param  -->
+        <literalExpression>
+            <text>bkm_015_1(sum)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <businessKnowledgeModel name="bkm_016_1" id="_bkm_016_1">
+        <variable name="bkm_016_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="fn1"/>
+            <literalExpression>
+                <!-- passed in 'sqrt' func is invoked with too many params -->
+                <text>fn1(10,2)</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision_016_1" id="_decision_016_1">
+        <variable name="decision_016_1"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_016_1"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>bkm_016_1(sqrt)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <businessKnowledgeModel name="bkm_017_1" id="_bkm_017_1">
+        <variable name="bkm_017_1"/>
+        <encapsulatedLogic>
+            <formalParameter name="fn1"/>
+            <literalExpression>
+                <!-- passed in 'precedes' lambda is passed again to sort() -->
+                <text>sort(["a","z", "a", "z"], fn1)</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <inputData name="input_017_1" id="_input_017_1">
+        <variable name="input_017_1"/>
+    </inputData>
+
+    <decision name="decision_017_1" id="_decision_017_1">
+        <variable name="decision_017_1"/>
+        <informationRequirement>
+            <requiredInput href="#_input_017_1"/>
+        </informationRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_017_1"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>bkm_017_1(function (a,b) if a = input_017_1 then true else false)</text>
+        </literalExpression>
+    </decision>
+
+    <!-- -->
+
+    <businessKnowledgeModel name="bkm_018" id="_bkm_018">
+        <variable name="bkm_018"/>
+        <encapsulatedLogic>
+            <formalParameter name="p1"/>
+            <formalParameter name="p2"/>
+            <literalExpression>
+                <text>if p1 = "a" then true else false</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <!-- decision pass a BKM to the sort() function -->
+    <decision name="decision_018" id="_decision_018">
+        <variable name="decision_018"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_bkm_018"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>sort(["a","z", "a", "z"], bkm_018)</text>
+        </literalExpression>
+    </decision>
+
+</definitions>


### PR DESCRIPTION
a re PR of here: https://github.com/dmn-tck/tck/pull/357

A number of tests to verify usage of user-defined functions and Function Definitions as lambdas. Additionally, verification on usage and behaviour of closed over values ('closures') is included.

A few things to note:

- no 'function' typeRefs or item definitions have been used here - so this is within what is describable in v1.2.
- as a Decision may house any type of expression, in theory, it can also provide a lambda as a return value by using a user-defined function expression like function (a,b) a+b or a Function Definition expression. I'm not saying this is how people will use it, but tests are not about that - they're here to prove a mechanism works. To that end, a number of the tests here have a Decision returning a lambda.
- I have also included some tests that show BKM, DS, and built-in functions can be passed about as arguments to other functions just like lambdas. This is not 'lambda anonymous functions' per se, but, simply the extension that if we can pass lambdas about then it only makes sense that other functions are treated in exactly the same manner. Like, for example, why would we not be able to pass a BKM knowledge requirement to the sort() function when we are permitted to pass a user-defined function?

I have made each test as short and sweet as I can - passing functions about can get confusing.

As always, happy for comments.

Greg.