### PR TITLE
DMN 1.3 equality

### DIFF
--- a/TestCases/compliance-level-3/0068-feel-equality/0068-feel-equality-test-01.xml
+++ b/TestCases/compliance-level-3/0068-feel-equality/0068-feel-equality-test-01.xml
@@ -727,6 +727,15 @@
         </resultNode>
     </testCase>
 
+    <testCase id="dt_duration_008">
+        <description>zero dt duration equals zero ym duration</description>
+        <resultNode name="dt_duration_008" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
     <testCase id="ym_duration_001">
         <description>same durations are equal</description>
         <resultNode name="ym_duration_001" type="decision">
@@ -870,5 +879,131 @@
             </expected>
         </resultNode>
     </testCase> -->
+
+    <testCase id="fn_001">
+        <description>two anon functions with same signature and body are not equal</description>
+        <resultNode name="fn_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="fn_002">
+        <description>two built in functions with same signature are not equal</description>
+        <resultNode name="fn_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="fn_003">
+        <description>a built in function is equal to itself</description>
+        <resultNode name="fn_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="fn_004">
+        <description>a BKM is equal to itself</description>
+        <resultNode name="fn_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="fn_005">
+        <description>a BKM is not equal to another BKM</description>
+        <resultNode name="fn_005" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_001">
+        <description>ranges with same endpoint and inclusivity are equal</description>
+        <resultNode name="range_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_002">
+        <description>ranges with different upper endpoints are not equal</description>
+        <resultNode name="range_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_003">
+        <description>ranges with different lower endpoints are not equal</description>
+        <resultNode name="range_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_004">
+        <description>ranges with same endpoints, but same though syntactically different lower inclusivity are equal</description>
+        <resultNode name="range_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_005">
+        <description>ranges with same endpoints, but same though syntactically different upper inclusivity are equal</description>
+        <resultNode name="range_005" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_006">
+        <description>equal ranges though syntactically different: LT </description>
+        <resultNode name="range_006" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_007">
+        <description>equal ranges though syntactically different: LE </description>
+        <resultNode name="range_007" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_008">
+        <description>equal ranges though syntactically different: GT </description>
+        <resultNode name="range_008" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_009">
+        <description>equal ranges though syntactically different: GE </description>
+        <resultNode name="range_009" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
 
 </testCases>

--- a/TestCases/compliance-level-3/0068-feel-equality/0068-feel-equality.dmn
+++ b/TestCases/compliance-level-3/0068-feel-equality/0068-feel-equality.dmn
@@ -803,6 +803,16 @@
         </literalExpression>
     </decision>
 
+    <decision name="dt_duration_008" id="_dt_duration_008">
+        <description>Tests FEEL expression: 'duration("P0D") = duration("P0Y")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'duration("P0D") = duration("P0Y")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="dt_duration_008"/>
+        <literalExpression>
+            <text>duration("P0D") = duration("P0Y")</text>
+        </literalExpression>
+    </decision>
+
     <decision name="ym_duration_001" id="_ym_duration_001">
         <description>Tests FEEL expression: 'duration("P1Y") = duration("P1Y")' and expects result: 'true (boolean)'</description>
         <question>Result of FEEL expression 'duration("P1Y") = duration("P1Y")'?</question>
@@ -953,6 +963,83 @@
         </literalExpression>
     </decision>
 
+    <decision name="fn_001" id="_fn_001">
+        <description>Tests FEEL expression: '(function() "foo") = (function() "foo")' and expects result: 'false (boolean)'</description>
+        <question>Tests FEEL expression: '(function() "foo") = (function() "foo")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="fn_001"/>
+        <literalExpression>
+            <text>(function() "foo") = (function() "foo")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="fn_002" id="_fn_002">
+        <description>Tests FEEL expression: "max = mean" and expects result: 'false (boolean)'</description>
+        <question>Tests FEEL expression: 'max = mean"?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="fn_002"/>
+        <literalExpression>
+            <text>max = mean</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="fn_003" id="_fn_003">
+        <description>Tests FEEL expression: "count = count" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: 'count = count"?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="fn_003"/>
+        <literalExpression>
+            <text>count = count</text>
+        </literalExpression>
+    </decision>
+
+    <businessKnowledgeModel name="fn_bkm_001" id="_fn_bkm_001">
+        <variable name="fn_bkm_001"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>"foo"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <businessKnowledgeModel name="fn_bkm_002" id="_fn_bkm_002">
+        <variable name="fn_bkm_002"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>"foo"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="fn_004" id="_fn_004">
+        <description>Tests FEEL expression: "fn_bkm_001 = fn_bkm_001" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: 'fn_bkm_001 = fn_bkm_001"?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="fn_004"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_fn_bkm_001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>fn_bkm_001 = fn_bkm_001</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="fn_005" id="_fn_005">
+        <description>Tests FEEL expression: "fn_bkm_001 = fn_bkm_002" and expects result: 'false (boolean)'</description>
+        <question>Tests FEEL expression: 'fn_bkm_001 = fn_bkm_002"?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="fn_005"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_fn_bkm_001"/>
+        </knowledgeRequirement>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_fn_bkm_002"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>fn_bkm_001 = fn_bkm_002</text>
+        </literalExpression>
+    </decision>
+
 <!--     <decision name="singleton_001" id="_singleton_001">
         <description>Tests FEEL expression: '[100] = 100' and expects result: 'null (boolean)'</description>
         <question>Result of FEEL expression '[100] = 100'?</question>
