### PR TITLE
DMN1-3 feel in

### DIFF
--- a/TestCases/compliance-level-3/0072-feel-in/0072-feel-in-test-01.xml
+++ b/TestCases/compliance-level-3/0072-feel-in/0072-feel-in-test-01.xml
@@ -2542,6 +2542,7 @@
         </resultNode>
     </testCase>
 
+<!--
     <testCase id="null_001">
         <description>range null test value</description>
         <resultNode errorResult="true" name="null_001" type="decision">
@@ -2586,13 +2587,15 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
     <testCase id="null_002">
         <!-- as null is a valid value for a range start, this test asserts that a null start caused by a
         invalid type coercion is not the same as simply supplying a null value -->
-        <description>range - invalid start type coerces to null and makes range check invalid</description>
+        <description>range - invalid inclusive start type coerces to null and makes range check invalid</description>
 
         <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
+        <!-- the range has a number end and we're supplying a list as the start -->
         <inputNode name="input_for_null_tests">
             <list></list>
         </inputNode>
@@ -2605,11 +2608,12 @@
     </testCase>
 
     <testCase id="null_003">
-        <!-- as null is a valid value for a range end, this test asserts that a null end caused by a
+        <!-- as null is a valid value for a range start, this test asserts that a null start caused by a
         invalid type coercion is not the same as simply supplying a null value -->
-        <description>range - invalid end type coerces to null and makes range check invalid</description>
+        <description>range - invalid non-inclusive start type coerces to null and makes range check invalid</description>
 
         <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
+        <!-- the range has a number end and we're supplying a list as the start -->
         <inputNode name="input_for_null_tests">
             <list></list>
         </inputNode>
@@ -2622,15 +2626,33 @@
     </testCase>
 
     <testCase id="null_004">
-        <description>range - incomparable end point types makes range check invalid</description>
+        <!-- as null is a valid value for a range end, this test asserts that a null end caused by a
+        invalid type coercion is not the same as simply supplying a null value -->
+        <description>range - invalid inclusive end type coerces to null and makes range check invalid</description>
 
         <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
-        <!-- the range has a number start and we're supplying a string as the end -->
+        <!-- the range has a number start and we're supplying a list as the end -->
         <inputNode name="input_for_null_tests">
-            <value xsi:type="xsd:string">foo</value>
+            <list></list>
         </inputNode>
 
         <resultNode errorResult="true" name="null_004" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="null_005">
+        <description>range - invalid non-inclusive end type coerces to null and makes range check invalid</description>
+
+        <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
+        <!-- the range has a number start and we're supplying a list as the end -->
+        <inputNode name="input_for_null_tests">
+            <list></list>
+        </inputNode>
+
+        <resultNode errorResult="true" name="null_005" type="decision">
             <expected>
                 <value xsi:nil="true"/>
             </expected>

--- a/TestCases/compliance-level-3/0072-feel-in/0072-feel-in-test-01.xml
+++ b/TestCases/compliance-level-3/0072-feel-in/0072-feel-in-test-01.xml
@@ -2542,4 +2542,99 @@
         </resultNode>
     </testCase>
 
+    <testCase id="null_001">
+        <description>range null test value</description>
+        <resultNode errorResult="true" name="null_001" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="null_001_a">
+        <description>range null start value with non-inclusive start</description>
+        <resultNode name="null_001_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="null_001_b">
+        <description>range null end value with non-inclusive end</description>
+        <resultNode name="null_001_b" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="null_001_c">
+        <description>range null start value with inclusive start</description>
+        <resultNode errorResult="true" name="null_001_c" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="null_001_d">
+        <description>range null end value with inclusive end</description>
+        <resultNode errorResult="true" name="null_001_d" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="null_002">
+        <!-- as null is a valid value for a range start, this test asserts that a null start caused by a
+        invalid type coercion is not the same as simply supplying a null value -->
+        <description>range - invalid start type coerces to null and makes range check invalid</description>
+
+        <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
+        <inputNode name="input_for_null_tests">
+            <list></list>
+        </inputNode>
+
+        <resultNode errorResult="true" name="null_002" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="null_003">
+        <!-- as null is a valid value for a range end, this test asserts that a null end caused by a
+        invalid type coercion is not the same as simply supplying a null value -->
+        <description>range - invalid end type coerces to null and makes range check invalid</description>
+
+        <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
+        <inputNode name="input_for_null_tests">
+            <list></list>
+        </inputNode>
+
+        <resultNode errorResult="true" name="null_003" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="null_004">
+        <description>range - incomparable end point types makes range check invalid</description>
+
+        <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
+        <!-- the range has a number start and we're supplying a string as the end -->
+        <inputNode name="input_for_null_tests">
+            <value xsi:type="xsd:string">foo</value>
+        </inputNode>
+
+        <resultNode errorResult="true" name="null_004" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
 </testCases>

