### PR TITLE
DMN 1.3 instance of

### DIFF
--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
@@ -1580,4 +1580,13 @@
         </resultNode>
     </testCase>
 
+    <testCase id="function_031">
+        <description>mixed list of type does not conform to a list function type</description>
+        <resultNode name="function_031" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
 </testCases>

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
@@ -867,6 +867,7 @@
         </resultNode>
     </testCase>
 
+    <!-- comment out as per: https://github.com/dmn-tck/tck/pull/390#issuecomment-1053664450
     <testCase id="list_021">
         <description>list is an instance of inline function types</description>
         <resultNode name="list_021" type="decision">
@@ -875,6 +876,7 @@
             </expected>
         </resultNode>
     </testCase>
+    -->
 
     <testCase id="ym_duration_001">
         <description>years and months duration instance of Any is true</description>
@@ -1409,6 +1411,7 @@
         </resultNode>
     </testCase>-->
 
+    <!-- comment out as per: https://github.com/dmn-tck/tck/pull/390#issuecomment-1053664450
     <testCase id="function_012">
         <description>conforms when no params and covariant return type</description>
         <resultNode name="function_012" type="decision">
@@ -1588,5 +1591,6 @@
             </expected>
         </resultNode>
     </testCase>
+    -->
 
 </testCases>

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
@@ -70,14 +70,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="null_008">
+    <testCase id="null_008">
         <description>null instance of list is false</description>
         <resultNode name="null_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="null_009">
         <description>null instance of years and months duration is false</description>
@@ -97,14 +97,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="null_011">
+<!--    <testCase id="null_011">
         <description>null instance of context is false</description>
         <resultNode name="null_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="null_012">
         <description>null instance of function is false</description>
@@ -113,7 +113,7 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="number_001">
         <description>number instance of Any is true</description>
@@ -178,14 +178,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="number_008">
+    <testCase id="number_008">
         <description>number instance of list is false</description>
         <resultNode name="number_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="number_009">
         <description>number instance of years and months duration is false</description>
@@ -205,14 +205,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="number_011">
+<!--    <testCase id="number_011">
         <description>number instance of context is false</description>
         <resultNode name="number_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="number_012">
         <description>number instance of function is false</description>
@@ -221,7 +221,16 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
+
+    <testCase id="number_013">
+        <description>type conformance does not take into account allowedValues</description>
+        <resultNode name="number_013" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
 
 
     <testCase id="string_001">
@@ -287,14 +296,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="string_008">
+    <testCase id="string_008">
         <description>string instance of list is false</description>
         <resultNode name="string_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="string_009">
         <description>string instance of years and months duration is false</description>
@@ -314,14 +323,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="string_011">
+<!--    <testCase id="string_011">
         <description>string instance of context is false</description>
         <resultNode name="string_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase-->>
 
     <testCase id="string_012">
         <description>string instance of function is false</description>
@@ -330,7 +339,16 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
+
+    <testCase id="string_013">
+        <description>string type conformance does not take into account allowedValues</description>
+        <resultNode name="string_013" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
 
 
     <testCase id="boolean_001">
@@ -396,14 +414,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="boolean_008">
+    <testCase id="boolean_008">
         <description>boolean instance of list is false</description>
         <resultNode name="boolean_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="boolean_009">
         <description>boolean instance of years and months duration is false</description>
@@ -423,14 +441,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="boolean_011">
+<!--    <testCase id="boolean_011">
         <description>boolean instance of context is false</description>
         <resultNode name="boolean_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="boolean_012">
         <description>boolean instance of function is false</description>
@@ -439,7 +457,7 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="date_001">
         <description>date instance of Any is true</description>
@@ -507,14 +525,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="date_008">
+    <testCase id="date_008">
         <description>date instance of list is false</description>
         <resultNode name="date_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="date_009">
         <description>date instance of years and months duration is false</description>
@@ -534,14 +552,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="date_011">
+<!--    <testCase id="date_011">
         <description>date instance of context is false</description>
         <resultNode name="date_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="date_012">
         <description>date instance of function is false</description>
@@ -550,7 +568,7 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="time_001">
         <description>time instance of Any is true</description>
@@ -615,14 +633,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="time_008">
+    <testCase id="time_008">
         <description>time instance of list is false</description>
         <resultNode name="time_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="time_009">
         <description>time instance of years and months duration is false</description>
@@ -642,14 +660,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="time_011">
+<!--    <testCase id="time_011">
         <description>time instance of context is false</description>
         <resultNode name="time_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="time_012">
         <description>time instance of function is false</description>
@@ -658,7 +676,7 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="list_001">
         <description>list instance of Any is true</description>
@@ -723,14 +741,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="list_008">
+    <testCase id="list_008">
         <description>list instance of list is rrue</description>
         <resultNode name="list_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">true</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="list_009">
         <description>list instance of years and months duration is false</description>
@@ -750,14 +768,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="list_011">
+<!--    <testCase id="list_011">
         <description>list instance of context is false</description>
         <resultNode name="list_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="list_012">
         <description>list instance of function is false</description>
@@ -766,9 +784,9 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
-<!--     <testCase id="list_013">
+    <testCase id="list_013">
         <description>list instance with same itemtype is true</description>
         <resultNode name="list_013" type="decision">
             <expected>
@@ -802,7 +820,7 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="list_016">
         <description>singleton list is not instance of element type</description>
@@ -813,14 +831,50 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="list_017">
+    <testCase id="list_017">
         <description>primitive is not instance of list of same type</description>
         <resultNode name="list_017" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
+
+    <testCase id="list_018">
+        <description>list is an instance of inline list of itemdefinition context type</description>
+        <resultNode name="list_018" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="list_019">
+        <description>list is not an instance of inline list of inline context type</description>
+        <resultNode name="list_019" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="list_20">
+        <description>list is an instance of inline list of inline context type</description>
+        <resultNode name="list_020" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="list_21">
+        <description>list is an instance of inline function types</description>
+        <resultNode name="list_021" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
 
     <testCase id="ym_duration_001">
         <description>years and months duration instance of Any is true</description>
@@ -885,14 +939,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="ym_duration_008">
+    <testCase id="ym_duration_008">
         <description>years and months duration instance of list is false</description>
         <resultNode name="ym_duration_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="ym_duration_009">
         <description>years and months duration instance of years and months duration is true</description>
@@ -912,14 +966,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="ym_duration_011">
+<!--    <testCase id="ym_duration_011">
         <description>years and months duration instance of context is false</description>
         <resultNode name="ym_duration_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="ym_duration_012">
         <description>years and months duration instance of function is false</description>
@@ -928,7 +982,7 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="dt_duration_001">
         <description>days and time duration instance of Any is true</description>
@@ -993,14 +1047,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="dt_duration_008">
+    <testCase id="dt_duration_008">
         <description>days and time durationinstance of list is false</description>
         <resultNode name="dt_duration_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="dt_duration_009">
         <description>days and time duration instance of years and months duration is false</description>
@@ -1020,14 +1074,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="dt_duration_011">
+<!--    <testCase id="dt_duration_011">
         <description>days and time duration instance of context is false</description>
         <resultNode name="dt_duration_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="dt_duration_012">
         <description>days and time duration instance of function is false</description>
@@ -1036,7 +1090,7 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="context_001">
         <description>context instance of Any is true</description>
@@ -1101,14 +1155,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="context_008">
+    <testCase id="context_008">
         <description>context instance of list is false</description>
         <resultNode name="context_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="context_009">
         <description>context instance of years and months duration is false</description>
@@ -1128,7 +1182,8 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="context_011">
+<!--
+    <testCase id="context_011">
         <description>context instance of context is true</description>
         <resultNode name="context_011" type="decision">
             <expected>
@@ -1136,6 +1191,7 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
     <testCase id="context_012">
         <description>context instance of function is false</description>
@@ -1144,9 +1200,9 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
-<!--     <testCase id="context_013">
+     <testCase id="context_013">
         <description>context instance of context with same property names is true</description>
         <resultNode name="context_013" type="decision">
             <expected>
@@ -1180,7 +1236,79 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
+
+<!--    <testCase id="context_017">
+        <description>empty context instance conforms to empty context type</description>
+        <resultNode name="context_017" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>-->
+
+    <testCase id="context_018">
+        <description>context instance conforms to equivalent type</description>
+        <resultNode name="context_018" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="context_019">
+        <description>context with null value conforms to specific type</description>
+        <resultNode name="context_019" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="context_020">
+        <description>context with multiple properties conforms to type with equivalent single property </description>
+        <resultNode name="context_020" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="context_021">
+        <description>context with multiple properties conforms to type with equivalent multiple properties </description>
+        <resultNode name="context_021" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="context_022">
+        <description>context with non-conforming property does not match type</description>
+        <resultNode name="context_022" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="context_023">
+        <description>context with nested context conforms to type</description>
+        <resultNode name="context_023" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="context_024">
+        <description>context with nested context dot not conform to type</description>
+        <resultNode name="context_024" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
 
     <testCase id="function_001">
         <description>function instance of Any is true</description>
@@ -1245,14 +1373,14 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="function_008">
+    <testCase id="function_008">
         <description>function instance of list is false</description>
         <resultNode name="function_008" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
 
     <testCase id="function_009">
         <description>function instance of years and months duration is false</description>
@@ -1272,22 +1400,94 @@
         </resultNode>
     </testCase>
 
-<!--     <testCase id="function_011">
+<!--    <testCase id="function_011">
         <description>function instance of context is false</description>
         <resultNode name="function_011" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase>
+    </testCase>-->
 
     <testCase id="function_012">
-        <description>function instance of function is true</description>
+        <description>conforms when no params and covariant return type</description>
         <resultNode name="function_012" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">true</value>
             </expected>
         </resultNode>
-    </testCase> -->
+    </testCase>
+
+    <testCase id="function_013">
+        <description>conforms when no params and equivalent return type</description>
+        <resultNode name="function_013" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_014">
+        <description>conforms when contravariant parm, covariant return type</description>
+        <resultNode name="function_014" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_015">
+        <description>does not conform when equivalent parm, non-covariant return type</description>
+        <resultNode name="function_015" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_016">
+        <description>conforms when contravariant parm, covariant return type</description>
+        <resultNode name="function_016" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_017">
+        <description>does not conform when non-contravariant parm, covariant return type</description>
+        <resultNode name="function_017" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_018">
+        <description>conforms when contravariant parms, covariant return type, same param arity</description>
+        <resultNode name="function_018" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_019">
+        <description>does not conform when contravariant parm, covariant return type, different param arity</description>
+        <resultNode name="function_019" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_020">
+        <description>conforms when multiple contravariant parms, equivalent return type</description>
+        <resultNode name="function_020" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
 
 </testCases>

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
@@ -330,7 +330,7 @@
                 <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
-    </testCase-->>
+    </testCase-->
 
     <testCase id="string_012">
         <description>string instance of function is false</description>

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of-test-01.xml
@@ -858,7 +858,7 @@
         </resultNode>
     </testCase>
 
-    <testCase id="list_20">
+    <testCase id="list_020">
         <description>list is an instance of inline list of inline context type</description>
         <resultNode name="list_020" type="decision">
             <expected>
@@ -867,7 +867,7 @@
         </resultNode>
     </testCase>
 
-    <testCase id="list_21">
+    <testCase id="list_021">
         <description>list is an instance of inline function types</description>
         <resultNode name="list_021" type="decision">
             <expected>
@@ -1486,6 +1486,96 @@
         <resultNode name="function_020" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_021">
+        <description>conforms to basic FunctionItem type</description>
+        <resultNode name="function_021" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_022">
+        <description>conforms to basic FunctionItem type with return type</description>
+        <resultNode name="function_022" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_023">
+        <description>does not conforms to basic FunctionItem type with return type</description>
+        <resultNode name="function_023" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_024">
+        <description>conforms to basic FunctionItem type with untyped params</description>
+        <resultNode name="function_024" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_025">
+        <description>conforms to basic FunctionItem type with simple typed params</description>
+        <resultNode name="function_025" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_026">
+        <description>does not conform to basic FunctionItem type with simple typed params</description>
+        <resultNode name="function_026" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_027">
+        <description>conform to list of function items</description>
+        <resultNode name="function_027" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_028">
+        <description>does not conform to list of function items</description>
+        <resultNode name="function_028" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_029">
+        <description>conforms to a context type with a function property</description>
+        <resultNode name="function_029" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="function_030">
+        <description>does not conform to a context type with a function property</description>
+        <resultNode name="function_030" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
@@ -1340,6 +1340,13 @@
         </literalExpression>
     </decision>
 
