### PR TITLE
DMN1-3 range properties

### DIFF
--- a/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties-test-01.xml
+++ b/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties-test-01.xml
@@ -407,4 +407,220 @@
         </resultNode>
     </testCase>
 
+    <testCase id="range_001">
+        <description>range - start</description>
+        <resultNode name="range_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">1</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_002">
+        <description>range - end</description>
+        <resultNode name="range_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">10</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_003">
+        <description>range - start included</description>
+        <resultNode name="range_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_004">
+        <description>range - start included '(' syntax</description>
+        <resultNode name="range_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_005">
+        <description>range - start included ']' syntax</description>
+        <resultNode name="range_005" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_006">
+        <description>range - end included</description>
+        <resultNode name="range_006" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_007">
+        <description>range - end included ')' syntax </description>
+        <resultNode name="range_007" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_008">
+        <description>range - end included '[' syntax</description>
+        <resultNode name="range_008" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_009">
+        <description>range - start: LT unary syntax</description>
+        <resultNode name="range_009" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_010">
+        <description>range - start: LE unary syntax</description>
+        <resultNode name="range_010" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_011">
+        <description>range - start: GT unary syntax</description>
+        <resultNode name="range_011" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">10</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_012">
+        <description>range - start: GE unary syntax</description>
+        <resultNode name="range_012" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">10</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_013">
+        <description>range - end: LT unary syntax</description>
+        <resultNode name="range_013" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">10</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_014">
+        <description>range - end: LE unary syntax</description>
+        <resultNode name="range_014" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">10</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_015">
+        <description>range - end: GT unary syntax</description>
+        <resultNode name="range_015" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_016">
+        <description>range - end: GE unary syntax</description>
+        <resultNode name="range_016" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_017">
+        <description>range - start included: LT unary syntax</description>
+        <resultNode name="range_017" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_018">
+        <description>range - start included: LE unary syntax</description>
+        <resultNode name="range_018" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_019">
+        <description>range - start included: GT unary syntax</description>
+        <resultNode name="range_019" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_020">
+        <description>range - start included: GE unary syntax</description>
+        <resultNode name="range_020" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_021">
+        <description>range - end included: LT unary syntax</description>
+        <resultNode name="range_021" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_022">
+        <description>range - end included: LE unary syntax</description>
+        <resultNode name="range_022" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_023">
+        <description>range - end included: GT unary syntax</description>
+        <resultNode name="range_023" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_024">
+        <description>range - end included: GE unary syntax</description>
+        <resultNode name="range_024" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
 </testCases>

--- a/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties-test-01.xml
+++ b/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties-test-01.xml
@@ -515,6 +515,8 @@
         </resultNode>
     </testCase>
 
+<!--
+    https://github.com/dmn-tck/tck/pull/394#issuecomment-858583811
     <testCase id="range_012_a">
         <description>range - start: ambiguous 'no operation syntax' gives null </description>
         <resultNode name="range_012_a" type="decision" errorResult="true">
@@ -523,6 +525,7 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
     <testCase id="range_013">
         <description>range - end: LT unary syntax</description>
@@ -560,6 +563,8 @@
         </resultNode>
     </testCase>
 
+<!--
+    https://github.com/dmn-tck/tck/pull/394#issuecomment-858583811
     <testCase id="range_016_a">
         <description>range - end: ambiguous 'no operation syntax' gives null </description>
         <resultNode name="range_016_a" type="decision" errorResult="true">
@@ -568,6 +573,7 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
     <testCase id="range_017">
         <description>range - start included: LT unary syntax</description>
@@ -605,6 +611,8 @@
         </resultNode>
     </testCase>
 
+<!--
+    https://github.com/dmn-tck/tck/pull/394#issuecomment-858583811
     <testCase id="range_020_a">
         <description>range - start included: ambiguous 'no operation syntax' gives null </description>
         <resultNode name="range_020_a" type="decision" errorResult="true">
@@ -613,6 +621,7 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
     <testCase id="range_021">
         <description>range - end included: LT unary syntax</description>
@@ -650,6 +659,8 @@
         </resultNode>
     </testCase>
 
+<!--
+    https://github.com/dmn-tck/tck/pull/394#issuecomment-858583811
     <testCase id="range_024_a">
         <description>range - end included: ambiguous 'no operation syntax' gives null </description>
         <resultNode name="range_024_a" type="decision" errorResult="true">