--- a/TestCases/compliance-level-3/0072-feel-in/0072-feel-in-test-01.xml
+++ b/TestCases/compliance-level-3/0072-feel-in/0072-feel-in-test-01.xml
@@ -2589,13 +2589,14 @@
     </testCase>
 -->
 
+<!--
     <testCase id="null_002">
-        <!-- as null is a valid value for a range start, this test asserts that a null start caused by a
-        invalid type coercion is not the same as simply supplying a null value -->
+        &lt;!&ndash; as null is a valid value for a range start, this test asserts that a null start caused by a
+        invalid type coercion is not the same as simply supplying a null value &ndash;&gt;
         <description>range - invalid inclusive start type coerces to null and makes range check invalid</description>
 
-        <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
-        <!-- the range has a number end and we're supplying a list as the start -->
+        &lt;!&ndash; invalid value provided as input so compiler type inference (if any) is not relevant &ndash;&gt;
+        &lt;!&ndash; the range has a number end and we're supplying a list as the start &ndash;&gt;
         <inputNode name="input_for_null_tests">
             <list></list>
         </inputNode>
@@ -2608,12 +2609,12 @@
     </testCase>
 
     <testCase id="null_003">
-        <!-- as null is a valid value for a range start, this test asserts that a null start caused by a
-        invalid type coercion is not the same as simply supplying a null value -->
+        &lt;!&ndash; as null is a valid value for a range start, this test asserts that a null start caused by a
+        invalid type coercion is not the same as simply supplying a null value &ndash;&gt;
         <description>range - invalid non-inclusive start type coerces to null and makes range check invalid</description>
 
-        <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
-        <!-- the range has a number end and we're supplying a list as the start -->
+        &lt;!&ndash; invalid value provided as input so compiler type inference (if any) is not relevant &ndash;&gt;
+        &lt;!&ndash; the range has a number end and we're supplying a list as the start &ndash;&gt;
         <inputNode name="input_for_null_tests">
             <list></list>
         </inputNode>
@@ -2626,12 +2627,12 @@
     </testCase>
 
     <testCase id="null_004">
-        <!-- as null is a valid value for a range end, this test asserts that a null end caused by a
-        invalid type coercion is not the same as simply supplying a null value -->
+        &lt;!&ndash; as null is a valid value for a range end, this test asserts that a null end caused by a
+        invalid type coercion is not the same as simply supplying a null value &ndash;&gt;
         <description>range - invalid inclusive end type coerces to null and makes range check invalid</description>
 
-        <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
-        <!-- the range has a number start and we're supplying a list as the end -->
+        &lt;!&ndash; invalid value provided as input so compiler type inference (if any) is not relevant &ndash;&gt;
+        &lt;!&ndash; the range has a number start and we're supplying a list as the end &ndash;&gt;
         <inputNode name="input_for_null_tests">
             <list></list>
         </inputNode>
@@ -2646,8 +2647,8 @@
     <testCase id="null_005">
         <description>range - invalid non-inclusive end type coerces to null and makes range check invalid</description>
 
-        <!-- invalid value provided as input so compiler type inference (if any) is not relevant -->
-        <!-- the range has a number start and we're supplying a list as the end -->
+        &lt;!&ndash; invalid value provided as input so compiler type inference (if any) is not relevant &ndash;&gt;
+        &lt;!&ndash; the range has a number start and we're supplying a list as the end &ndash;&gt;
         <inputNode name="input_for_null_tests">
             <list></list>
         </inputNode>
@@ -2658,5 +2659,6 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
 </testCases>

--- a/TestCases/compliance-level-3/0072-feel-in/0072-feel-in.dmn
+++ b/TestCases/compliance-level-3/0072-feel-in/0072-feel-in.dmn
@@ -2024,5 +2024,75 @@
         </literalExpression>
     </decision>
 