+    <decision name="function_031" id="_function_031">
+        <variable name="function_031"/>
+        <literalExpression>
+            <text>[(function(a: string, b: number) "123"), "foo"] instance of tListOfFunctions</text>
+        </literalExpression>
+    </decision>
+
 
 </definitions>
 

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
@@ -85,7 +85,7 @@
     <decision name="null_008" id="_null_008">
         <variable name="null_008"/>
         <literalExpression>
-            <text>null instance of list&lt;any&gt;</text>
+            <text>null instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -114,8 +114,8 @@
     <decision name="null_012" id="_null_012">
         <variable name="null_012"/>
         <literalExpression>
-            <!-- function<> -> any -->
-            <text>null instance of function&lt;&gt; -&gt; any</text>
+            <!-- function<> -> Any -->
+            <text>null instance of function&lt;&gt; -&gt; Any</text>
         </literalExpression>
     </decision>
 
@@ -171,7 +171,7 @@
     <decision name="number_008" id="_number_008">
         <variable name="number_008"/>
         <literalExpression>
-            <text>123.01 instance of list&lt;any&gt;</text>
+            <text>123.01 instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -199,7 +199,7 @@
     <decision name="number_012" id="_number_012">
         <variable name="number_012"/>
         <literalExpression>
-            <text>123.01 instance of function&lt;&gt;-&gt;any</text>
+            <text>123.01 instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -263,7 +263,7 @@
     <decision name="string_008" id="_string_008">
         <variable name="string_008"/>
         <literalExpression>
-            <text>"foo" instance of list&lt;any&gt;</text>
+            <text>"foo" instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -291,7 +291,7 @@
     <decision name="string_012" id="_string_012">
         <variable name="string_012"/>
         <literalExpression>
-            <text>"foo" instance of function&lt;&gt;-&gt;any</text>
+            <text>"foo" instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -356,7 +356,7 @@
     <decision name="boolean_008" id="_boolean_008">
         <variable name="boolean_008"/>
         <literalExpression>
-            <text>true instance of list&lt;any&gt;</text>
+            <text>true instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -386,7 +386,7 @@
     <decision name="boolean_012" id="_boolean_012">
         <variable name="boolean_012"/>
         <literalExpression>
-            <text>true instance of function&lt;&gt;-&gt;any</text>
+            <text>true instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -443,7 +443,7 @@
     <decision name="date_008" id="_date_008">
         <variable name="date_008"/>
         <literalExpression>
-            <text>date("2018-12-08") instance of list&lt;any&gt;</text>
+            <text>date("2018-12-08") instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -471,7 +471,7 @@
     <decision name="date_012" id="_date_012">
         <variable name="date_012"/>
         <literalExpression>
-            <text>date("2018-12-08") instance of function&lt;&gt;-&gt;any</text>
+            <text>date("2018-12-08") instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -527,7 +527,7 @@
     <decision name="time_008" id="_time_008">
         <variable name="time_008"/>
         <literalExpression>
-            <text>time("10:30:00") instance of list&lt;any&gt;</text>
+            <text>time("10:30:00") instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -555,7 +555,7 @@
     <decision name="time_012" id="_time_012">
         <variable name="time_012"/>
         <literalExpression>
-            <text>time("10:30:00") instance of function&lt;&gt;-&gt;any</text>
+            <text>time("10:30:00") instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -640,7 +640,7 @@
     <decision name="list_012" id="_list_012">
         <variable name="list_012"/>
         <literalExpression>
-            <text>[1,2,3] instance of function&lt;&gt;-&gt;any</text>
+            <text>[1,2,3] instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -770,7 +770,7 @@
     <decision name="ym_duration_008" id="_ym_duration_008">
         <variable name="ym_duration_008"/>
         <literalExpression>
-            <text>duration("P1Y") instance of list&lt;any&gt;</text>
+            <text>duration("P1Y") instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -798,7 +798,7 @@
     <decision name="ym_duration_012" id="_ym_duration_012">
         <variable name="ym_duration_012"/>
         <literalExpression>
-            <text>duration("P1Y") instance of function&lt;&gt;-&gt;any</text>
+            <text>duration("P1Y") instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -855,7 +855,7 @@
     <decision name="dt_duration_008" id="_dt_duration_008">
         <variable name="dt_duration_008"/>
         <literalExpression>
-            <text>duration("P1D") instance of list&lt;any&gt;</text>
+            <text>duration("P1D") instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -883,7 +883,7 @@
     <decision name="dt_duration_012" id="_dt_duration_012">
         <variable name="dt_duration_012"/>
         <literalExpression>
-            <text>duration("P1D") instance of function&lt;&gt;-&gt;any</text>
+            <text>duration("P1D") instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -940,7 +940,7 @@
     <decision name="context_008" id="_context_008">
         <variable name="context_008"/>
         <literalExpression>
-            <text>{a: "foo"} instance of list&lt;any&gt;</text>
+            <text>{a: "foo"} instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -968,7 +968,7 @@
     <decision name="context_012" id="_context_012">
         <variable name="context_012"/>
         <literalExpression>
-            <text>{a: "foo"} instance of function&lt;&gt;-&gt;any</text>
+            <text>{a: "foo"} instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 
@@ -1124,7 +1124,7 @@
     <decision name="function_008" id="_function_008">
         <variable name="function_008"/>
         <literalExpression>
-            <text>(function() "foo") instance of list&lt;any&gt;</text>
+            <text>(function() "foo") instance of list&lt;Any&gt;</text>
         </literalExpression>
     </decision>
 
@@ -1153,7 +1153,7 @@
         <variable name="function_012"/>
         <literalExpression>
             <!-- true: covariant return type -->
-            <text>(function() "foo") instance of function&lt;&gt;-&gt;any</text>
+            <text>(function() "foo") instance of function&lt;&gt;-&gt;Any</text>
         </literalExpression>
     </decision>
 

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
@@ -748,13 +748,15 @@
         </dmn:literalExpression>
     </dmn:decision>
 
+    <!-- comment out as per: https://github.com/dmn-tck/tck/pull/390#issuecomment-1053664450
     <dmn:decision name="list_021" id="_list_021">
         <dmn:variable name="list_021"/>
         <dmn:literalExpression>
-            <!-- list<function<string, string> -> number>> -->
+             // list<function<string, string> -> number>>
             <dmn:text>[(function(a:string, b:string) 1), (function(a:string, b:string) 2)] instance of list&lt;function&lt;string, string&gt;-&gt;number&gt;</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
+    -->
 
     <dmn:decision name="ym_duration_001" id="_ym_duration_001">
         <dmn:variable name="ym_duration_001"/>
@@ -1187,10 +1189,11 @@
         </dmn:literalExpression>
     </dmn:decision>-->
 
+    <!-- comment out as per: https://github.com/dmn-tck/tck/pull/390#issuecomment-1053664450
     <dmn:decision name="function_012" id="_function_012">
         <dmn:variable name="function_012"/>
         <dmn:literalExpression>
-            <!-- true: covariant return type -->
+             // true: covariant return type
             <dmn:text>(function() "foo") instance of function&lt;&gt;-&gt;Any</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1198,7 +1201,7 @@
     <dmn:decision name="function_013" id="_function_013">
         <dmn:variable name="function_013"/>
         <dmn:literalExpression>
-            <!-- true: equivalent return type -->
+             // true: equivalent return type
             <dmn:text>(function() "foo") instance of function&lt;&gt;-&gt;string</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1206,8 +1209,8 @@
     <dmn:decision name="function_014" id="_function_014">
         <dmn:variable name="function_014"/>
         <dmn:literalExpression>
-            <!-- true: equivalent parm, covariant return type -->
-            <!-- (function(a: list<number>) {b: "b", c: "c", d: "d"}) instance of function<list<number>> -> context<b: string, c: string> -->
+             // true: equivalent parm, covariant return type
+             // (function(a: list<number>) {b: "b", c: "c", d: "d"}) instance of function<list<number>> -> context<b: string, c: string>
             <dmn:text>(function(a: list&lt;number&gt;) {b: "b", c: "c", d: "d"}) instance of function&lt;list&lt;number&gt;&gt;-&gt;context&lt;b: string, c: string&gt;</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1215,8 +1218,8 @@
     <dmn:decision name="function_015" id="_function_015">
         <dmn:variable name="function_015"/>
         <dmn:literalExpression>
-            <!-- false: equivalent parm, non-covariant return type -->
-            <!-- (function(a: list<number>) {b: "b"}) instance of function<list<number>> -> context<b: string, c: string> -->
+             // false: equivalent parm, non-covariant return type
+             // (function(a: list<number>) {b: "b"}) instance of function<list<number>> -> context<b: string, c: string>
             <dmn:text>(function(a: list&lt;number&gt;) {b: "b"}) instance of function&lt;list&lt;number&gt;&gt;-&gt;context&lt;b: string, c: string&gt;</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1224,8 +1227,8 @@
     <dmn:decision name="function_016" id="_function_016">
         <dmn:variable name="function_016"/>
         <dmn:literalExpression>
-            <!-- true: contravariant parm, covariant return type -->
-            <!-- (function(a: context<a: string>) {b: "b", c: "c"}) instance of function<context<a: string, b: string> -> context<b: string> -->
+             // true: contravariant parm, covariant return type
+             // (function(a: context<a: string>) {b: "b", c: "c"}) instance of function<context<a: string, b: string> -> context<b: string>
             <dmn:text>(function(a: context&lt;a: string&gt;) {b: "b", c: "c"}) instance of function&lt;context&lt;a: string, b: string&gt;&gt;-&gt;context&lt;b: string&gt;</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1233,8 +1236,8 @@
     <dmn:decision name="function_017" id="_function_017">
         <dmn:variable name="function_017"/>
         <dmn:literalExpression>
