### PR TITLE
Migrate TravisCI settings to GitHub Actions

### DIFF
--- a/.github/workflows/global_validation.yml
+++ b/.github/workflows/global_validation.yml
@@ -1,0 +1,22 @@
+name: "TCK Validation"
+
+on:
+  [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run TCK Validation
+      run: cd runners && mvn verify --batch-mode --update-snapshots -Pvalidation

--- a/.github/workflows/optional_camunda.yml
+++ b/.github/workflows/optional_camunda.yml
@@ -1,4 +1,4 @@
-name: "OPTIONAL Camunda Runner"
+name: "[OPTIONAL] Camunda Runner"
 
 on:
   [ push, pull_request ]

--- a/.github/workflows/optional_camunda.yml
+++ b/.github/workflows/optional_camunda.yml
@@ -1,0 +1,22 @@
+name: "OPTIONAL Camunda Runner"
+
+on:
+  [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run OPTIONAL Camunda Runner
+      run: cd runners && mvn verify --batch-mode --update-snapshots -Pcamunda

--- a/.github/workflows/optional_drools.yml
+++ b/.github/workflows/optional_drools.yml
@@ -1,0 +1,22 @@
+name: "OPTIONAL Drools Runner"
+
+on:
+  [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run OPTIONAL Drools Runner
+      run: cd runners && mvn verify --batch-mode --update-snapshots -Pdrools

--- a/.github/workflows/optional_drools.yml
+++ b/.github/workflows/optional_drools.yml
@@ -1,4 +1,4 @@
-name: "OPTIONAL Drools Runner"
+name: "[OPTIONAL] Drools Runner"
 
 on:
   [ push, pull_request ]


### PR DESCRIPTION
This PR is to migrate the current TravisCI settings:

https://github.com/dmn-tck/tck/blob/ee648ef0f9dfbe7c61ca95343b44d2c19bbceb08/.travis.yml#L6-L9

to GitHub Actions.

This is to avoid relying on Travis CI, which in the past year has not been very reliable to pick up webhooks and jobs from this repo.

Once GitHub Actions are merged, and in-place, we will eventually remove the Travis CI file.