+    <decision name="null_001" id="_null_001">
+        <variable name="null_001"/>
+        <literalExpression>
+            <text>null in [1..10]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="null_001_a" id="_null_001_a">
+        <variable name="null_001_a"/>
+        <literalExpression>
+            <text>5 in (null..10]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="null_001_b" id="_null_001_b">
+        <variable name="null_001_b"/>
+        <literalExpression>
+            <text>5 in [1..null)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="null_001_c" id="_null_001_c">
+        <variable name="null_001_c"/>
+        <literalExpression>
+            <text>5 in [1..null]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="null_001_d" id="_null_001_d">
+        <variable name="null_001_d"/>
+        <literalExpression>
+            <text>5 in [null..10]</text>
+        </literalExpression>
+    </decision>
+
+    <inputData name="input_for_null_tests" id="_input_for_null_tests">
+        <variable name="input_for_null_tests"/>
+    </inputData>
+
+    <decision name="null_002" id="_null_002">
+        <variable name="null_002"/>
+        <informationRequirement>
+            <requiredInput href="#_input_for_null_tests"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>5 in (input_for_null_tests..10]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="null_003" id="_null_003">
+        <variable name="null_003"/>
+        <informationRequirement>
+            <requiredInput href="#_input_for_null_tests"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>5 in [1..input_for_null_tests)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="null_004" id="_null_004">
+        <variable name="null_004"/>
+        <informationRequirement>
+            <requiredInput href="#_input_for_null_tests"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>5 in [1..input_for_null_tests]</text>
+        </literalExpression>
+    </decision>
+
+
 </definitions>
 

--- a/TestCases/compliance-level-3/0072-feel-in/0072-feel-in.dmn
+++ b/TestCases/compliance-level-3/0072-feel-in/0072-feel-in.dmn
@@ -2031,37 +2031,49 @@
         </literalExpression>
     </decision>
 
+    <inputData name="input_for_null_tests" id="_input_for_null_tests">
+        <variable name="input_for_null_tests"/>
+    </inputData>
+
     <decision name="null_001_a" id="_null_001_a">
         <variable name="null_001_a"/>
+        <informationRequirement>
+            <requiredInput href="#_input_for_null_tests"/>
+        </informationRequirement>
         <literalExpression>
-            <text>5 in (null..10]</text>
+            <text>5 in (input_for_null_tests..10]</text>
         </literalExpression>
     </decision>
 
     <decision name="null_001_b" id="_null_001_b">
         <variable name="null_001_b"/>
+        <informationRequirement>
+            <requiredInput href="#_input_for_null_tests"/>
+        </informationRequirement>
         <literalExpression>
-            <text>5 in [1..null)</text>
+            <text>5 in [1..input_for_null_tests)</text>
         </literalExpression>
     </decision>
 
     <decision name="null_001_c" id="_null_001_c">
         <variable name="null_001_c"/>
+        <informationRequirement>
+            <requiredInput href="#_input_for_null_tests"/>
+        </informationRequirement>
         <literalExpression>
-            <text>5 in [1..null]</text>
+            <text>5 in [1..input_for_null_tests]</text>
         </literalExpression>
     </decision>
 
     <decision name="null_001_d" id="_null_001_d">
         <variable name="null_001_d"/>
+        <informationRequirement>
+            <requiredInput href="#_input_for_null_tests"/>
+        </informationRequirement>
         <literalExpression>
-            <text>5 in [null..10]</text>
+            <text>5 in [input_for_null_tests..10]</text>
         </literalExpression>
     </decision>
-
-    <inputData name="input_for_null_tests" id="_input_for_null_tests">
-        <variable name="input_for_null_tests"/>
-    </inputData>
 
     <decision name="null_002" id="_null_002">
         <variable name="null_002"/>

--- a/TestCases/compliance-level-3/0072-feel-in/0072-feel-in.dmn
+++ b/TestCases/compliance-level-3/0072-feel-in/0072-feel-in.dmn
@@ -2024,56 +2024,46 @@
         </literalExpression>
     </decision>
 
-    <decision name="null_001" id="_null_001">
-        <variable name="null_001"/>
-        <literalExpression>
-            <text>null in [1..10]</text>
-        </literalExpression>
-    </decision>
-
     <inputData name="input_for_null_tests" id="_input_for_null_tests">
         <variable name="input_for_null_tests"/>
     </inputData>
 