@@ -658,5 +669,6 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
 </testCases>

--- a/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties-test-01.xml
+++ b/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties-test-01.xml
@@ -515,6 +515,15 @@
         </resultNode>
     </testCase>
 
+    <testCase id="range_012_a">
+        <description>range - start: ambiguous 'no operation syntax' gives null </description>
+        <resultNode name="range_012_a" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
     <testCase id="range_013">
         <description>range - end: LT unary syntax</description>
         <resultNode name="range_013" type="decision">
@@ -545,6 +554,15 @@
     <testCase id="range_016">
         <description>range - end: GE unary syntax</description>
         <resultNode name="range_016" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_016_a">
+        <description>range - end: ambiguous 'no operation syntax' gives null </description>
+        <resultNode name="range_016_a" type="decision" errorResult="true">
             <expected>
                 <value xsi:nil="true"/>
             </expected>
@@ -587,6 +605,15 @@
         </resultNode>
     </testCase>
 
+    <testCase id="range_020_a">
+        <description>range - start included: ambiguous 'no operation syntax' gives null </description>
+        <resultNode name="range_020_a" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
     <testCase id="range_021">
         <description>range - end included: LT unary syntax</description>
         <resultNode name="range_021" type="decision">
@@ -619,6 +646,15 @@
         <resultNode name="range_024" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="range_024_a">
+        <description>range - end included: ambiguous 'no operation syntax' gives null </description>
+        <resultNode name="range_024_a" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties.dmn
+++ b/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties.dmn
@@ -422,6 +422,13 @@
         </literalExpression>
     </decision>
 
+    <decision name="range_012_a" id="_range_012_a">
+        <variable name="range_012_a"/>
+        <literalExpression>
+            <text>(10).start</text>
+        </literalExpression>
+    </decision>
+
     <decision name="range_013" id="_range_013">
         <variable name="range_013"/>
         <literalExpression>
@@ -447,6 +454,13 @@
         <variable name="range_016"/>
         <literalExpression>
             <text>(&gt;= 10).end</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_016_a" id="_range_016_a">
+        <variable name="range_016_a"/>
+        <literalExpression>
+            <text>(10).end</text>
         </literalExpression>
     </decision>
 
@@ -478,6 +492,13 @@
         </literalExpression>
     </decision>
 
+    <decision name="range_020_a" id="_range_020_a">
+        <variable name="range_020_a"/>
+        <literalExpression>
+            <text>(10).start included</text>
+        </literalExpression>
+    </decision>
+
     <decision name="range_021" id="_range_021">
         <variable name="range_021"/>
         <literalExpression>
@@ -503,6 +524,13 @@
         <variable name="range_024"/>
         <literalExpression>
             <text>(&gt;= 10).end included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_024_a" id="_range_024_a">
+        <variable name="range_024_a"/>
+        <literalExpression>
+            <text>(10).end included</text>
         </literalExpression>
     </decision>
 

--- a/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties.dmn
+++ b/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties.dmn
@@ -422,12 +422,15 @@
         </literalExpression>
     </decision>
 
+<!--
+    https://github.com/dmn-tck/tck/pull/394#issuecomment-858583811
     <decision name="range_012_a" id="_range_012_a">
         <variable name="range_012_a"/>
         <literalExpression>
             <text>(10).start</text>
         </literalExpression>
     </decision>
+-->
 
     <decision name="range_013" id="_range_013">
         <variable name="range_013"/>
@@ -457,12 +460,15 @@
         </literalExpression>
     </decision>
 
+<!--
+    https://github.com/dmn-tck/tck/pull/394#issuecomment-858583811
     <decision name="range_016_a" id="_range_016_a">
         <variable name="range_016_a"/>
         <literalExpression>
             <text>(10).end</text>
         </literalExpression>
     </decision>
+-->
 
     <decision name="range_017" id="_range_017">
         <variable name="range_017"/>
@@ -492,12 +498,15 @@
         </literalExpression>
     </decision>
 
+<!--
+    https://github.com/dmn-tck/tck/pull/394#issuecomment-858583811
     <decision name="range_020_a" id="_range_020_a">
         <variable name="range_020_a"/>
         <literalExpression>
             <text>(10).start included</text>
         </literalExpression>
     </decision>
+-->
 
     <decision name="range_021" id="_range_021">
         <variable name="range_021"/>
@@ -527,12 +536,15 @@
         </literalExpression>
     </decision>
 