-            <!-- false: non-contravariant parm, equivalent return type -->
-            <!-- (function(a: context<a: string, b: string>) "foo") instance of function<context<a: string> -> string -->
+             // false: non-contravariant parm, equivalent return type
+             // (function(a: context<a: string, b: string>) "foo") instance of function<context<a: string> -> string
             <dmn:text>(function(a: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string&gt;&gt;-&gt;string</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1242,8 +1245,8 @@
     <dmn:decision name="function_018" id="_function_018">
         <dmn:variable name="function_018"/>
         <dmn:literalExpression>
-            <!-- true: contravariant parm, equivalent return type, same param arity -->
-            <!-- (function(a: string, b: number> "foo") instance of function<string, number> -> string -->
+             // true: contravariant parm, equivalent return type, same param arity
+             // (function(a: string, b: number> "foo") instance of function<string, number> -> string
             <dmn:text>(function(a: string, b: number) "foo") instance of function&lt;string, number&gt;-&gt;string</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1251,8 +1254,8 @@
     <dmn:decision name="function_019" id="_function_019">
         <dmn:variable name="function_019"/>
         <dmn:literalExpression>
-            <!-- false: contravariant parm, equivalent return type, different param arity -->
-            <!-- (function(a: string, b: string> "foo") instance of function<string> -> string -->
+             // false: contravariant parm, equivalent return type, different param arity
+             // (function(a: string, b: string> "foo") instance of function<string> -> string
             <dmn:text>(function(a: string, b: string) "foo") instance of function&lt;string&gt;-&gt;string</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1260,8 +1263,8 @@
     <dmn:decision name="function_020" id="_function_020">
         <dmn:variable name="function_020"/>
         <dmn:literalExpression>
-            <!-- true: multiple contravariant parms, equivalent return type -->
-            <!-- (function(a: context<a: string>, b: context<a: string, b: string>> "foo") instance of function<context<a: string, b: string>, context<a: string, b: string, c: string>> -> string -->
+             // true: multiple contravariant parms, equivalent return type
+             // (function(a: context<a: string>, b: context<a: string, b: string>> "foo") instance of function<context<a: string, b: string>, context<a: string, b: string, c: string>> -> string
             <dmn:text>(function(a: context&lt;a: string&gt;, b: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string, b: string&gt;,context&lt;a: string, b: string, c: string&gt;&gt;-&gt;string</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1311,8 +1314,8 @@
     <dmn:decision name="function_027" id="_function_027">
         <dmn:variable name="function_027"/>
         <dmn:literalExpression>
-            <!-- note that the param names differ to each other and also tListOfFunctions - FEEL type conformance does
-            not consider param names -->
+             // note that the param names differ to each other and also tListOfFunctions - FEEL type conformance does
+            // not consider param names
             <dmn:text>[(function(a: string, b: number) "123"), (function(c: string, d: number) "456")] instance of tListOfFunctions</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1320,8 +1323,8 @@
     <dmn:decision name="function_028" id="_function_028">
         <dmn:variable name="function_028"/>
         <dmn:literalExpression>
-            <!-- true, not false.  The LHS list type is list<function<string, Any> -> string> which makes the 'b' param
-            contravariant to the b 'number' type in tListOfFunctions   -->
+             // true, not false.  The LHS list type is list<function<string, Any> -> string> which makes the 'b' param
+            // contravariant to the b 'number' type in tListOfFunctions
             <dmn:text>[(function(a: string, b: number) "123"), (function(c: string, d: string) "456")] instance of tListOfFunctions</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
@@ -1346,6 +1349,7 @@
             <dmn:text>[(function(a: string, b: number) "123"), "foo"] instance of tListOfFunctions</dmn:text>
         </dmn:literalExpression>
     </dmn:decision>
+    -->
 
 
 </dmn:definitions>

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
@@ -19,6 +19,20 @@
         <typeRef>Any</typeRef>
     </itemDefinition>
 
+    <itemDefinition name="t255">
+        <typeRef>number</typeRef>
+        <allowedValues>
+            <text>[0..255]</text>
+        </allowedValues>
+    </itemDefinition>
+
+    <itemDefinition name="tFooBar">
+        <typeRef>string</typeRef>
+        <allowedValues>
+            <text>"FOO", "BAR"</text>
+        </allowedValues>
+    </itemDefinition>
+
     <decision name="null_001" id="_null_001">
         <variable name="null_001"/>
         <literalExpression>
@@ -68,12 +82,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="null_008" id="_null_008">
+    <decision name="null_008" id="_null_008">
         <variable name="null_008"/>
         <literalExpression>
-            <text>null instance of list</text>
+            <text>null instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="null_009" id="_null_009">
         <variable name="null_009"/>
@@ -89,19 +103,21 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="null_011" id="_null_011">
+<!--    <decision name="null_011" id="_null_011">
         <variable name="null_011"/>
         <literalExpression>
-            <text>null instance of context</text>
+            &lt;!&ndash; context<> &ndash;&gt;
+            <text>null instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="null_012" id="_null_012">
+    <decision name="null_012" id="_null_012">
         <variable name="null_012"/>
         <literalExpression>
-            <text>null instance of function</text>
+            <!-- function<> -> any -->
+            <text>null instance of function&lt;&gt; -&gt; any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="number_001" id="_number_001">
         <variable name="number_001"/>
@@ -152,12 +168,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="number_008" id="_number_008">
+    <decision name="number_008" id="_number_008">
         <variable name="number_008"/>
         <literalExpression>
-            <text>123.01 instance of list</text>
+            <text>123.01 instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="number_009" id="_number_009">
         <variable name="number_009"/>
@@ -173,19 +189,27 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="number_011" id="_number_011">
+<!--    <decision name="number_011" id="_number_011">
         <variable name="number_011"/>
         <literalExpression>
-            <text>123.01 instance of context</text>
+            <text>123.01 instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="number_012" id="_number_012">
+    <decision name="number_012" id="_number_012">
         <variable name="number_012"/>
         <literalExpression>
-            <text>123.01 instance of function</text>
+            <text>123.01 instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
+
+    <decision name="number_013" id="_number_013">
+        <variable name="number_013"/>
+        <literalExpression>
+            <!-- true: does not take allowedValues into account -->
+            <text>256 instance of t255</text>
+        </literalExpression>
+    </decision>
 
     <decision name="string_001" id="_string_001">
         <variable name="string_001"/>
@@ -236,12 +260,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="string_008" id="_string_008">
+    <decision name="string_008" id="_string_008">
         <variable name="string_008"/>
         <literalExpression>
-            <text>"foo" instance of list</text>
+            <text>"foo" instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="string_009" id="_string_009">
         <variable name="string_009"/>
@@ -257,19 +281,27 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="string_011" id="_string_011">
+<!--    <decision name="string_011" id="_string_011">
         <variable name="string_011"/>
         <literalExpression>
-            <text>"foo" instance of context</text>
+            <text>"foo" instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="string_012" id="_string_012">
+    <decision name="string_012" id="_string_012">
         <variable name="string_012"/>
         <literalExpression>
-            <text>"foo" instance of function</text>
+            <text>"foo" instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
+
+    <decision name="string_013" id="_string_013">
+        <variable name="string_013"/>
+        <literalExpression>
+            <!-- true: does not take into account allowedValues -->
+            <text>"123" instance of tFooBar</text>
+        </literalExpression>
+    </decision>
 
 
     <decision name="boolean_001" id="_boolean_001">
@@ -321,12 +353,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="boolean_008" id="_boolean_008">
+    <decision name="boolean_008" id="_boolean_008">
         <variable name="boolean_008"/>
         <literalExpression>
-            <text>true instance of list</text>
+            <text>true instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="boolean_009" id="_boolean_009">
         <variable name="boolean_009"/>
@@ -342,19 +374,21 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="boolean_011" id="_boolean_011">
+<!--
+    <decision name="boolean_011" id="_boolean_011">
         <variable name="boolean_011"/>
         <literalExpression>
-            <text>true instance of context</text>
+            <text>true instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
+-->
 
-<!--     <decision name="boolean_012" id="_boolean_012">
+    <decision name="boolean_012" id="_boolean_012">
         <variable name="boolean_012"/>
         <literalExpression>
-            <text>true instance of function</text>
+            <text>true instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
 
     <decision name="date_001" id="_date_001">
@@ -406,12 +440,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="date_008" id="_date_008">
+    <decision name="date_008" id="_date_008">
         <variable name="date_008"/>
         <literalExpression>
-            <text>date("2018-12-08") instance of list</text>
+            <text>date("2018-12-08") instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="date_009" id="_date_009">
         <variable name="date_009"/>
@@ -427,19 +461,19 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="date_011" id="_date_011">
+<!--    <decision name="date_011" id="_date_011">
         <variable name="date_011"/>
         <literalExpression>
-            <text>date("2018-12-08") instance of context</text>
+            <text>date("2018-12-08") instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="date_012" id="_date_012">
+    <decision name="date_012" id="_date_012">
         <variable name="date_012"/>
         <literalExpression>
-            <text>date("2018-12-08") instance of function</text>
+            <text>date("2018-12-08") instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="time_001" id="_time_001">
         <variable name="time_001"/>
@@ -490,12 +524,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="time_008" id="_time_008">
+    <decision name="time_008" id="_time_008">
         <variable name="time_008"/>
         <literalExpression>
-            <text>time("10:30:00") instance of list</text>
+            <text>time("10:30:00") instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="time_009" id="_time_009">
         <variable name="time_009"/>
@@ -511,19 +545,19 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="time_011" id="_time_011">
+<!--    <decision name="time_011" id="_time_011">
         <variable name="time_011"/>
         <literalExpression>
-            <text>time("10:30:00") instance of context</text>
+            <text>time("10:30:00") instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="time_012" id="_time_012">
+    <decision name="time_012" id="_time_012">
         <variable name="time_012"/>
         <literalExpression>
-            <text>time("10:30:00") instance of function</text>
+            <text>time("10:30:00") instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="list_001" id="_list_001">
         <variable name="list_001"/>
@@ -574,12 +608,13 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="list_008" id="_list_008">
+    <decision name="list_008" id="_list_008">
         <variable name="list_008"/>
         <literalExpression>
-            <text>[1,2,3] instance of list</text>
+            <!-- list<Any>-->
+            <text>[1,2,3] instance of list&lt;Any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="list_009" id="_list_009">
         <variable name="list_009"/>
@@ -595,28 +630,28 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="list_011" id="_list_011">
+<!--    <decision name="list_011" id="_list_011">
         <variable name="list_011"/>
         <literalExpression>
-            <text>[1,2,3] instance of context</text>
+            <text>[1,2,3] instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="list_012" id="_list_012">
+    <decision name="list_012" id="_list_012">
         <variable name="list_012"/>
         <literalExpression>
-            <text>[1,2,3] instance of function</text>
+            <text>[1,2,3] instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
-<!--     <decision name="list_013" id="_list_013">
+    <decision name="list_013" id="_list_013">
         <variable name="list_013"/>
         <literalExpression>
             <text>[1,2,3] instance of tNumberList</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
-<!--     <decision name="list_014" id="_list_014">
+    <decision name="list_014" id="_list_014">
         <variable name="list_014"/>
         <literalExpression>
             <text>[1,"2", date("2018-12-08")] instance of tAnyList</text>
@@ -628,14 +663,14 @@
         <literalExpression>
             <text>[] instance of tAnyList</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
-<!--     <decision name="list_015" id="_list_015">
+    <decision name="list_015" id="_list_015">
         <variable name="list_015"/>
         <literalExpression>
             <text>[1,"2", date("2018-12-08")] instance of tNumberList</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="list_016" id="_list_016">
         <variable name="list_016"/>
@@ -644,12 +679,44 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="list_017" id="_list_017">
+    <decision name="list_017" id="_list_017">
         <variable name="list_017"/>
         <literalExpression>
             <text>1 instance of tNumberList</text>
         </literalExpression>
-    </decision> -->
+    </decision>
+
+    <decision name="list_018" id="_list_018">
+        <variable name="list_018"/>
+        <literalExpression>
+            <!-- list<t_context_013>-->
+            <text>[{a: "a", b: "b"}] instance of list&lt;t_context_013&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="list_019" id="_list_019">
+        <variable name="list_019"/>
+        <literalExpression>
+            <!-- list<t_context_013>-->
+            <text>[{a: "a"}] instance of list&lt;t_context_013&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="list_020" id="_list_020">
+        <variable name="list_020"/>
+        <literalExpression>
+            <!-- list<context<a: string, b: string>>-->
+            <text>[{a: "a", b: "b"}] instance of list&lt;context&lt;a: string, b: string&gt;&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="list_021" id="_list_021">
+        <variable name="list_021"/>
+        <literalExpression>
+            <!-- list<function<string, string> -> number>> -->
+            <text>[(function(a:string, b:string) 1), (function(a:string, b:string) 2)] instance of list&lt;function&lt;string, string&gt;-&gt;number&gt;</text>
+        </literalExpression>
+    </decision>
 
     <decision name="ym_duration_001" id="_ym_duration_001">
         <variable name="ym_duration_001"/>
@@ -700,12 +767,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="ym_duration_008" id="_ym_duration_008">
+    <decision name="ym_duration_008" id="_ym_duration_008">
         <variable name="ym_duration_008"/>
         <literalExpression>
-            <text>duration("P1Y") instance of list</text>
+            <text>duration("P1Y") instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="ym_duration_009" id="_ym_duration_009">
         <variable name="ym_duration_009"/>
@@ -721,19 +788,19 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="ym_duration_011" id="_ym_duration_011">
+<!--    <decision name="ym_duration_011" id="_ym_duration_011">
         <variable name="ym_duration_011"/>
         <literalExpression>
-            <text>duration("P1Y") instance of context</text>
+            <text>duration("P1Y") instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="ym_duration_012" id="_ym_duration_012">
+    <decision name="ym_duration_012" id="_ym_duration_012">
         <variable name="ym_duration_012"/>
         <literalExpression>
-            <text>duration("P1Y") instance of function</text>
+            <text>duration("P1Y") instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
 
     <decision name="dt_duration_001" id="_dt_duration_001">
@@ -785,12 +852,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="dt_duration_008" id="_dt_duration_008">
+    <decision name="dt_duration_008" id="_dt_duration_008">
         <variable name="dt_duration_008"/>
         <literalExpression>
-            <text>duration("P1D") instance of list</text>
+            <text>duration("P1D") instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="dt_duration_009" id="_dt_duration_009">
         <variable name="dt_duration_009"/>
@@ -806,19 +873,19 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="dt_duration_011" id="_dt_duration_011">
+<!--    <decision name="dt_duration_011" id="_dt_duration_011">
         <variable name="dt_duration_011"/>
         <literalExpression>
-            <text>duration("P1D") instance of context</text>
+            <text>duration("P1D") instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="dt_duration_012" id="_dt_duration_012">
+    <decision name="dt_duration_012" id="_dt_duration_012">
         <variable name="dt_duration_012"/>
         <literalExpression>
-            <text>duration("P1D") instance of function</text>
+            <text>duration("P1D") instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
 
     <decision name="context_001" id="_context_001">
@@ -870,12 +937,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="context_008" id="_context_008">
+    <decision name="context_008" id="_context_008">
         <variable name="context_008"/>
         <literalExpression>
-            <text>{a: "foo"} instance of list</text>
+            <text>{a: "foo"} instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="context_009" id="_context_009">
         <variable name="context_009"/>
@@ -891,21 +958,21 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="context_011" id="_context_011">
+<!--    <decision name="context_011" id="_context_011">
         <variable name="context_011"/>
         <literalExpression>
-            <text>{a: "foo"} instance of context</text>
+            <text>{a: "foo"} instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="context_012" id="_context_012">
+    <decision name="context_012" id="_context_012">
         <variable name="context_012"/>
         <literalExpression>
-            <text>{a: "foo"} instance of function</text>
+            <text>{a: "foo"} instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
-<!--     <decision name="context_013" id="_context_013">
+    <decision name="context_013" id="_context_013">
         <variable name="context_013"/>
         <literalExpression>
             <text>{a: "foo", b: "bar"} instance of t_context_013</text>
@@ -931,7 +998,78 @@
         <literalExpression>
             <text>{a: "foo", b: [1,2,3]} instance of t_context_013</text>
         </literalExpression>
-    </decision> -->
+    </decision>
+
+<!--    <decision name="context_017" id="_context_017">
+        <variable name="context_017"/>
+        <literalExpression>
+            &lt;!&ndash; true &ndash;&gt;
+            <text>{} instance of context&lt;&gt;</text>
+        </literalExpression>
+    </decision>-->
+
+    <decision name="context_018" id="_context_018">
+        <variable name="context_018"/>
+        <literalExpression>
+            <!-- true -->
+            <!-- {a: "foo"} instance of context<a: string> -->
+            <text>{a: "foo"} instance of context&lt;a: string&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="context_019" id="_context_019">
+        <variable name="context_019"/>
+        <literalExpression>
+            <!-- true -->
+            <!-- {a: null} instance of context<a: string> -->
+            <text>{a: null} instance of context&lt;a: string&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="context_020" id="_context_020">
+        <variable name="context_020"/>
+        <literalExpression>
+            <!-- true -->
+            <!-- {a: "123", b: 123} instance of context<a: string> -->
+            <text>{a: "123", b: 123} instance of context&lt;a: string&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="context_021" id="_context_021">
+        <variable name="context_021"/>
+        <literalExpression>
+            <!-- true -->
+            <!-- {a: "123", b: 123} instance of context<a: string, b: number> -->
+            <text>{a: "123", b: 123} instance of context&lt;a: string, b: number&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="context_022" id="_context_022">
+        <variable name="context_022"/>
+        <literalExpression>
+            <!-- false -->
+            <!-- {a: "123"} instance of context<a: number> -->
+            <text>{a: "123"} instance of context&lt;a: number&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="context_023" id="_context_023">
+        <variable name="context_023"/>
+        <literalExpression>
+            <!-- true -->
+            <!-- {a: {b: 123}} instance of context<a: context<b: number>> -->
+            <text>{a: {b: 123}} instance of context&lt;a: context&lt;b: number&gt;&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="context_024" id="_context_024">
+        <variable name="context_024"/>
+        <literalExpression>
+            <!-- false -->
+            <!-- {a: {b: 123}} instance of context<a: context<b: string>> -->
+            <text>{a: {b: 123}} instance of context&lt;a: context&lt;b: string&gt;&gt;</text>
+        </literalExpression>
+    </decision>
 
 
     <decision name="function_001" id="_function_001">
@@ -983,12 +1121,12 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="function_008" id="_function_008">
+    <decision name="function_008" id="_function_008">
         <variable name="function_008"/>
         <literalExpression>
-            <text>(function() "foo") instance of list</text>
+            <text>(function() "foo") instance of list&lt;any&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
     <decision name="function_009" id="_function_009">
         <variable name="function_009"/>
@@ -1004,21 +1142,91 @@
         </literalExpression>
     </decision>
 
-<!--     <decision name="function_011" id="_function_011">
+<!--    <decision name="function_011" id="_function_011">
         <variable name="function_011"/>
         <literalExpression>
-            <text>(function() "foo") instance of context</text>
+            <text>(function() "foo") instance of context&lt;&gt;</text>
         </literalExpression>
-    </decision> -->
+    </decision>-->
 
-<!--     <decision name="function_012" id="_function_012">
+    <decision name="function_012" id="_function_012">
         <variable name="function_012"/>
         <literalExpression>
-            <text>(function() "foo") instance of function</text>
+            <!-- true: covariant return type -->
+            <text>(function() "foo") instance of function&lt;&gt;-&gt;any</text>
         </literalExpression>
-    </decision> -->
+    </decision>
 
+    <decision name="function_013" id="_function_013">
+        <variable name="function_013"/>
+        <literalExpression>
+            <!-- true: equivalent return type -->
+            <text>(function() "foo") instance of function&lt;&gt;-&gt;string</text>
+        </literalExpression>
+    </decision>
 
+    <decision name="function_014" id="_function_014">
+        <variable name="function_014"/>
+        <literalExpression>
+            <!-- true: equivalent parm, covariant return type -->
+            <!-- (function(a: list<number>) {b: "b", c: "c", d: "d"}) instance of function<list<number>> -> context<b: string, c: string> -->
+            <text>(function(a: list&lt;number&gt;) {b: "b", c: "c", d: "d"}) instance of function&lt;list&lt;number&gt;&gt;-&gt;context&lt;b: string, c: string&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_015" id="_function_015">
+        <variable name="function_015"/>
+        <literalExpression>
+            <!-- false: equivalent parm, non-covariant return type -->
+            <!-- (function(a: list<number>) {b: "b"}) instance of function<list<number>> -> context<b: string, c: string> -->
+            <text>(function(a: list&lt;number&gt;) {b: "b"}) instance of function&lt;list&lt;number&gt;&gt;-&gt;context&lt;b: string, c: string&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_016" id="_function_016">
+        <variable name="function_016"/>
+        <literalExpression>
+            <!-- true: contravariant parm, covariant return type -->
+            <!-- (function(a: context<a: string>) {b: "b", c: "c"}) instance of function<context<a: string, b: string> -> context<b: string> -->
+            <text>(function(a: context&lt;a: string&gt;) {b: "b", c: "c"}) instance of function&lt;context&lt;a: string, b: string&gt;&gt;-&gt;context&lt;b: string&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_017" id="_function_017">
+        <variable name="function_017"/>
+        <literalExpression>
+            <!-- false: non-contravariant parm, equivalent return type -->
+            <!-- (function(a: context<a: string, b: string>) "foo") instance of function<context<a: string> -> string -->
+            <text>(function(a: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string&gt;&gt;-&gt;string</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_018" id="_function_018">
+        <variable name="function_018"/>
+        <literalExpression>
+            <!-- true: contravariant parm, equivalent return type, same param arity -->
+            <!-- (function(a: string, b: number> "foo") instance of function<string, number> -> string -->
+            <text>(function(a: string, b: number) "foo") instance of function&lt;string, number&gt;-&gt;string</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_019" id="_function_019">
+        <variable name="function_019"/>
+        <literalExpression>
+            <!-- false: contravariant parm, equivalent return type, different param arity -->
+            <!-- (function(a: string, b: string> "foo") instance of function<string> -> string -->
+            <text>(function(a: string, b: string) "foo") instance of function&lt;string&gt;-&gt;string</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_020" id="_function_020">
+        <variable name="function_020"/>
+        <literalExpression>
+            <!-- true: multiple contravariant parms, equivalent return type -->
+            <!-- (function(a: context<a: string>, b: context<a: string, b: string>> "foo") instance of function<context<a: string, b: string>, context<a: string, b: string, c: string>> -> string -->
+            <text>(function(a: context&lt;a: string&gt;, b: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string, b: string&gt;,context&lt;a: string, b: string, c: string&gt;&gt;-&gt;string</text>
+        </literalExpression>
+    </decision>
 
 </definitions>
 

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
@@ -33,6 +33,44 @@
         </allowedValues>
     </itemDefinition>
 
+    <itemDefinition name="tFunctionWithNoParams">
+        <functionItem></functionItem>
+    </itemDefinition>
+
+    <itemDefinition name="tStringFunctionWithNoParams">
+        <functionItem outputTypeRef="string"></functionItem>
+    </itemDefinition>
+
+    <itemDefinition name="tStringFunctionWithUntypedParams">
+        <functionItem outputTypeRef="string">
+            <parameters name="p1"></parameters>
+            <parameters name="p2"></parameters>
+        </functionItem>
+    </itemDefinition>
+
+    <itemDefinition name="tListOfFunctions" isCollection="true">
+        <!-- note - the typeRef here has not yet been declared in the XML. This
+        is on purpose to catch the assumption that item definitions are declared
+        in a 'nice' order -->
+        <typeRef>tStringFunctionWithSimpleTypedParams</typeRef>
+    </itemDefinition>
+
+    <itemDefinition name="tContextWithFunction">
+        <itemComponent name="prop1">
+            <!-- note - the typeRef here has not yet been declared in the XML. This
+            is on purpose to catch the assumption that item definitions are declared
+            in a 'nice' order -->
+            <typeRef>tStringFunctionWithSimpleTypedParams</typeRef>
+        </itemComponent>
+    </itemDefinition>
+
+    <itemDefinition name="tStringFunctionWithSimpleTypedParams">
+        <functionItem outputTypeRef="string">
+            <parameters name="p1" typeRef="string"></parameters>
+            <parameters name="p2" typeRef="number"></parameters>
+        </functionItem>
+    </itemDefinition>
+
     <decision name="null_001" id="_null_001">
         <variable name="null_001"/>
         <literalExpression>
@@ -1227,6 +1265,81 @@
             <text>(function(a: context&lt;a: string&gt;, b: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string, b: string&gt;,context&lt;a: string, b: string, c: string&gt;&gt;-&gt;string</text>
         </literalExpression>
     </decision>
+
+    <decision name="function_021" id="_function_021">
+        <variable name="function_021"/>
+        <literalExpression>
+            <text>(function() "foo") instance of tFunctionWithNoParams</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_022" id="_function_022">
+        <variable name="function_022"/>
+        <literalExpression>
+            <text>(function() "foo") instance of tStringFunctionWithNoParams</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_023" id="_function_023">
+        <variable name="function_023"/>
+        <literalExpression>
+            <text>(function() 123) instance of tStringFunctionWithNoParams</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_024" id="_function_024">
+        <variable name="function_024"/>
+        <literalExpression>
+            <text>(function(a, b) "123") instance of tStringFunctionWithUntypedParams</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_025" id="_function_025">
+        <variable name="function_025"/>
+        <literalExpression>
+            <text>(function(a: string, b: number) "123") instance of tStringFunctionWithSimpleTypedParams</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_026" id="_function_026">
+        <variable name="function_026"/>
+        <literalExpression>
+            <text>(function(a: string, b: string) "123") instance of tStringFunctionWithSimpleTypedParams</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_027" id="_function_027">
+        <variable name="function_027"/>
+        <literalExpression>
+            <!-- note that the param names differ to each other and also tListOfFunctions - FEEL type conformance does
+            not consider param names -->
+            <text>[(function(a: string, b: number) "123"), (function(c: string, d: number) "456")] instance of tListOfFunctions</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_028" id="_function_028">
+        <variable name="function_028"/>
+        <literalExpression>
+            <!-- true, not false.  The LHS list type is list<function<string, Any> -> string> which makes the 'b' param
+            contravariant to the b 'number' type in tListOfFunctions   -->
+            <text>[(function(a: string, b: number) "123"), (function(c: string, d: string) "456")] instance of tListOfFunctions</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_029" id="_function_029">
+        <variable name="function_029"/>
+        <literalExpression>
+            <text>{prop1: (function(a: string, b: number) "123")} instance of tContextWithFunction</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="function_030" id="_function_030">
+        <variable name="function_030"/>
+        <literalExpression>
+            <text>{prop1: (function(a: string, b: string) "123")} instance of tContextWithFunction</text>
+        </literalExpression>
+    </decision>
+
 
 </definitions>
 

--- a/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
+++ b/TestCases/compliance-level-3/0070-feel-instance-of/0070-feel-instance-of.dmn
@@ -1,1352 +1,1351 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<definitions namespace="http://www.montera.com.au/spec/DMN/0070-feel-instance-of" name="0070-feel-instance-of" id="_i9fboPUUEeesLuP4RHs4vA" xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <description>FEEL instance of</description>
+<dmn:definitions namespace="http://www.montera.com.au/spec/DMN/0070-feel-instance-of" xmlns:dmn="https://www.omg.org/spec/DMN/20191111/MODEL/" name="0070-feel-instance-of" id="_i9fboPUUEeesLuP4RHs4vA" xmlns="http://www.montera.com.au/spec/DMN/0070-feel-instance-of" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <dmn:description>FEEL instance of</dmn:description>
 
-    <itemDefinition name="t_context_013">
-        <itemComponent name="a">
-            <typeRef>string</typeRef>
-        </itemComponent>
-        <itemComponent name="b">
-            <typeRef>string</typeRef>
-        </itemComponent>
-    </itemDefinition>
+    <dmn:itemDefinition name="t_context_013">
+        <dmn:itemComponent name="a">
+            <dmn:typeRef>string</dmn:typeRef>
+        </dmn:itemComponent>
+        <dmn:itemComponent name="b">
+            <dmn:typeRef>string</dmn:typeRef>
+        </dmn:itemComponent>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tNumberList" isCollection="true">
-        <typeRef>number</typeRef>
-    </itemDefinition>
+    <dmn:itemDefinition name="tNumberList" isCollection="true">
+        <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tAnyList" isCollection="true">
-        <typeRef>Any</typeRef>
-    </itemDefinition>
+    <dmn:itemDefinition name="tAnyList" isCollection="true">
+        <dmn:typeRef>Any</dmn:typeRef>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="t255">
-        <typeRef>number</typeRef>
-        <allowedValues>
-            <text>[0..255]</text>
-        </allowedValues>
-    </itemDefinition>
+    <dmn:itemDefinition name="t255">
+        <dmn:typeRef>number</dmn:typeRef>
+        <dmn:allowedValues>
+            <dmn:text>[0..255]</dmn:text>
+        </dmn:allowedValues>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tFooBar">
-        <typeRef>string</typeRef>
-        <allowedValues>
-            <text>"FOO", "BAR"</text>
-        </allowedValues>
-    </itemDefinition>
+    <dmn:itemDefinition name="tFooBar">
+        <dmn:typeRef>string</dmn:typeRef>
+        <dmn:allowedValues>
+            <dmn:text>"FOO", "BAR"</dmn:text>
+        </dmn:allowedValues>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tFunctionWithNoParams">
-        <functionItem></functionItem>
-    </itemDefinition>
+    <dmn:itemDefinition name="tFunctionWithNoParams">
+        <dmn:functionItem></dmn:functionItem>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tStringFunctionWithNoParams">
-        <functionItem outputTypeRef="string"></functionItem>
-    </itemDefinition>
+    <dmn:itemDefinition name="tStringFunctionWithNoParams">
+        <dmn:functionItem outputTypeRef="string"></dmn:functionItem>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tStringFunctionWithUntypedParams">
-        <functionItem outputTypeRef="string">
-            <parameters name="p1"></parameters>
-            <parameters name="p2"></parameters>
-        </functionItem>
-    </itemDefinition>
+    <dmn:itemDefinition name="tStringFunctionWithUntypedParams">
+        <dmn:functionItem outputTypeRef="string">
+            <dmn:parameters name="p1"></dmn:parameters>
+            <dmn:parameters name="p2"></dmn:parameters>
+        </dmn:functionItem>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tListOfFunctions" isCollection="true">
+    <dmn:itemDefinition name="tListOfFunctions" isCollection="true">
         <!-- note - the typeRef here has not yet been declared in the XML. This
         is on purpose to catch the assumption that item definitions are declared
         in a 'nice' order -->
-        <typeRef>tStringFunctionWithSimpleTypedParams</typeRef>
-    </itemDefinition>
+        <dmn:typeRef>tStringFunctionWithSimpleTypedParams</dmn:typeRef>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tContextWithFunction">
-        <itemComponent name="prop1">
+    <dmn:itemDefinition name="tContextWithFunction">
+        <dmn:itemComponent name="prop1">
             <!-- note - the typeRef here has not yet been declared in the XML. This
             is on purpose to catch the assumption that item definitions are declared
             in a 'nice' order -->
-            <typeRef>tStringFunctionWithSimpleTypedParams</typeRef>
-        </itemComponent>
-    </itemDefinition>
+            <dmn:typeRef>tStringFunctionWithSimpleTypedParams</dmn:typeRef>
+        </dmn:itemComponent>
+    </dmn:itemDefinition>
 
-    <itemDefinition name="tStringFunctionWithSimpleTypedParams">
-        <functionItem outputTypeRef="string">
-            <parameters name="p1" typeRef="string"></parameters>
-            <parameters name="p2" typeRef="number"></parameters>
-        </functionItem>
-    </itemDefinition>
+    <dmn:itemDefinition name="tStringFunctionWithSimpleTypedParams">
+        <dmn:functionItem outputTypeRef="string">
+            <dmn:parameters name="p1" typeRef="string"></dmn:parameters>
+            <dmn:parameters name="p2" typeRef="number"></dmn:parameters>
+        </dmn:functionItem>
+    </dmn:itemDefinition>
 
-    <decision name="null_001" id="_null_001">
-        <variable name="null_001"/>
-        <literalExpression>
-            <text>null instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_001" id="_null_001">
+        <dmn:variable name="null_001"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_002" id="_null_002">
-        <variable name="null_002"/>
-        <literalExpression>
-            <text>null instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_002" id="_null_002">
+        <dmn:variable name="null_002"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_003" id="_null_003">
-        <variable name="null_003"/>
-        <literalExpression>
-            <text>null instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_003" id="_null_003">
+        <dmn:variable name="null_003"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_004" id="_null_004">
-        <variable name="null_004"/>
-        <literalExpression>
-            <text>null instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_004" id="_null_004">
+        <dmn:variable name="null_004"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_005" id="_null_005">
-        <variable name="null_005"/>
-        <literalExpression>
-            <text>null instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_005" id="_null_005">
+        <dmn:variable name="null_005"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_006" id="_null_006">
-        <variable name="null_006"/>
-        <literalExpression>
-            <text>null instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_006" id="_null_006">
+        <dmn:variable name="null_006"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_007" id="_null_007">
-        <variable name="null_007"/>
-        <literalExpression>
-            <text>null instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_007" id="_null_007">
+        <dmn:variable name="null_007"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_008" id="_null_008">
-        <variable name="null_008"/>
-        <literalExpression>
-            <text>null instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_008" id="_null_008">
+        <dmn:variable name="null_008"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_009" id="_null_009">
-        <variable name="null_009"/>
-        <literalExpression>
-            <text>null instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_009" id="_null_009">
+        <dmn:variable name="null_009"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="null_010" id="_null_010">
-        <variable name="null_010"/>
-        <literalExpression>
-            <text>null instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_010" id="_null_010">
+        <dmn:variable name="null_010"/>
+        <dmn:literalExpression>
+            <dmn:text>null instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="null_011" id="_null_011">
-        <variable name="null_011"/>
-        <literalExpression>
+<!--    <dmn:decision name="null_011" id="_null_011">
+        <dmn:variable name="null_011"/>
+        <dmn:literalExpression>
             &lt;!&ndash; context<> &ndash;&gt;
-            <text>null instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+            <dmn:text>null instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="null_012" id="_null_012">
-        <variable name="null_012"/>
-        <literalExpression>
-            <!-- function<> -> Any -->
-            <text>null instance of function&lt;&gt; -&gt; Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="null_012" id="_null_012">
+        <dmn:variable name="null_012"/>
+        <dmn:literalExpression>
+            <!-- function<dmn:> -> Any -->
+            <dmn:text>null instance of function&lt;&gt; -&gt; Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_001" id="_number_001">
-        <variable name="number_001"/>
-        <literalExpression>
-            <text>123.01 instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_001" id="_number_001">
+        <dmn:variable name="number_001"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_002" id="_number_002">
-        <variable name="number_002"/>
-        <literalExpression>
-            <text>123.01 instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_002" id="_number_002">
+        <dmn:variable name="number_002"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_003" id="_number_003">
-        <variable name="number_003"/>
-        <literalExpression>
-            <text>123.01 instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_003" id="_number_003">
+        <dmn:variable name="number_003"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_004" id="_number_004">
-        <variable name="number_004"/>
-        <literalExpression>
-            <text>123.01 instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_004" id="_number_004">
+        <dmn:variable name="number_004"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_005" id="_number_005">
-        <variable name="number_005"/>
-        <literalExpression>
-            <text>123.01 instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_005" id="_number_005">
+        <dmn:variable name="number_005"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_006" id="_number_006">
-        <variable name="number_006"/>
-        <literalExpression>
-            <text>123.01 instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_006" id="_number_006">
+        <dmn:variable name="number_006"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_007" id="_number_007">
-        <variable name="number_007"/>
-        <literalExpression>
-            <text>123.01 instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_007" id="_number_007">
+        <dmn:variable name="number_007"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_008" id="_number_008">
-        <variable name="number_008"/>
-        <literalExpression>
-            <text>123.01 instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_008" id="_number_008">
+        <dmn:variable name="number_008"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_009" id="_number_009">
-        <variable name="number_009"/>
-        <literalExpression>
-            <text>123.01 instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_009" id="_number_009">
+        <dmn:variable name="number_009"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_010" id="_number_010">
-        <variable name="number_010"/>
-        <literalExpression>
-            <text>123.01 instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_010" id="_number_010">
+        <dmn:variable name="number_010"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="number_011" id="_number_011">
-        <variable name="number_011"/>
-        <literalExpression>
-            <text>123.01 instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+<!--    <dmn:decision name="number_011" id="_number_011">
+        <dmn:variable name="number_011"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="number_012" id="_number_012">
-        <variable name="number_012"/>
-        <literalExpression>
-            <text>123.01 instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="number_012" id="_number_012">
+        <dmn:variable name="number_012"/>
+        <dmn:literalExpression>
+            <dmn:text>123.01 instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="number_013" id="_number_013">
-        <variable name="number_013"/>
-        <literalExpression>
+    <dmn:decision name="number_013" id="_number_013">
+        <dmn:variable name="number_013"/>
+        <dmn:literalExpression>
             <!-- true: does not take allowedValues into account -->
-            <text>256 instance of t255</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>256 instance of t255</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_001" id="_string_001">
-        <variable name="string_001"/>
-        <literalExpression>
-            <text>"foo" instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_001" id="_string_001">
+        <dmn:variable name="string_001"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_002" id="_string_002">
-        <variable name="string_002"/>
-        <literalExpression>
-            <text>"foo" instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_002" id="_string_002">
+        <dmn:variable name="string_002"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_003" id="_string_003">
-        <variable name="string_003"/>
-        <literalExpression>
-            <text>"foo" instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_003" id="_string_003">
+        <dmn:variable name="string_003"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_004" id="_string_004">
-        <variable name="string_004"/>
-        <literalExpression>
-            <text>"foo" instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_004" id="_string_004">
+        <dmn:variable name="string_004"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_005" id="_string_005">
-        <variable name="string_005"/>
-        <literalExpression>
-            <text>"foo" instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_005" id="_string_005">
+        <dmn:variable name="string_005"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_006" id="_string_006">
-        <variable name="string_006"/>
-        <literalExpression>
-            <text>"foo" instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_006" id="_string_006">
+        <dmn:variable name="string_006"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_007" id="_string_007">
-        <variable name="string_007"/>
-        <literalExpression>
-            <text>"foo" instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_007" id="_string_007">
+        <dmn:variable name="string_007"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_008" id="_string_008">
-        <variable name="string_008"/>
-        <literalExpression>
-            <text>"foo" instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_008" id="_string_008">
+        <dmn:variable name="string_008"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_009" id="_string_009">
-        <variable name="string_009"/>
-        <literalExpression>
-            <text>"foo" instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_009" id="_string_009">
+        <dmn:variable name="string_009"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_010" id="_string_010">
-        <variable name="string_010"/>
-        <literalExpression>
-            <text>"foo" instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_010" id="_string_010">
+        <dmn:variable name="string_010"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="string_011" id="_string_011">
-        <variable name="string_011"/>
-        <literalExpression>
-            <text>"foo" instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+<!--    <dmn:decision name="string_011" id="_string_011">
+        <dmn:variable name="string_011"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="string_012" id="_string_012">
-        <variable name="string_012"/>
-        <literalExpression>
-            <text>"foo" instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="string_012" id="_string_012">
+        <dmn:variable name="string_012"/>
+        <dmn:literalExpression>
+            <dmn:text>"foo" instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="string_013" id="_string_013">
-        <variable name="string_013"/>
-        <literalExpression>
+    <dmn:decision name="string_013" id="_string_013">
+        <dmn:variable name="string_013"/>
+        <dmn:literalExpression>
             <!-- true: does not take into account allowedValues -->
-            <text>"123" instance of tFooBar</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>"123" instance of tFooBar</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
 
-    <decision name="boolean_001" id="_boolean_001">
-        <variable name="boolean_001"/>
-        <literalExpression>
-            <text>true instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_001" id="_boolean_001">
+        <dmn:variable name="boolean_001"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_002" id="_boolean_002">
-        <variable name="boolean_002"/>
-        <literalExpression>
-            <text>true instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_002" id="_boolean_002">
+        <dmn:variable name="boolean_002"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_003" id="_boolean_003">
-        <variable name="boolean_003"/>
-        <literalExpression>
-            <text>true instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_003" id="_boolean_003">
+        <dmn:variable name="boolean_003"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_004" id="_boolean_004">
-        <variable name="boolean_004"/>
-        <literalExpression>
-            <text>true instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_004" id="_boolean_004">
+        <dmn:variable name="boolean_004"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_005" id="_boolean_005">
-        <variable name="boolean_005"/>
-        <literalExpression>
-            <text>true instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_005" id="_boolean_005">
+        <dmn:variable name="boolean_005"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_006" id="_boolean_006">
-        <variable name="boolean_006"/>
-        <literalExpression>
-            <text>true instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_006" id="_boolean_006">
+        <dmn:variable name="boolean_006"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_007" id="_boolean_007">
-        <variable name="boolean_007"/>
-        <literalExpression>
-            <text>true instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_007" id="_boolean_007">
+        <dmn:variable name="boolean_007"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_008" id="_boolean_008">
-        <variable name="boolean_008"/>
-        <literalExpression>
-            <text>true instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_008" id="_boolean_008">
+        <dmn:variable name="boolean_008"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_009" id="_boolean_009">
-        <variable name="boolean_009"/>
-        <literalExpression>
-            <text>true instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_009" id="_boolean_009">
+        <dmn:variable name="boolean_009"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="boolean_010" id="_boolean_010">
-        <variable name="boolean_010"/>
-        <literalExpression>
-            <text>true instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_010" id="_boolean_010">
+        <dmn:variable name="boolean_010"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
 <!--
-    <decision name="boolean_011" id="_boolean_011">
-        <variable name="boolean_011"/>
-        <literalExpression>
-            <text>true instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_011" id="_boolean_011">
+        <dmn:variable name="boolean_011"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 -->
 
-    <decision name="boolean_012" id="_boolean_012">
-        <variable name="boolean_012"/>
-        <literalExpression>
-            <text>true instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="boolean_012" id="_boolean_012">
+        <dmn:variable name="boolean_012"/>
+        <dmn:literalExpression>
+            <dmn:text>true instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
 
-    <decision name="date_001" id="_date_001">
-        <variable name="date_001"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_001" id="_date_001">
+        <dmn:variable name="date_001"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_002" id="_date_002">
-        <variable name="date_002"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_002" id="_date_002">
+        <dmn:variable name="date_002"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_003" id="_date_003">
-        <variable name="date_003"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_003" id="_date_003">
+        <dmn:variable name="date_003"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_004" id="_date_004">
-        <variable name="date_004"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_004" id="_date_004">
+        <dmn:variable name="date_004"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_005" id="_date_005">
-        <variable name="date_005"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_005" id="_date_005">
+        <dmn:variable name="date_005"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_006" id="_date_006">
-        <variable name="date_006"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_006" id="_date_006">
+        <dmn:variable name="date_006"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_007" id="_date_007">
-        <variable name="date_007"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_007" id="_date_007">
+        <dmn:variable name="date_007"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_008" id="_date_008">
-        <variable name="date_008"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_008" id="_date_008">
+        <dmn:variable name="date_008"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_009" id="_date_009">
-        <variable name="date_009"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_009" id="_date_009">
+        <dmn:variable name="date_009"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="date_010" id="_date_010">
-        <variable name="date_010"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_010" id="_date_010">
+        <dmn:variable name="date_010"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="date_011" id="_date_011">
-        <variable name="date_011"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+<!--    <dmn:decision name="date_011" id="_date_011">
+        <dmn:variable name="date_011"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="date_012" id="_date_012">
-        <variable name="date_012"/>
-        <literalExpression>
-            <text>date("2018-12-08") instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="date_012" id="_date_012">
+        <dmn:variable name="date_012"/>
+        <dmn:literalExpression>
+            <dmn:text>date("2018-12-08") instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_001" id="_time_001">
-        <variable name="time_001"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_001" id="_time_001">
+        <dmn:variable name="time_001"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_002" id="_time_002">
-        <variable name="time_002"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_002" id="_time_002">
+        <dmn:variable name="time_002"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_003" id="_time_003">
-        <variable name="time_003"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_003" id="_time_003">
+        <dmn:variable name="time_003"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_004" id="_time_004">
-        <variable name="time_004"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_004" id="_time_004">
+        <dmn:variable name="time_004"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_005" id="_time_005">
-        <variable name="time_005"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_005" id="_time_005">
+        <dmn:variable name="time_005"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_006" id="_time_006">
-        <variable name="time_006"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_006" id="_time_006">
+        <dmn:variable name="time_006"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_007" id="_time_007">
-        <variable name="time_007"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_007" id="_time_007">
+        <dmn:variable name="time_007"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_008" id="_time_008">
-        <variable name="time_008"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_008" id="_time_008">
+        <dmn:variable name="time_008"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_009" id="_time_009">
-        <variable name="time_009"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_009" id="_time_009">
+        <dmn:variable name="time_009"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="time_010" id="_time_010">
-        <variable name="time_010"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_010" id="_time_010">
+        <dmn:variable name="time_010"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="time_011" id="_time_011">
-        <variable name="time_011"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+<!--    <dmn:decision name="time_011" id="_time_011">
+        <dmn:variable name="time_011"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="time_012" id="_time_012">
-        <variable name="time_012"/>
-        <literalExpression>
-            <text>time("10:30:00") instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="time_012" id="_time_012">
+        <dmn:variable name="time_012"/>
+        <dmn:literalExpression>
+            <dmn:text>time("10:30:00") instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_001" id="_list_001">
-        <variable name="list_001"/>
-        <literalExpression>
-            <text>[1,2,3] instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_001" id="_list_001">
+        <dmn:variable name="list_001"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_002" id="_list_002">
-        <variable name="list_002"/>
-        <literalExpression>
-            <text>[1,2,3] instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_002" id="_list_002">
+        <dmn:variable name="list_002"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_003" id="_list_003">
-        <variable name="list_003"/>
-        <literalExpression>
-            <text>[1,2,3] instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_003" id="_list_003">
+        <dmn:variable name="list_003"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_004" id="_list_004">
-        <variable name="list_004"/>
-        <literalExpression>
-            <text>[1,2,3] instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_004" id="_list_004">
+        <dmn:variable name="list_004"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_005" id="_list_005">
-        <variable name="list_005"/>
-        <literalExpression>
-            <text>[1,2,3] instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_005" id="_list_005">
+        <dmn:variable name="list_005"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_006" id="_list_006">
-        <variable name="list_006"/>
-        <literalExpression>
-            <text>[1,2,3] instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_006" id="_list_006">
+        <dmn:variable name="list_006"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_007" id="_list_007">
-        <variable name="list_007"/>
-        <literalExpression>
-            <text>[1,2,3] instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_007" id="_list_007">
+        <dmn:variable name="list_007"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_008" id="_list_008">
-        <variable name="list_008"/>
-        <literalExpression>
+    <dmn:decision name="list_008" id="_list_008">
+        <dmn:variable name="list_008"/>
+        <dmn:literalExpression>
             <!-- list<Any>-->
-            <text>[1,2,3] instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>[1,2,3] instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_009" id="_list_009">
-        <variable name="list_009"/>
-        <literalExpression>
-            <text>[1,2,3] instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_009" id="_list_009">
+        <dmn:variable name="list_009"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_010" id="_list_010">
-        <variable name="list_010"/>
-        <literalExpression>
-            <text>[1,2,3] instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_010" id="_list_010">
+        <dmn:variable name="list_010"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="list_011" id="_list_011">
-        <variable name="list_011"/>
-        <literalExpression>
-            <text>[1,2,3] instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+<!--    <dmn:decision name="list_011" id="_list_011">
+        <dmn:variable name="list_011"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="list_012" id="_list_012">
-        <variable name="list_012"/>
-        <literalExpression>
-            <text>[1,2,3] instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_012" id="_list_012">
+        <dmn:variable name="list_012"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_013" id="_list_013">
-        <variable name="list_013"/>
-        <literalExpression>
-            <text>[1,2,3] instance of tNumberList</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_013" id="_list_013">
+        <dmn:variable name="list_013"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,2,3] instance of tNumberList</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_014" id="_list_014">
-        <variable name="list_014"/>
-        <literalExpression>
-            <text>[1,"2", date("2018-12-08")] instance of tAnyList</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_014" id="_list_014">
+        <dmn:variable name="list_014"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,"2", date("2018-12-08")] instance of tAnyList</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_014_a" id="_list_014_a">
-        <variable name="list_014_a"/>
-        <literalExpression>
-            <text>[] instance of tAnyList</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_014_a" id="_list_014_a">
+        <dmn:variable name="list_014_a"/>
+        <dmn:literalExpression>
+            <dmn:text>[] instance of tAnyList</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_015" id="_list_015">
-        <variable name="list_015"/>
-        <literalExpression>
-            <text>[1,"2", date("2018-12-08")] instance of tNumberList</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_015" id="_list_015">
+        <dmn:variable name="list_015"/>
+        <dmn:literalExpression>
+            <dmn:text>[1,"2", date("2018-12-08")] instance of tNumberList</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_016" id="_list_016">
-        <variable name="list_016"/>
-        <literalExpression>
-            <text>[1] instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_016" id="_list_016">
+        <dmn:variable name="list_016"/>
+        <dmn:literalExpression>
+            <dmn:text>[1] instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_017" id="_list_017">
-        <variable name="list_017"/>
-        <literalExpression>
-            <text>1 instance of tNumberList</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="list_017" id="_list_017">
+        <dmn:variable name="list_017"/>
+        <dmn:literalExpression>
+            <dmn:text>1 instance of tNumberList</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_018" id="_list_018">
-        <variable name="list_018"/>
-        <literalExpression>
+    <dmn:decision name="list_018" id="_list_018">
+        <dmn:variable name="list_018"/>
+        <dmn:literalExpression>
             <!-- list<t_context_013>-->
-            <text>[{a: "a", b: "b"}] instance of list&lt;t_context_013&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>[{a: "a", b: "b"}] instance of list&lt;t_context_013&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_019" id="_list_019">
-        <variable name="list_019"/>
-        <literalExpression>
+    <dmn:decision name="list_019" id="_list_019">
+        <dmn:variable name="list_019"/>
+        <dmn:literalExpression>
             <!-- list<t_context_013>-->
-            <text>[{a: "a"}] instance of list&lt;t_context_013&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>[{a: "a"}] instance of list&lt;t_context_013&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_020" id="_list_020">
-        <variable name="list_020"/>
-        <literalExpression>
+    <dmn:decision name="list_020" id="_list_020">
+        <dmn:variable name="list_020"/>
+        <dmn:literalExpression>
             <!-- list<context<a: string, b: string>>-->
-            <text>[{a: "a", b: "b"}] instance of list&lt;context&lt;a: string, b: string&gt;&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>[{a: "a", b: "b"}] instance of list&lt;context&lt;a: string, b: string&gt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="list_021" id="_list_021">
-        <variable name="list_021"/>
-        <literalExpression>
+    <dmn:decision name="list_021" id="_list_021">
+        <dmn:variable name="list_021"/>
+        <dmn:literalExpression>
             <!-- list<function<string, string> -> number>> -->
-            <text>[(function(a:string, b:string) 1), (function(a:string, b:string) 2)] instance of list&lt;function&lt;string, string&gt;-&gt;number&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>[(function(a:string, b:string) 1), (function(a:string, b:string) 2)] instance of list&lt;function&lt;string, string&gt;-&gt;number&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_001" id="_ym_duration_001">
-        <variable name="ym_duration_001"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_001" id="_ym_duration_001">
+        <dmn:variable name="ym_duration_001"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_002" id="_ym_duration_002">
-        <variable name="ym_duration_002"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_002" id="_ym_duration_002">
+        <dmn:variable name="ym_duration_002"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_003" id="_ym_duration_003">
-        <variable name="ym_duration_003"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_003" id="_ym_duration_003">
+        <dmn:variable name="ym_duration_003"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_004" id="_ym_duration_004">
-        <variable name="ym_duration_004"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_004" id="_ym_duration_004">
+        <dmn:variable name="ym_duration_004"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_005" id="_ym_duration_005">
-        <variable name="ym_duration_005"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_005" id="_ym_duration_005">
+        <dmn:variable name="ym_duration_005"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_006" id="_ym_duration_006">
-        <variable name="ym_duration_006"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_006" id="_ym_duration_006">
+        <dmn:variable name="ym_duration_006"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_007" id="_ym_duration_007">
-        <variable name="ym_duration_007"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_007" id="_ym_duration_007">
+        <dmn:variable name="ym_duration_007"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_008" id="_ym_duration_008">
-        <variable name="ym_duration_008"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_008" id="_ym_duration_008">
+        <dmn:variable name="ym_duration_008"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_009" id="_ym_duration_009">
-        <variable name="ym_duration_009"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_009" id="_ym_duration_009">
+        <dmn:variable name="ym_duration_009"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="ym_duration_010" id="_ym_duration_010">
-        <variable name="ym_duration_010"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_010" id="_ym_duration_010">
+        <dmn:variable name="ym_duration_010"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="ym_duration_011" id="_ym_duration_011">
-        <variable name="ym_duration_011"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+<!--    <dmn:decision name="ym_duration_011" id="_ym_duration_011">
+        <dmn:variable name="ym_duration_011"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="ym_duration_012" id="_ym_duration_012">
-        <variable name="ym_duration_012"/>
-        <literalExpression>
-            <text>duration("P1Y") instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
-
-
-    <decision name="dt_duration_001" id="_dt_duration_001">
-        <variable name="dt_duration_001"/>
-        <literalExpression>
-            <text>duration("P1D") instance of Any</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_002" id="_dt_duration_002">
-        <variable name="dt_duration_002"/>
-        <literalExpression>
-            <text>duration("P1D") instance of number</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_003" id="_dt_duration_003">
-        <variable name="dt_duration_003"/>
-        <literalExpression>
-            <text>duration("P1D") instance of string</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_004" id="_dt_duration_004">
-        <variable name="dt_duration_004"/>
-        <literalExpression>
-            <text>duration("P1D") instance of boolean</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_005" id="_dt_duration_005">
-        <variable name="dt_duration_005"/>
-        <literalExpression>
-            <text>duration("P1D") instance of date</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_006" id="_dt_duration_006">
-        <variable name="dt_duration_006"/>
-        <literalExpression>
-            <text>duration("P1D") instance of time</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_007" id="_dt_duration_007">
-        <variable name="dt_duration_007"/>
-        <literalExpression>
-            <text>duration("P1D") instance of date and time</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_008" id="_dt_duration_008">
-        <variable name="dt_duration_008"/>
-        <literalExpression>
-            <text>duration("P1D") instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_009" id="_dt_duration_009">
-        <variable name="dt_duration_009"/>
-        <literalExpression>
-            <text>duration("P1D") instance of years and months duration</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="dt_duration_010" id="_dt_duration_010">
-        <variable name="dt_duration_010"/>
-        <literalExpression>
-            <text>duration("P1D") instance of days and time duration</text>
-        </literalExpression>
-    </decision>
-
-<!--    <decision name="dt_duration_011" id="_dt_duration_011">
-        <variable name="dt_duration_011"/>
-        <literalExpression>
-            <text>duration("P1D") instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
-
-    <decision name="dt_duration_012" id="_dt_duration_012">
-        <variable name="dt_duration_012"/>
-        <literalExpression>
-            <text>duration("P1D") instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="ym_duration_012" id="_ym_duration_012">
+        <dmn:variable name="ym_duration_012"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1Y") instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
 
-    <decision name="context_001" id="_context_001">
-        <variable name="context_001"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_001" id="_dt_duration_001">
+        <dmn:variable name="dt_duration_001"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_002" id="_context_002">
-        <variable name="context_002"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_002" id="_dt_duration_002">
+        <dmn:variable name="dt_duration_002"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_003" id="_context_003">
-        <variable name="context_003"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_003" id="_dt_duration_003">
+        <dmn:variable name="dt_duration_003"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_004" id="_context_004">
-        <variable name="context_004"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_004" id="_dt_duration_004">
+        <dmn:variable name="dt_duration_004"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_005" id="_context_005">
-        <variable name="context_005"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_005" id="_dt_duration_005">
+        <dmn:variable name="dt_duration_005"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_006" id="_context_006">
-        <variable name="context_006"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_006" id="_dt_duration_006">
+        <dmn:variable name="dt_duration_006"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_007" id="_context_007">
-        <variable name="context_007"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_007" id="_dt_duration_007">
+        <dmn:variable name="dt_duration_007"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_008" id="_context_008">
-        <variable name="context_008"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_008" id="_dt_duration_008">
+        <dmn:variable name="dt_duration_008"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_009" id="_context_009">
-        <variable name="context_009"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_009" id="_dt_duration_009">
+        <dmn:variable name="dt_duration_009"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_010" id="_context_010">
-        <variable name="context_010"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_010" id="_dt_duration_010">
+        <dmn:variable name="dt_duration_010"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="context_011" id="_context_011">
-        <variable name="context_011"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+<!--    <dmn:decision name="dt_duration_011" id="_dt_duration_011">
+        <dmn:variable name="dt_duration_011"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="context_012" id="_context_012">
-        <variable name="context_012"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="dt_duration_012" id="_dt_duration_012">
+        <dmn:variable name="dt_duration_012"/>
+        <dmn:literalExpression>
+            <dmn:text>duration("P1D") instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_013" id="_context_013">
-        <variable name="context_013"/>
-        <literalExpression>
-            <text>{a: "foo", b: "bar"} instance of t_context_013</text>
-        </literalExpression>
-    </decision>
 
-    <decision name="context_014" id="_context_014">
-        <variable name="context_014"/>
-        <literalExpression>
-            <text>{a: "foo", b: "bar"} instance of t_context_013</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="context_001" id="_context_001">
+        <dmn:variable name="context_001"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_015" id="_context_015">
-        <variable name="context_015"/>
-        <literalExpression>
-            <text>{a: "foo"} instance of t_context_013</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="context_002" id="_context_002">
+        <dmn:variable name="context_002"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_016" id="_context_016">
-        <variable name="context_016"/>
-        <literalExpression>
-            <text>{a: "foo", b: [1,2,3]} instance of t_context_013</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="context_003" id="_context_003">
+        <dmn:variable name="context_003"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="context_017" id="_context_017">
-        <variable name="context_017"/>
-        <literalExpression>
+    <dmn:decision name="context_004" id="_context_004">
+        <dmn:variable name="context_004"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_005" id="_context_005">
+        <dmn:variable name="context_005"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_006" id="_context_006">
+        <dmn:variable name="context_006"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_007" id="_context_007">
+        <dmn:variable name="context_007"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_008" id="_context_008">
+        <dmn:variable name="context_008"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_009" id="_context_009">
+        <dmn:variable name="context_009"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_010" id="_context_010">
+        <dmn:variable name="context_010"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+<!--    <dmn:decision name="context_011" id="_context_011">
+        <dmn:variable name="context_011"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
+
+    <dmn:decision name="context_012" id="_context_012">
+        <dmn:variable name="context_012"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_013" id="_context_013">
+        <dmn:variable name="context_013"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo", b: "bar"} instance of t_context_013</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_014" id="_context_014">
+        <dmn:variable name="context_014"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo", b: "bar", c: "baz"} instance of t_context_013</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_015" id="_context_015">
+        <dmn:variable name="context_015"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo"} instance of t_context_013</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+    <dmn:decision name="context_016" id="_context_016">
+        <dmn:variable name="context_016"/>
+        <dmn:literalExpression>
+            <dmn:text>{a: "foo", b: [1,2,3]} instance of t_context_013</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
+
+<!--    <dmn:decision name="context_017" id="_context_017">
+        <dmn:variable name="context_017"/>
+        <dmn:literalExpression>
             &lt;!&ndash; true &ndash;&gt;
-            <text>{} instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+            <dmn:text>{} instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="context_018" id="_context_018">
-        <variable name="context_018"/>
-        <literalExpression>
+    <dmn:decision name="context_018" id="_context_018">
+        <dmn:variable name="context_018"/>
+        <dmn:literalExpression>
             <!-- true -->
             <!-- {a: "foo"} instance of context<a: string> -->
-            <text>{a: "foo"} instance of context&lt;a: string&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>{a: "foo"} instance of context&lt;a: string&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_019" id="_context_019">
-        <variable name="context_019"/>
-        <literalExpression>
+    <dmn:decision name="context_019" id="_context_019">
+        <dmn:variable name="context_019"/>
+        <dmn:literalExpression>
             <!-- true -->
             <!-- {a: null} instance of context<a: string> -->
-            <text>{a: null} instance of context&lt;a: string&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>{a: null} instance of context&lt;a: string&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_020" id="_context_020">
-        <variable name="context_020"/>
-        <literalExpression>
+    <dmn:decision name="context_020" id="_context_020">
+        <dmn:variable name="context_020"/>
+        <dmn:literalExpression>
             <!-- true -->
             <!-- {a: "123", b: 123} instance of context<a: string> -->
-            <text>{a: "123", b: 123} instance of context&lt;a: string&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>{a: "123", b: 123} instance of context&lt;a: string&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_021" id="_context_021">
-        <variable name="context_021"/>
-        <literalExpression>
+    <dmn:decision name="context_021" id="_context_021">
+        <dmn:variable name="context_021"/>
+        <dmn:literalExpression>
             <!-- true -->
             <!-- {a: "123", b: 123} instance of context<a: string, b: number> -->
-            <text>{a: "123", b: 123} instance of context&lt;a: string, b: number&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>{a: "123", b: 123} instance of context&lt;a: string, b: number&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_022" id="_context_022">
-        <variable name="context_022"/>
-        <literalExpression>
+    <dmn:decision name="context_022" id="_context_022">
+        <dmn:variable name="context_022"/>
+        <dmn:literalExpression>
             <!-- false -->
             <!-- {a: "123"} instance of context<a: number> -->
-            <text>{a: "123"} instance of context&lt;a: number&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>{a: "123"} instance of context&lt;a: number&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_023" id="_context_023">
-        <variable name="context_023"/>
-        <literalExpression>
+    <dmn:decision name="context_023" id="_context_023">
+        <dmn:variable name="context_023"/>
+        <dmn:literalExpression>
             <!-- true -->
             <!-- {a: {b: 123}} instance of context<a: context<b: number>> -->
-            <text>{a: {b: 123}} instance of context&lt;a: context&lt;b: number&gt;&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>{a: {b: 123}} instance of context&lt;a: context&lt;b: number&gt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="context_024" id="_context_024">
-        <variable name="context_024"/>
-        <literalExpression>
+    <dmn:decision name="context_024" id="_context_024">
+        <dmn:variable name="context_024"/>
+        <dmn:literalExpression>
             <!-- false -->
             <!-- {a: {b: 123}} instance of context<a: context<b: string>> -->
-            <text>{a: {b: 123}} instance of context&lt;a: context&lt;b: string&gt;&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>{a: {b: 123}} instance of context&lt;a: context&lt;b: string&gt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
 
-    <decision name="function_001" id="_function_001">
-        <variable name="function_001"/>
-        <literalExpression>
-            <text>(function() "foo") instance of Any</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_001" id="_function_001">
+        <dmn:variable name="function_001"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_002" id="_function_002">
-        <variable name="function_002"/>
-        <literalExpression>
-            <text>(function() "foo") instance of number</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_002" id="_function_002">
+        <dmn:variable name="function_002"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of number</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_003" id="_function_003">
-        <variable name="function_003"/>
-        <literalExpression>
-            <text>(function() "foo") instance of string</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_003" id="_function_003">
+        <dmn:variable name="function_003"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_004" id="_function_004">
-        <variable name="function_004"/>
-        <literalExpression>
-            <text>(function() "foo") instance of boolean</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_004" id="_function_004">
+        <dmn:variable name="function_004"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of boolean</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_005" id="_function_005">
-        <variable name="function_005"/>
-        <literalExpression>
-            <text>(function() "foo") instance of date</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_005" id="_function_005">
+        <dmn:variable name="function_005"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of date</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_006" id="_function_006">
-        <variable name="function_006"/>
-        <literalExpression>
-            <text>(function() "foo") instance of time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_006" id="_function_006">
+        <dmn:variable name="function_006"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_007" id="_function_007">
-        <variable name="function_007"/>
-        <literalExpression>
-            <text>(function() "foo") instance of date and time</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_007" id="_function_007">
+        <dmn:variable name="function_007"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of date and time</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_008" id="_function_008">
-        <variable name="function_008"/>
-        <literalExpression>
-            <text>(function() "foo") instance of list&lt;Any&gt;</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_008" id="_function_008">
+        <dmn:variable name="function_008"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of list&lt;Any&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_009" id="_function_009">
-        <variable name="function_009"/>
-        <literalExpression>
-            <text>(function() "foo") instance of years and months duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_009" id="_function_009">
+        <dmn:variable name="function_009"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of years and months duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_010" id="_function_010">
-        <variable name="function_010"/>
-        <literalExpression>
-            <text>(function() "foo") instance of days and time duration</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_010" id="_function_010">
+        <dmn:variable name="function_010"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of days and time duration</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-<!--    <decision name="function_011" id="_function_011">
-        <variable name="function_011"/>
-        <literalExpression>
-            <text>(function() "foo") instance of context&lt;&gt;</text>
-        </literalExpression>
-    </decision>-->
+<!--    <dmn:decision name="function_011" id="_function_011">
+        <dmn:variable name="function_011"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of context&lt;&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>-->
 
-    <decision name="function_012" id="_function_012">
-        <variable name="function_012"/>
-        <literalExpression>
+    <dmn:decision name="function_012" id="_function_012">
+        <dmn:variable name="function_012"/>
+        <dmn:literalExpression>
             <!-- true: covariant return type -->
-            <text>(function() "foo") instance of function&lt;&gt;-&gt;Any</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function() "foo") instance of function&lt;&gt;-&gt;Any</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_013" id="_function_013">
-        <variable name="function_013"/>
-        <literalExpression>
+    <dmn:decision name="function_013" id="_function_013">
+        <dmn:variable name="function_013"/>
+        <dmn:literalExpression>
             <!-- true: equivalent return type -->
-            <text>(function() "foo") instance of function&lt;&gt;-&gt;string</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function() "foo") instance of function&lt;&gt;-&gt;string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_014" id="_function_014">
-        <variable name="function_014"/>
-        <literalExpression>
+    <dmn:decision name="function_014" id="_function_014">
+        <dmn:variable name="function_014"/>
+        <dmn:literalExpression>
             <!-- true: equivalent parm, covariant return type -->
             <!-- (function(a: list<number>) {b: "b", c: "c", d: "d"}) instance of function<list<number>> -> context<b: string, c: string> -->
-            <text>(function(a: list&lt;number&gt;) {b: "b", c: "c", d: "d"}) instance of function&lt;list&lt;number&gt;&gt;-&gt;context&lt;b: string, c: string&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function(a: list&lt;number&gt;) {b: "b", c: "c", d: "d"}) instance of function&lt;list&lt;number&gt;&gt;-&gt;context&lt;b: string, c: string&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_015" id="_function_015">
-        <variable name="function_015"/>
-        <literalExpression>
+    <dmn:decision name="function_015" id="_function_015">
+        <dmn:variable name="function_015"/>
+        <dmn:literalExpression>
             <!-- false: equivalent parm, non-covariant return type -->
             <!-- (function(a: list<number>) {b: "b"}) instance of function<list<number>> -> context<b: string, c: string> -->
-            <text>(function(a: list&lt;number&gt;) {b: "b"}) instance of function&lt;list&lt;number&gt;&gt;-&gt;context&lt;b: string, c: string&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function(a: list&lt;number&gt;) {b: "b"}) instance of function&lt;list&lt;number&gt;&gt;-&gt;context&lt;b: string, c: string&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_016" id="_function_016">
-        <variable name="function_016"/>
-        <literalExpression>
+    <dmn:decision name="function_016" id="_function_016">
+        <dmn:variable name="function_016"/>
+        <dmn:literalExpression>
             <!-- true: contravariant parm, covariant return type -->
             <!-- (function(a: context<a: string>) {b: "b", c: "c"}) instance of function<context<a: string, b: string> -> context<b: string> -->
-            <text>(function(a: context&lt;a: string&gt;) {b: "b", c: "c"}) instance of function&lt;context&lt;a: string, b: string&gt;&gt;-&gt;context&lt;b: string&gt;</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function(a: context&lt;a: string&gt;) {b: "b", c: "c"}) instance of function&lt;context&lt;a: string, b: string&gt;&gt;-&gt;context&lt;b: string&gt;</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_017" id="_function_017">
-        <variable name="function_017"/>
-        <literalExpression>
+    <dmn:decision name="function_017" id="_function_017">
+        <dmn:variable name="function_017"/>
+        <dmn:literalExpression>
             <!-- false: non-contravariant parm, equivalent return type -->
             <!-- (function(a: context<a: string, b: string>) "foo") instance of function<context<a: string> -> string -->
-            <text>(function(a: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string&gt;&gt;-&gt;string</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function(a: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string&gt;&gt;-&gt;string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_018" id="_function_018">
-        <variable name="function_018"/>
-        <literalExpression>
+    <dmn:decision name="function_018" id="_function_018">
+        <dmn:variable name="function_018"/>
+        <dmn:literalExpression>
             <!-- true: contravariant parm, equivalent return type, same param arity -->
             <!-- (function(a: string, b: number> "foo") instance of function<string, number> -> string -->
-            <text>(function(a: string, b: number) "foo") instance of function&lt;string, number&gt;-&gt;string</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function(a: string, b: number) "foo") instance of function&lt;string, number&gt;-&gt;string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_019" id="_function_019">
-        <variable name="function_019"/>
-        <literalExpression>
+    <dmn:decision name="function_019" id="_function_019">
+        <dmn:variable name="function_019"/>
+        <dmn:literalExpression>
             <!-- false: contravariant parm, equivalent return type, different param arity -->
             <!-- (function(a: string, b: string> "foo") instance of function<string> -> string -->
-            <text>(function(a: string, b: string) "foo") instance of function&lt;string&gt;-&gt;string</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function(a: string, b: string) "foo") instance of function&lt;string&gt;-&gt;string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_020" id="_function_020">
-        <variable name="function_020"/>
-        <literalExpression>
+    <dmn:decision name="function_020" id="_function_020">
+        <dmn:variable name="function_020"/>
+        <dmn:literalExpression>
             <!-- true: multiple contravariant parms, equivalent return type -->
             <!-- (function(a: context<a: string>, b: context<a: string, b: string>> "foo") instance of function<context<a: string, b: string>, context<a: string, b: string, c: string>> -> string -->
-            <text>(function(a: context&lt;a: string&gt;, b: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string, b: string&gt;,context&lt;a: string, b: string, c: string&gt;&gt;-&gt;string</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>(function(a: context&lt;a: string&gt;, b: context&lt;a: string, b: string&gt;) "foo") instance of function&lt;context&lt;a: string, b: string&gt;,context&lt;a: string, b: string, c: string&gt;&gt;-&gt;string</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_021" id="_function_021">
-        <variable name="function_021"/>
-        <literalExpression>
-            <text>(function() "foo") instance of tFunctionWithNoParams</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_021" id="_function_021">
+        <dmn:variable name="function_021"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of tFunctionWithNoParams</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_022" id="_function_022">
-        <variable name="function_022"/>
-        <literalExpression>
-            <text>(function() "foo") instance of tStringFunctionWithNoParams</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_022" id="_function_022">
+        <dmn:variable name="function_022"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() "foo") instance of tStringFunctionWithNoParams</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_023" id="_function_023">
-        <variable name="function_023"/>
-        <literalExpression>
-            <text>(function() 123) instance of tStringFunctionWithNoParams</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_023" id="_function_023">
+        <dmn:variable name="function_023"/>
+        <dmn:literalExpression>
+            <dmn:text>(function() 123) instance of tStringFunctionWithNoParams</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_024" id="_function_024">
-        <variable name="function_024"/>
-        <literalExpression>
-            <text>(function(a, b) "123") instance of tStringFunctionWithUntypedParams</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_024" id="_function_024">
+        <dmn:variable name="function_024"/>
+        <dmn:literalExpression>
+            <dmn:text>(function(a, b) "123") instance of tStringFunctionWithUntypedParams</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_025" id="_function_025">
-        <variable name="function_025"/>
-        <literalExpression>
-            <text>(function(a: string, b: number) "123") instance of tStringFunctionWithSimpleTypedParams</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_025" id="_function_025">
+        <dmn:variable name="function_025"/>
+        <dmn:literalExpression>
+            <dmn:text>(function(a: string, b: number) "123") instance of tStringFunctionWithSimpleTypedParams</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_026" id="_function_026">
-        <variable name="function_026"/>
-        <literalExpression>
-            <text>(function(a: string, b: string) "123") instance of tStringFunctionWithSimpleTypedParams</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_026" id="_function_026">
+        <dmn:variable name="function_026"/>
+        <dmn:literalExpression>
+            <dmn:text>(function(a: string, b: string) "123") instance of tStringFunctionWithSimpleTypedParams</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_027" id="_function_027">
-        <variable name="function_027"/>
-        <literalExpression>
+    <dmn:decision name="function_027" id="_function_027">
+        <dmn:variable name="function_027"/>
+        <dmn:literalExpression>
             <!-- note that the param names differ to each other and also tListOfFunctions - FEEL type conformance does
             not consider param names -->
-            <text>[(function(a: string, b: number) "123"), (function(c: string, d: number) "456")] instance of tListOfFunctions</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>[(function(a: string, b: number) "123"), (function(c: string, d: number) "456")] instance of tListOfFunctions</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_028" id="_function_028">
-        <variable name="function_028"/>
-        <literalExpression>
+    <dmn:decision name="function_028" id="_function_028">
+        <dmn:variable name="function_028"/>
+        <dmn:literalExpression>
             <!-- true, not false.  The LHS list type is list<function<string, Any> -> string> which makes the 'b' param
             contravariant to the b 'number' type in tListOfFunctions   -->
-            <text>[(function(a: string, b: number) "123"), (function(c: string, d: string) "456")] instance of tListOfFunctions</text>
-        </literalExpression>
-    </decision>
+            <dmn:text>[(function(a: string, b: number) "123"), (function(c: string, d: string) "456")] instance of tListOfFunctions</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_029" id="_function_029">
-        <variable name="function_029"/>
-        <literalExpression>
-            <text>{prop1: (function(a: string, b: number) "123")} instance of tContextWithFunction</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_029" id="_function_029">
+        <dmn:variable name="function_029"/>
+        <dmn:literalExpression>
+            <dmn:text>{prop1: (function(a: string, b: number) "123")} instance of tContextWithFunction</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_030" id="_function_030">
-        <variable name="function_030"/>
-        <literalExpression>
-            <text>{prop1: (function(a: string, b: string) "123")} instance of tContextWithFunction</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_030" id="_function_030">
+        <dmn:variable name="function_030"/>
+        <dmn:literalExpression>
+            <dmn:text>{prop1: (function(a: string, b: string) "123")} instance of tContextWithFunction</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
-    <decision name="function_031" id="_function_031">
-        <variable name="function_031"/>
-        <literalExpression>
-            <text>[(function(a: string, b: number) "123"), "foo"] instance of tListOfFunctions</text>
-        </literalExpression>
-    </decision>
+    <dmn:decision name="function_031" id="_function_031">
+        <dmn:variable name="function_031"/>
+        <dmn:literalExpression>
+            <dmn:text>[(function(a: string, b: number) "123"), "foo"] instance of tListOfFunctions</dmn:text>
+        </dmn:literalExpression>
+    </dmn:decision>
 
 
-</definitions>
-
+</dmn:definitions>


### PR DESCRIPTION
DMN 1.3 instance of changes - and some stuff

Some previously-commented tests have been uncommented now that types are a supported syntax. 

A series of tests for list, context and function type conformity.

Note (very oddly) there is no syntax in the DMN 1.3 spec for range types, so we officially can't check (say) if `[1..2] instance of range<number>`.

Also, it is not possible to check if something is simply a context or a function.  The described grammar for context requires _at least_ one property.  So, it is not possible to assert (say) `{foo: "bar"} instance of context`, or even worse, `{} instance of context`.  There seems to be no way to describe an empty context type.  So, that is a gap (correct me if I am wrong) and thus there are no assertions included here for same.

Re functions, the same, there is no grammar to describe just a function.  So (say) `function() "foo" instance of function` is not possible, you have to supply params and a return type.  And `function<> -> any` does not mean 'any function', it means a function with no params that returns any - quite different.  So, again, no assertions here for the 'is a function' meaning.

The function covariance/contravariance stuff might be pretty hard to read so hopefully they make sense.  And hopefully they are correct! :-)    

Also, I have added some assertions proving that allowed values on items definition types to not affect conformity.  The spec does not include any notion of allowed values in the equivalence section so I thought it best to assert that as that could be a point of 'implicit difference' between runtimes.

Comments welcome.