-    <decision name="null_001_a" id="_null_001_a">
-        <variable name="null_001_a"/>
-        <informationRequirement>
-            <requiredInput href="#_input_for_null_tests"/>
-        </informationRequirement>
-        <literalExpression>
-            <text>5 in (input_for_null_tests..10]</text>
-        </literalExpression>
-    </decision>
+    <!--
+        <decision name="null_001" id="_null_001">
+            <variable name="null_001"/>
+            <literalExpression>
+                <text>null in [1..10]</text>
+            </literalExpression>
+        </decision>
 
-    <decision name="null_001_b" id="_null_001_b">
-        <variable name="null_001_b"/>
-        <informationRequirement>
-            <requiredInput href="#_input_for_null_tests"/>
-        </informationRequirement>
-        <literalExpression>
-            <text>5 in [1..input_for_null_tests)</text>
-        </literalExpression>
-    </decision>
+        <decision name="null_001_a" id="_null_001_a">
+            <variable name="null_001_a"/>
+            <literalExpression>
+                <text>5 in (null..10]</text>
+            </literalExpression>
+        </decision>
 
-    <decision name="null_001_c" id="_null_001_c">
-        <variable name="null_001_c"/>
-        <informationRequirement>
-            <requiredInput href="#_input_for_null_tests"/>
-        </informationRequirement>
-        <literalExpression>
-            <text>5 in [1..input_for_null_tests]</text>
-        </literalExpression>
-    </decision>
+        <decision name="null_001_b" id="_null_001_b">
+            <variable name="null_001_b"/>
+            <literalExpression>
+                <text>5 in [1..null)</text>
+            </literalExpression>
+        </decision>
 
-    <decision name="null_001_d" id="_null_001_d">
-        <variable name="null_001_d"/>
-        <informationRequirement>
-            <requiredInput href="#_input_for_null_tests"/>
-        </informationRequirement>
-        <literalExpression>
-            <text>5 in [input_for_null_tests..10]</text>
-        </literalExpression>
-    </decision>
+        <decision name="null_001_c" id="_null_001_c">
+            <variable name="null_001_c"/>
+            <literalExpression>
+                <text>5 in [1..null]</text>
+            </literalExpression>
+        </decision>
+
+        <decision name="null_001_d" id="_null_001_d">
+            <variable name="null_001_d"/>
+            <literalExpression>
+                <text>5 in [null..10]</text>
+            </literalExpression>
+        </decision>
+    -->
 
     <decision name="null_002" id="_null_002">
         <variable name="null_002"/>
@@ -2081,7 +2071,7 @@
             <requiredInput href="#_input_for_null_tests"/>
         </informationRequirement>
         <literalExpression>
-            <text>5 in (input_for_null_tests..10]</text>
+            <text>5 in [input_for_null_tests..10]</text>
         </literalExpression>
     </decision>
 
@@ -2091,7 +2081,7 @@
             <requiredInput href="#_input_for_null_tests"/>
         </informationRequirement>
         <literalExpression>
-            <text>5 in [1..input_for_null_tests)</text>
+            <text>5 in (input_for_null_tests..10]</text>
         </literalExpression>
     </decision>
 
@@ -2102,6 +2092,16 @@
         </informationRequirement>
         <literalExpression>
             <text>5 in [1..input_for_null_tests]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="null_005" id="_null_005">
+        <variable name="null_005"/>
+        <informationRequirement>
+            <requiredInput href="#_input_for_null_tests"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>5 in [1..input_for_null_tests)</text>
         </literalExpression>
     </decision>
 

--- a/TestCases/compliance-level-3/0072-feel-in/0072-feel-in.dmn
+++ b/TestCases/compliance-level-3/0072-feel-in/0072-feel-in.dmn
@@ -2065,6 +2065,7 @@
         </decision>
     -->
 
+<!--
     <decision name="null_002" id="_null_002">
         <variable name="null_002"/>
         <informationRequirement>
@@ -2105,6 +2106,7 @@
         </literalExpression>
     </decision>
 
+-->
 
 </definitions>
 


### PR DESCRIPTION
Some additional assertions on what happens when nulls are part of ranges and when endpoints are null-coerced and incompatible.

The unary syntax for range and equivalence thereof with the non unary syntax kind of means non unary ranges can act like unary ranges.

Note the specs do not seem to support the usage on a unary syntax range with the 'in' keyword, so no assertions for that are made here - just what happens with nulls in non-unary ranges.

Comments welcome.   