@@ -962,6 +1049,96 @@
             <text>[100] = 100</text>
         </literalExpression>
     </decision> -->
+
+    <decision name="range_001" id="_range_001">
+        <description>Tests FEEL expression: "[1..10] = [1..10]" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: '[1..10] = [1..10]'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_001"/>
+        <literalExpression>
+            <text>[1..10] = [1..10]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_002" id="_range_002">
+        <description>Tests FEEL expression: "[1..10] = [1..11]" and expects result: 'false (boolean)'</description>
+        <question>Tests FEEL expression: '[1..10] = [1..11]'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_002"/>
+        <literalExpression>
+            <text>[1..2] = [1..3]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_003" id="_range_003">
+        <description>Tests FEEL expression: "[2..10] = [1..10]" and expects result: 'false (boolean)'</description>
+        <question>Tests FEEL expression: '[2..10] = [1..10]"?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_003"/>
+        <literalExpression>
+            <text>[2..10] = [1..10]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_004" id="_range_004">
+        <description>Tests FEEL expression: "(1..10] = ]1..10]" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: '(1..10] = ]1..10]"?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_004"/>
+        <literalExpression>
+            <text>(1..10] = ]1..10]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_005" id="_range_005">
+        <description>Tests FEEL expression: "[1..10) = [1..10[" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: '[1..10) = [1..10['?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_005"/>
+        <literalExpression>
+            <text>[1..10) = [1..10[</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_006" id="_range_006">
+        <description>Tests FEEL expression: "(&lt; 10) = (null..10)" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: '(&lt; 10) = (null..10)'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_006"/>
+        <literalExpression>
+            <text>(&lt; 10) = (null..10)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_007" id="_range_007">
+        <description>Tests FEEL expression: "(&lt;= 10) = (null..10]" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: '(&lt;= 10) = (null..10]'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_007"/>
+        <literalExpression>
+            <text>(&lt;= 10) = (null..10]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_008" id="_range_008">
+        <description>Tests FEEL expression: "(&gt; 10) = (10..null)" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: '(&gt; 10) = (10..null)'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_008"/>
+        <literalExpression>
+            <text>(&gt; 10) = (10..null)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_009" id="_range_009">
+        <description>Tests FEEL expression: "(&gt;= 10) = [10..null)" and expects result: 'true (boolean)'</description>
+        <question>Tests FEEL expression: '(&gt;= 10) = [10..null)'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable typeRef="boolean" name="range_009"/>
+        <literalExpression>
+            <text>(&gt;= 10) = [10..null)</text>
+        </literalExpression>
+    </decision>
 
 </definitions>
 


### PR DESCRIPTION
Assertions for 1.3 changes plus some missing stuff

P0D - P0Y assertion: due to:

> Comparison operators are defined only when the two operands have the same type, except for years and months duration
and days and time duration, which can be compared for equality. Notice, however, that “with the exception of the zerolength
duration, no instance of xs:dayTimeDuration can ever be equal to an instance of xs:yearMonthDuration.

Function equality:

This sure needs more discussion I think as the spec refers to 'body' equality and distinguishes between internal and external functions.  So, for now, I have just added some tests based on identity to get the ball rolling  Comments welcome.

Ranges:

We did not have equality tests on ranges.  Now we have.  Also, the 'unary' syntax is officially a range now.  Before, some implementers (like us), may not have implemented them as ranges, but as a 'unary test' or, indeed, something else. There are assertions that ranges created with either syntax are equal if endpoint/inclusivity etc are equal - regardless of syntax used to create them.   

Comments welcome.