### PR TITLE
DMN1-3 context functions

### DIFF
--- a/TestCases/compliance-level-3/0080-feel-getvalue-function/0080-feel-getvalue-function-test-01.xml
+++ b/TestCases/compliance-level-3/0080-feel-getvalue-function/0080-feel-getvalue-function-test-01.xml
@@ -61,7 +61,6 @@
         </resultNode>
     </testCase>
 
-<!--
     <testCase id="decision_007">
         <description>named params</description>
         <resultNode name="decision_007" type="decision">
@@ -79,7 +78,6 @@
             </expected>
         </resultNode>
     </testCase>
--->
 
     <testCase id="decision_009">
         <description>null map param</description>
@@ -100,8 +98,8 @@
     </testCase>
 
     <testCase id="decision_011">
-        <description>null map and key params</description>
-        <resultNode errorResult="true" name="decision_011" type="decision">
+        <description>null context param</description>
+        <resultNode name="decision_011" type="decision" errorResult="true">
             <expected>
                 <value xsi:nil="true"></value>
             </expected>
@@ -109,13 +107,38 @@
     </testCase>
 
     <testCase id="decision_012">
-        <description>null value stored in context</description>
+        <description>null item value stored in context</description>
         <resultNode name="decision_012" type="decision">
             <expected>
                 <value xsi:nil="true"></value>
             </expected>
         </resultNode>
     </testCase>
+
+    <testCase id="decision_013">
+        <description>non literal key of string type</description>
+        <inputNode name="input_001">
+            <value xsi:type="xsd:string">a</value>
+        </inputNode>
+        <resultNode name="decision_013" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">foo</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_014">
+        <description>non literal key of incorrect type</description>
+        <inputNode name="input_001">
+            <value xsi:type="xsd:decimal">12</value>
+        </inputNode>
+        <resultNode name="decision_013" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
 
 
 

--- a/TestCases/compliance-level-3/0080-feel-getvalue-function/0080-feel-getvalue-function.dmn
+++ b/TestCases/compliance-level-3/0080-feel-getvalue-function/0080-feel-getvalue-function.dmn
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<definitions namespace="http://www.montera.com.au/spec/DMN/0080-feel-getvalue-function" name="0080-feel-getvalue-function" id="_i9fboPUUEeesLuP4RHs4vA" xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<definitions namespace="http://www.montera.com.au/spec/DMN/0080-feel-getvalue-function"
+             name="0080-feel-getvalue-function"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <description>FEEL built-in function 'get value(m, key)' in unspecified category</description>
+
+    <inputData name="input_001" id="_input_001">
+        <variable name="input_001"/>
+    </inputData>
 
     <decision name="decision_001" id="_decision_001">
         <description>Tests FEEL expression: 'get value()' and expects result: 'null'</description>
@@ -62,7 +73,6 @@
         </literalExpression>
     </decision>
 
-<!--
     <decision name="decision_007" id="_decision_007">
         <description>Tests FEEL expression: 'get value(key:"a", m:{a: "foo"})' and expects result: 'foo'</description>
         <question>Result of FEEL expression 'get value(key:"a", m:{a: "foo"})'?</question>
@@ -82,7 +92,6 @@
             <text>get value(k:"a", m:{a: "foo"})</text>
         </literalExpression>
     </decision>
--->
 
     <decision name="decision_009" id="_decision_009">
         <description>Tests FEEL expression: 'get value(null, "a")' and expects result: 'null'</description>
@@ -121,6 +130,20 @@
         <variable typeRef="string" name="decision_012"/>
         <literalExpression>
             <text>get value({a: null}, "a")</text>
+        </literalExpression>
+    </decision>
+
+
+    <decision name="decision_013" id="_decision_013">
+        <description>Tests FEEL expression: 'get value({a: "foo"}, input_001)' and expects result: 'foo'</description>
+        <question>Result of FEEL expression 'get value({a: "foo"}, input_001)'?</question>
+        <allowedAnswers>null</allowedAnswers>
+        <variable typeRef="string" name="decision_013"/>
+        <informationRequirement>
+            <requiredInput href="#_input_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>get value({a: "foo"}, input_001)</text>
         </literalExpression>
     </decision>
 

--- a/TestCases/compliance-level-3/0081-feel-getentries-function/0081-feel-getentries-function-test-01.xml
+++ b/TestCases/compliance-level-3/0081-feel-getentries-function/0081-feel-getentries-function-test-01.xml
@@ -60,7 +60,6 @@
         </resultNode>
     </testCase>
 
-<!--
     <testCase id="decision_005">
         <description>named param</description>
         <resultNode name="decision_005" type="decision">
@@ -86,9 +85,7 @@
             </expected>
         </resultNode>
     </testCase>
--->
 
-<!--
     <testCase id="decision_006">
         <description>bad named param</description>
         <resultNode errorResult="true" name="decision_006" type="decision">
@@ -97,7 +94,6 @@
             </expected>
         </resultNode>
     </testCase>
--->
 
     <testCase id="decision_007">
         <description>not a map as param</description>

--- a/TestCases/compliance-level-3/0081-feel-getentries-function/0081-feel-getentries-function.dmn
+++ b/TestCases/compliance-level-3/0081-feel-getentries-function/0081-feel-getentries-function.dmn
@@ -42,7 +42,6 @@
         </literalExpression>
     </decision>
 
-<!--
     <decision name="decision_005" id="_decision_005">
         <description>Tests FEEL expression: 'get entries(m:{a: "foo", b: "bar"})' and expects result: '[{a: "foo}, {b: "bar"}]'</description>
         <question>Result of FEEL expression 'get entries(m:{a: "foo", b: "bar"})'?</question>
@@ -52,9 +51,7 @@
             <text>get entries(m:{a: "foo", b: "bar"})</text>
         </literalExpression>
     </decision>
--->
 
-<!--
     <decision name="decision_006" id="_decision_006">
         <description>Tests FEEL expression: 'get entries(map:{a: "foo", b: "bar"})' and expects result: 'null'</description>
         <question>Result of FEEL expression 'get entries(map:{a: "foo", b: "bar"})'?</question>
@@ -64,7 +61,6 @@
             <text>get entries(map:{a: "foo", b: "bar"})</text>
         </literalExpression>
     </decision>
--->
 
     <decision name="decision_007" id="_decision_007">
         <description>Tests FEEL expression: 'get entries(123)' and expects result: 'null'</description>


### PR DESCRIPTION
the `entries()` and `get value()` functions were kind of only half in the 1.2 spec.  We had tests for them but not for named params - they were commented out because (if I recall) those names were not yet official, or something. Those tests are now uncommented here. Plus, I've added two tests for the `get value` function that assert it will accept a non-literal string key name - all existing tests were providing a literal string 'key' param and for those that implement type inference here based on the literal key name and its corresponding type in the context - it could be a gotcha. 

Apols for the inexactly named branch.