### PR TITLE
0099-arithmetic-negation

### DIFF
--- a/TestCases/compliance-level-3/0099-arithmetic-negation/0099-arithmetic-negation-test-01.xml
+++ b/TestCases/compliance-level-3/0099-arithmetic-negation/0099-arithmetic-negation-test-01.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>0099-arithmetic-negation.dmn</modelName>
+
+    <testCase id="decision_001">
+        <description>negate number</description>
+        <resultNode name="decision_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">-10</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_002">
+        <description>negate negative number</description>
+        <resultNode name="decision_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">10</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_003">
+        <description>negate days and time duration</description>
+        <resultNode name="decision_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:duration">-P1D</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_003_a">
+        <description>negate a negative days and time duration</description>
+        <resultNode name="decision_003_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:duration">P1D</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_004">
+        <description>negate years and months duration</description>
+        <resultNode name="decision_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:duration">-P1Y</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_004_a">
+        <description>negate a negative years and months duration</description>
+        <resultNode name="decision_004_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:duration">P1Y</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_005">
+        <description>negate date gives null</description>
+        <resultNode name="decision_005" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_006">
+        <description>negate datetime gives null</description>
+        <resultNode name="decision_006" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_007">
+        <description>negate time gives null</description>
+        <resultNode name="decision_007" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_008">
+        <description>negate context gives null</description>
+        <resultNode name="decision_008" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_009">
+        <description>negate string gives null</description>
+        <resultNode name="decision_009" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_010">
+        <description>negate singleton list gives null</description>
+        <resultNode name="decision_010" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_011">
+        <description>negate range gives null</description>
+        <resultNode name="decision_011" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_012">
+        <description>negate expression result</description>
+        <resultNode name="decision_012" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">-10</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/0099-arithmetic-negation/0099-arithmetic-negation-test-01.xml
+++ b/TestCases/compliance-level-3/0099-arithmetic-negation/0099-arithmetic-negation-test-01.xml
@@ -24,41 +24,45 @@
         </resultNode>
     </testCase>
 
-    <testCase id="decision_003">
-        <description>negate days and time duration</description>
-        <resultNode name="decision_003" type="decision">
-            <expected>
-                <value xsi:type="xsd:duration">-P1D</value>
-            </expected>
-        </resultNode>
-    </testCase>
+    <!-- commented as per https://github.com/dmn-tck/tck/pull/401#issuecomment-962982239 -->
+<!--    <testCase id="decision_003">-->
+<!--        <description>negate days and time duration</description>-->
+<!--        <resultNode name="decision_003" type="decision">-->
+<!--            <expected>-->
+<!--                <value xsi:type="xsd:duration">-P1D</value>-->
+<!--            </expected>-->
+<!--        </resultNode>-->
+<!--    </testCase>-->
 
-    <testCase id="decision_003_a">
-        <description>negate a negative days and time duration</description>
-        <resultNode name="decision_003_a" type="decision">
-            <expected>
-                <value xsi:type="xsd:duration">P1D</value>
-            </expected>
-        </resultNode>
-    </testCase>
+    <!-- commented as per https://github.com/dmn-tck/tck/pull/401#issuecomment-962982239 -->
+<!--    <testCase id="decision_003_a">-->
+<!--        <description>negate a negative days and time duration</description>-->
+<!--        <resultNode name="decision_003_a" type="decision">-->
+<!--            <expected>-->
+<!--                <value xsi:type="xsd:duration">P1D</value>-->
+<!--            </expected>-->
+<!--        </resultNode>-->
+<!--    </testCase>-->
 
-    <testCase id="decision_004">
-        <description>negate years and months duration</description>
-        <resultNode name="decision_004" type="decision">
-            <expected>
-                <value xsi:type="xsd:duration">-P1Y</value>
-            </expected>
-        </resultNode>
-    </testCase>
+    <!-- commented as per https://github.com/dmn-tck/tck/pull/401#issuecomment-962982239 -->
+<!--    <testCase id="decision_004">-->
+<!--        <description>negate years and months duration</description>-->
+<!--        <resultNode name="decision_004" type="decision">-->
+<!--            <expected>-->
+<!--                <value xsi:type="xsd:duration">-P1Y</value>-->
+<!--            </expected>-->
+<!--        </resultNode>-->
+<!--    </testCase>-->
 
-    <testCase id="decision_004_a">
-        <description>negate a negative years and months duration</description>
-        <resultNode name="decision_004_a" type="decision">
-            <expected>
-                <value xsi:type="xsd:duration">P1Y</value>
-            </expected>
-        </resultNode>
-    </testCase>
+    <!-- commented as per https://github.com/dmn-tck/tck/pull/401#issuecomment-962982239 -->
+<!--    <testCase id="decision_004_a">-->
+<!--        <description>negate a negative years and months duration</description>-->
+<!--        <resultNode name="decision_004_a" type="decision">-->
+<!--            <expected>-->
+<!--                <value xsi:type="xsd:duration">P1Y</value>-->
+<!--            </expected>-->
+<!--        </resultNode>-->
+<!--    </testCase>-->
 
     <testCase id="decision_005">
         <description>negate date gives null</description>

--- a/TestCases/compliance-level-3/0099-arithmetic-negation/0099-arithmetic-negation.dmn
+++ b/TestCases/compliance-level-3/0099-arithmetic-negation/0099-arithmetic-negation.dmn
@@ -23,33 +23,37 @@
         </literalExpression>
     </decision>
 