+<!--
+    https://github.com/dmn-tck/tck/pull/394#issuecomment-858583811
     <decision name="range_024_a" id="_range_024_a">
         <variable name="range_024_a"/>
         <literalExpression>
             <text>(10).end included</text>
         </literalExpression>
     </decision>
+-->
 
 
 

--- a/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties.dmn
+++ b/TestCases/compliance-level-3/0074-feel-properties/0074-feel-properties.dmn
@@ -310,4 +310,202 @@
         </literalExpression>
     </decision>
 
+    <decision name="range_001" id="_range_001">
+        <variable name="range_001"/>
+        <literalExpression>
+            <text>[1..10].start</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_002" id="_range_002">
+        <variable name="range_002"/>
+        <literalExpression>
+            <text>[1..10].end</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_003" id="_range_003">
+        <variable name="range_003"/>
+        <literalExpression>
+            <text>[1..10].start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_004" id="_range_004">
+        <variable name="range_004"/>
+        <literalExpression>
+            <text>(1..10].start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_004_a" id="_range_004_a">
+        <variable name="range_004_a"/>
+        <literalExpression>
+            <text>(&lt; 10).start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_004_b" id="_range_004_b">
+        <variable name="range_004_b"/>
+        <literalExpression>
+            <text>(&lt;= 10).start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_004_c" id="_range_004_c">
+        <variable name="range_004_c"/>
+        <literalExpression>
+            <text>(&gt; 10).start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_004_d" id="_range_004_d">
+        <variable name="range_004_d"/>
+        <literalExpression>
+            <text>(&gt;= 10).start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_005" id="_range_005">
+        <variable name="range_005"/>
+        <literalExpression>
+            <text>]1..10].start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_006" id="_range_006">
+        <variable name="range_006"/>
+        <literalExpression>
+            <text>[1..10].end included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_007" id="_range_007">
+        <variable name="range_007"/>
+        <literalExpression>
+            <text>[1..10).end included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_008" id="_range_008">
+        <variable name="range_008"/>
+        <literalExpression>
+            <text>[1..10[.end included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_009" id="_range_009">
+        <variable name="range_009"/>
+        <literalExpression>
+            <text>(&lt; 10).start</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_010" id="_range_010">
+        <variable name="range_010"/>
+        <literalExpression>
+            <text>(&lt;= 10).start</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_011" id="_range_011">
+        <variable name="range_011"/>
+        <literalExpression>
+            <text>(&gt; 10).start</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_012" id="_range_012">
+        <variable name="range_012"/>
+        <literalExpression>
+            <text>(&gt;= 10).start</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_013" id="_range_013">
+        <variable name="range_013"/>
+        <literalExpression>
+            <text>(&lt; 10).end</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_014" id="_range_014">
+        <variable name="range_014"/>
+        <literalExpression>
+            <text>(&lt;= 10).end</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_015" id="_range_015">
+        <variable name="range_015"/>
+        <literalExpression>
+            <text>(&gt; 10).end</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_016" id="_range_016">
+        <variable name="range_016"/>
+        <literalExpression>
+            <text>(&gt;= 10).end</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_017" id="_range_017">
+        <variable name="range_017"/>
+        <literalExpression>
+            <text>(&lt; 10).start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_018" id="_range_018">
+        <variable name="range_018"/>
+        <literalExpression>
+            <text>(&lt;= 10).start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_019" id="_range_019">
+        <variable name="range_019"/>
+        <literalExpression>
+            <text>(&gt; 10).start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_020" id="_range_020">
+        <variable name="range_020"/>
+        <literalExpression>
+            <text>(&gt;= 10).start included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_021" id="_range_021">
+        <variable name="range_021"/>
+        <literalExpression>
+            <text>(&lt; 10).end included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_022" id="_range_022">
+        <variable name="range_022"/>
+        <literalExpression>
+            <text>(&lt;= 10).end included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_023" id="_range_023">
+        <variable name="range_023"/>
+        <literalExpression>
+            <text>(&gt; 10).end included</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="range_024" id="_range_024">
+        <variable name="range_024"/>
+        <literalExpression>
+            <text>(&gt;= 10).end included</text>
+        </literalExpression>
+    </decision>
+
+
+
 </definitions>


### PR DESCRIPTION
Assertions on the new 1.3 range properties for both range syntaxes.

Note the unary style syntax are disambiguated with ().  Otherwise, the dot property will be taken to be part of the end range expression.  