-    <decision name="decision_003" id="_decision_003">
-        <variable name="decision_003"/>
-        <literalExpression>
-            <text>-@"P1D"</text>
-        </literalExpression>
-    </decision>
+    <!-- commented as per https://github.com/dmn-tck/tck/pull/401#issuecomment-962982239 -->
+<!--    <decision name="decision_003" id="_decision_003">-->
+<!--        <variable name="decision_003"/>-->
+<!--        <literalExpression>-->
+<!--            <text>-@"P1D"</text>-->
+<!--        </literalExpression>-->
+<!--    </decision>-->
 
-    <decision name="decision_003_a" id="_decision_003_a">
-        <variable name="decision_003_a"/>
-        <literalExpression>
-            <text>-@"-P1D"</text>
-        </literalExpression>
-    </decision>
+    <!-- commented as per https://github.com/dmn-tck/tck/pull/401#issuecomment-962982239 -->
+<!--    <decision name="decision_003_a" id="_decision_003_a">-->
+<!--        <variable name="decision_003_a"/>-->
+<!--        <literalExpression>-->
+<!--            <text>-@"-P1D"</text>-->
+<!--        </literalExpression>-->
+<!--    </decision>-->
 
-    <decision name="decision_004" id="_decision_004">
-        <variable name="decision_004"/>
-        <literalExpression>
-            <text>-@"P1Y"</text>
-        </literalExpression>
-    </decision>
+    <!-- commented as per https://github.com/dmn-tck/tck/pull/401#issuecomment-962982239 -->
+<!--    <decision name="decision_004" id="_decision_004">-->
+<!--        <variable name="decision_004"/>-->
+<!--        <literalExpression>-->
+<!--            <text>-@"P1Y"</text>-->
+<!--        </literalExpression>-->
+<!--    </decision>-->
 
-    <decision name="decision_004_a" id="_decision_004_a">
-        <variable name="decision_004_a"/>
-        <literalExpression>
-            <text>-@"-P1Y"</text>
-        </literalExpression>
-    </decision>
+    <!-- commented as per https://github.com/dmn-tck/tck/pull/401#issuecomment-962982239 -->
+<!--    <decision name="decision_004_a" id="_decision_004_a">-->
+<!--        <variable name="decision_004_a"/>-->
+<!--        <literalExpression>-->
+<!--            <text>-@"-P1Y"</text>-->
+<!--        </literalExpression>-->
+<!--    </decision>-->
 
     <decision name="decision_005" id="_decision_005">
         <variable name="decision_005"/>

--- a/TestCases/compliance-level-3/0099-arithmetic-negation/0099-arithmetic-negation.dmn
+++ b/TestCases/compliance-level-3/0099-arithmetic-negation/0099-arithmetic-negation.dmn
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0099-arithmetic-negation"
+             name="0099-arithmetic-negation"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <description>arithmetic negation</description>
+
+    <decision name="decision_001" id="_decision_001">
+        <variable name="decision_001"/>
+        <literalExpression>
+            <text>-10</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_002" id="_decision_002">
+        <variable name="decision_002"/>
+        <literalExpression>
+            <text>--10</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_003" id="_decision_003">
+        <variable name="decision_003"/>
+        <literalExpression>
+            <text>-@"P1D"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_003_a" id="_decision_003_a">
+        <variable name="decision_003_a"/>
+        <literalExpression>
+            <text>-@"-P1D"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_004" id="_decision_004">
+        <variable name="decision_004"/>
+        <literalExpression>
+            <text>-@"P1Y"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_004_a" id="_decision_004_a">
+        <variable name="decision_004_a"/>
+        <literalExpression>
+            <text>-@"-P1Y"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_005" id="_decision_005">
+        <variable name="decision_005"/>
+        <literalExpression>
+            <text>-@"2021-01-01"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_006" id="_decision_006">
+        <variable name="decision_006"/>
+        <literalExpression>
+            <text>-@"2021-01-01T10:10:10"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_007" id="_decision_007">
+        <variable name="decision_007"/>
+        <literalExpression>
+            <text>-@"10:10:10"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_008" id="_decision_008">
+        <variable name="decision_008"/>
+        <literalExpression>
+            <text>-{a: 1}</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_009" id="_decision_009">
+        <variable name="decision_009"/>
+        <literalExpression>
+            <text>-"10"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_010" id="_decision_010">
+        <variable name="decision_010"/>
+        <literalExpression>
+            <text>-[10]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_011" id="_decision_011">
+        <variable name="decision_011"/>
+        <literalExpression>
+            <text>-[1..5]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_012" id="_decision_012">
+        <variable name="decision_012"/>
+        <literalExpression>
+            <text>-(function(a) a)(10)</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+


### PR DESCRIPTION
Some specific tests re arithmetic negation.  Just asserting what types may be negated.  And negation of already negated stuff.

There is one thing I'd like to highlight about arithmetic negation and my feeling is it is an oversight and may need to go for clarification and that is this in the S-FEEL section 9.5:

> Arithmetic negation (grammar rule 2.d) is defined only when its operand is a number: in that case, its semantics is
according to the specification of op:numeric-unary-minus

The same 'number' restriction is not mentioned in the FEEL (proper) section.

But as of 1.3 .. both duration types are now supported by abs() .  They already are supported by multiplications, so `@"P1D" * -1` is `-P1D` - arithmetic negation is effectively the same thing.  Indeed, a runtime is likely to implement arithmetic negation using the same logic it uses for `<duration> * <number>` (and vice versa).

So (IMO) it doesn't make too much sense to permit `@"P1D" * -1`, but not permit `-@"P1D"`, or `-foo`, where `foo` is a duration variable.

To that end the tests here include assertions that numbers and durations can be the subject of arithmetic negation.

If this requires clarification for FEEL (as opposed S-FEEL) then I'm happy to comment out those assertions and leave the rest.

Comments welcome.