### PR TITLE
DMN1-3 feel is function.

### DIFF
--- a/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function-test-01.xml
+++ b/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function-test-01.xml
@@ -1,0 +1,460 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>0103-feel-is-function.dmn</modelName>
+
+    <testCase id="number_001">
+        <description>number: is equal</description>
+        <resultNode name="number_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="number_002">
+        <description>number: is not equal</description>
+        <resultNode name="number_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="boolean_001">
+        <description>boolean: is equal</description>
+        <resultNode name="boolean_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="boolean_002">
+        <description>boolean: is not equal</description>
+        <resultNode name="boolean_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="string_001">
+        <description>string: is equal</description>
+        <resultNode name="string_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="string_002">
+        <description>string: is not equal</description>
+        <resultNode name="string_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="date_001">
+        <description>date: is equal</description>
+        <resultNode name="date_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="date_002">
+        <description>date: is not equal when year differs</description>
+        <resultNode name="date_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="date_003">
+        <description>date: is not equal when months differs</description>
+        <resultNode name="date_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="date_004">
+        <description>date: is not equal when days differs</description>
+        <resultNode name="date_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="date_005">
+        <description>date: is not equal to UTC zero time of same date</description>
+        <resultNode name="date_005" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_001">
+        <description>time: is equal</description>
+        <resultNode name="time_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_002">
+        <description>time: is equal with same offset</description>
+        <resultNode name="time_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_003">
+        <description>time: is equal with same timezone</description>
+        <resultNode name="time_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_004">
+        <description>time: is equal - UTC zone and UTC offset</description>
+        <resultNode name="time_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_005">
+        <description>time: is not equal - no zone time vs UTC zone time</description>
+        <resultNode name="time_005" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_006">
+        <description>time: is equal - @ zone time with same offset zone time</description>
+        <resultNode name="time_006" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_007">
+        <description>time: is equal - @ GMT vs zero offset zone time</description>
+        <resultNode name="time_007" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_008">
+        <description>time: is not equal when hour differs</description>
+        <resultNode name="time_008" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_009">
+        <description>time: is not equal when minute differs</description>
+        <resultNode name="time_009" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_010">
+        <description>time: is not equal when second differs</description>
+        <resultNode name="time_010" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_011">
+        <description>time: is not equal when offset differs</description>
+        <resultNode name="time_011" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_012">
+        <description>time: is equal when zone differs but offset is same</description>
+        <resultNode name="time_012" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="time_013">
+        <description>time: is not equal when equivalent time in different zones</description>
+        <resultNode name="time_013" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_001">
+        <description>datetime: is equal with same date and time</description>
+        <resultNode name="datetime_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_002">
+        <description>datetime: is equal with same date and time and offset</description>
+        <resultNode name="datetime_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_003">
+        <description>datetime: is equal with same date and time and timezone</description>
+        <resultNode name="datetime_003" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_004">
+        <description>datetime: not equals despite being equal points in time</description>
+        <resultNode name="datetime_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_005">
+        <description>datetime: not equals despite being equal points in time</description>
+        <resultNode name="datetime_005" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_006">
+        <description>datetime: not equals despite being equal points in time</description>
+        <resultNode name="datetime_006" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_007">
+        <description>datetime: not equals when year differs</description>
+        <resultNode name="datetime_007" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_008">
+        <description>datetime: not equals when month differs</description>
+        <resultNode name="datetime_008" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_009">
+        <description>datetime: not equals when day differs</description>
+        <resultNode name="datetime_009" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_010">
+        <description>datetime: not equals when hour differs</description>
+        <resultNode name="datetime_010" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_011">
+        <description>datetime: not equals when minute differs</description>
+        <resultNode name="datetime_011" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_012">
+        <description>datetime: not equals when seconds differs</description>
+        <resultNode name="datetime_012" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_013">
+        <description>datetime: not equals when offset differs</description>
+        <resultNode name="datetime_013" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_014">
+        <description>datetime: equals when zone ofset is same even though zone differs</description>
+        <resultNode name="datetime_014" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_015">
+        <description>datetime: is equal - UTC zone vs UTC offset</description>
+        <resultNode name="datetime_015" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_016">
+        <description>datetime: is equal - zone vs offset - in DST</description>
+        <resultNode name="datetime_016" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="datetime_017">
+        <description>datetime: is equal - zone vs offset - outside DST</description>
+        <resultNode name="datetime_017" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="dt_duration_001">
+        <description>days and time duration: same stuff is equal</description>
+        <resultNode name="dt_duration_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="dt_duration_002">
+        <description>days and time duration: same duration in different units is equal</description>
+        <resultNode name="dt_duration_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="ym_duration_001">
+        <description>years and months duration: not a permitted type</description>
+        <resultNode name="ym_duration_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="ym_duration_002">
+        <description>years and months duration: same duration in different units is equal</description>
+        <resultNode name="ym_duration_002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="zero_duration_001">
+        <description>zero durations are not equal</description>
+        <resultNode name="zero_duration_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">false</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="named_params_001">
+        <description>correct names params okay</description>
+        <resultNode name="named_params_001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="named_params_002">
+        <description>null: is not a permitted value1 type</description>
+        <resultNode name="named_params_002" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="named_params_003">
+        <description>null: is not a permitted value2 type</description>
+        <resultNode name="named_params_003" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"></value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="named_params_004">
+        <!-- @tarilabs ... I still think this is wrong .... -->
+        <description>will ignore mismatching named params</description>
+        <resultNode name="named_params_004" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function-test-01.xml
+++ b/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function-test-01.xml
@@ -151,19 +151,19 @@
     </testCase>
 
     <testCase id="time_006">
-        <description>time: is equal - @ zone time with same offset zone time</description>
+        <description>time: is not equal - @ zone time with same offset zone time</description>
         <resultNode name="time_006" type="decision">
             <expected>
-                <value xsi:type="xsd:boolean">true</value>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>
 
     <testCase id="time_007">
-        <description>time: is equal - @ GMT vs zero offset zone time</description>
+        <description>time: is not equal - @ GMT vs zero offset zone time</description>
         <resultNode name="time_007" type="decision">
             <expected>
-                <value xsi:type="xsd:boolean">true</value>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>
@@ -205,10 +205,10 @@
     </testCase>
 
     <testCase id="time_012">
-        <description>time: is equal when zone differs but offset is same</description>
+        <description>time: is not equal when zone differs but offset is same</description>
         <resultNode name="time_012" type="decision">
             <expected>
-                <value xsi:type="xsd:boolean">true</value>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>
@@ -340,10 +340,10 @@
     </testCase>
 
     <testCase id="datetime_014">
-        <description>datetime: equals when zone ofset is same even though zone differs</description>
+        <description>datetime: not equals when region differs even though offset is same</description>
         <resultNode name="datetime_014" type="decision">
             <expected>
-                <value xsi:type="xsd:boolean">true</value>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>
@@ -358,19 +358,19 @@
     </testCase>
 
     <testCase id="datetime_016">
-        <description>datetime: is equal - zone vs offset - in DST</description>
+        <description>datetime: is not equal - zone vs offset - DST</description>
         <resultNode name="datetime_016" type="decision">
             <expected>
-                <value xsi:type="xsd:boolean">true</value>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>
 
     <testCase id="datetime_017">
-        <description>datetime: is equal - zone vs offset - outside DST</description>
+        <description>datetime: is not equal - zone vs offset - outside DST</description>
         <resultNode name="datetime_017" type="decision">
             <expected>
-                <value xsi:type="xsd:boolean">true</value>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>
@@ -448,11 +448,10 @@
     </testCase>
 
     <testCase id="named_params_004">
-        <!-- @tarilabs ... I still think this is wrong .... -->
-        <description>will ignore mismatching named params</description>
-        <resultNode name="named_params_004" type="decision">
+        <description>will return null when unknown named params</description>
+        <resultNode name="named_params_004" type="decision" errorResult="true">
             <expected>
-                <value xsi:type="xsd:boolean">true</value>
+                <value xsi:nil="true"></value>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function-test-01.xml
+++ b/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function-test-01.xml
@@ -430,19 +430,19 @@
     </testCase>
 
     <testCase id="named_params_002">
-        <description>null: is not a permitted value1 type</description>
-        <resultNode name="named_params_002" type="decision" errorResult="true">
+        <description>value1 param is nullable</description>
+        <resultNode name="named_params_002" type="decision">
             <expected>
-                <value xsi:nil="true"></value>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>
 
     <testCase id="named_params_003">
-        <description>null: is not a permitted value2 type</description>
-        <resultNode name="named_params_003" type="decision" errorResult="true">
+        <description>value2 param is nullable</description>
+        <resultNode name="named_params_003" type="decision">
             <expected>
-                <value xsi:nil="true"></value>
+                <value xsi:type="xsd:boolean">false</value>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function.dmn
+++ b/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function.dmn
@@ -170,9 +170,9 @@
     </decision>
 
     <decision name="time_006" id="_time_006">
-        <description>Tests FEEL expression: 'is(@"23:00:50@Australia/Melbourne", @"23:00:50+10:00")' and expects result: 'true (boolean)'</description>
+        <description>Tests FEEL expression: 'is(@"23:00:50@Australia/Melbourne", @"23:00:50+10:00")' and expects result: 'false (boolean)'</description>
         <question>Result of FEEL expression 'is(@"23:00:50@Australia/Melbourne", @"23:00:50+10:00")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <allowedAnswers>false (boolean)</allowedAnswers>
         <variable name="time_006"/>
         <literalExpression>
             <text>is(@"23:00:50@Australia/Melbourne", @"23:00:50+10:00")</text>
@@ -180,9 +180,9 @@
     </decision>
 
     <decision name="time_007" id="_time_007">
-        <description>Tests FEEL expression: 'is(@"23:00:50@Etc/GMT", @"23:00:50Z")' and expects result: 'true (boolean)'</description>
+        <description>Tests FEEL expression: 'is(@"23:00:50@Etc/GMT", @"23:00:50Z")' and expects result: 'false (boolean)'</description>
         <question>Result of FEEL expression 'is(@"23:00:50@Etc/GMT", @"23:00:50Z")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <allowedAnswers>false (boolean)</allowedAnswers>
         <variable name="time_007"/>
         <literalExpression>
             <text>is(@"23:00:50@Etc/GMT", @"23:00:50Z")</text>
@@ -230,9 +230,9 @@
     </decision>
 
     <decision name="time_012" id="_time_012">
-        <description>Tests FEEL expression: 'is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Sydney")' and expects result: 'true (boolean)'</description>
+        <description>Tests FEEL expression: 'is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Sydney")' and expects result: 'false (boolean)'</description>
         <question>Result of FEEL expression 'is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Sydney")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <allowedAnswers>false (boolean)</allowedAnswers>
         <variable name="time_012"/>
         <literalExpression>
             <text>is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Sydney")</text>
@@ -387,9 +387,9 @@
     </decision>
 
     <decision name="datetime_014" id="_datetime_014">
-        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00@Australia/Melbourne", @"2002-04-02T23:00:00@Australia/Sydney")' and expects result: 'true (boolean)'</description>
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00@Australia/Melbourne", @"2002-04-02T23:00:00@Australia/Sydney")' and expects result: 'false (boolean)'</description>
         <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00@Australia/Melbourne", @"2002-04-02T23:00:00@Australia/Sydney")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <allowedAnswers>false (boolean)</allowedAnswers>
         <variable name="datetime_014"/>
         <literalExpression>
             <text>is(@"2002-04-02T23:00:00@Australia/Melbourne", @"2002-04-02T23:00:00@Australia/Sydney")</text>
@@ -407,9 +407,9 @@
     </decision>
 
     <decision name="datetime_016" id="_datetime_016">
-        <description>Tests FEEL expression: 'is(@"2021-04-02T23:00:00@Australia/Melbourne", @"2021-04-02T23:00:00+11:00")' and expects result: 'true (boolean)'</description>
+        <description>Tests FEEL expression: 'is(@"2021-04-02T23:00:00@Australia/Melbourne", @"2021-04-02T23:00:00+11:00")' and expects result: 'false (boolean)'</description>
         <question>Result of FEEL expression 'is(@"2021-04-02T23:00:00@Australia/Melbourne", @"2021-04-02T23:00:00+11:00")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <allowedAnswers>false (boolean)</allowedAnswers>
         <variable name="datetime_016"/>
         <literalExpression>
             <text>is(@"2021-04-02T23:00:00@Australia/Melbourne", @"2021-04-02T23:00:00+11:00")</text>
@@ -417,9 +417,9 @@
     </decision>
 
     <decision name="datetime_017" id="_datetime_017">
-        <description>Tests FEEL expression: 'is(@"2021-10-02T23:00:00@Australia/Melbourne", @"2021-10-02T23:00:00+10:00")' and expects result: 'true (boolean)'</description>
+        <description>Tests FEEL expression: 'is(@"2021-10-02T23:00:00@Australia/Melbourne", @"2021-10-02T23:00:00+10:00")' and expects result: 'false (boolean)'</description>
         <question>Result of FEEL expression 'is(@"2021-10-02T23:00:00@Australia/Melbourne", @"2021-10-02T23:00:00+10:00")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <allowedAnswers>false (boolean)</allowedAnswers>
         <variable name="datetime_017"/>
         <literalExpression>
             <text>is(@"2021-10-02T23:00:00@Australia/Melbourne", @"2021-10-02T23:00:00+10:00")</text>
@@ -507,9 +507,9 @@
     </decision>
 
     <decision name="named_params_004" id="named_params_004">
-        <description>Tests FEEL expression: 'is(value1: @"2021-02-13" , value2: @"2021-02-13", value3: @"2020-01-01")' and expects result: 'true (boolean)'</description>
+        <description>Tests FEEL expression: 'is(value1: @"2021-02-13" , value2: @"2021-02-13", value3: @"2020-01-01")' and expects result: 'null (boolean)'</description>
         <question>Result of FEEL expression 'is(value1: @"2021-02-13" , value2: @"2021-02-13", value3: @"2020-01-01")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <allowedAnswers>null (boolean)</allowedAnswers>
         <variable name="named_params_004"/>
         <literalExpression>
             <text>is(value1: @"2021-02-13" , value2: @"2021-02-13", value3: @"2020-01-01")</text>

--- a/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function.dmn
+++ b/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function.dmn
@@ -1,0 +1,520 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/0103-feel-is-function"
+             name="0103-feel-is-function"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <description>is function</description>
+
+    <decision name="number_001" id="_number_001">
+        <description>Tests FEEL expression: 'is(1, 1)' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(1, 1)'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="number_001"/>
+        <literalExpression>
+            <text>is(1, 1)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="number_002" id="_number_002">
+        <description>Tests FEEL expression: 'is(1, 2)' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(1, 2)'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="number_002"/>
+        <literalExpression>
+            <text>is(1, 2)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="boolean_001" id="_boolean_001">
+        <description>Tests FEEL expression: 'is(true, true)' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(true, true)'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="boolean_001"/>
+        <literalExpression>
+            <text>is(true, true)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="boolean_002" id="_boolean_002">
+        <description>Tests FEEL expression: 'is(true, false)' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(true, false)'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="boolean_002"/>
+        <literalExpression>
+            <text>is(true, false)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="string_001" id="_string_001">
+        <description>Tests FEEL expression: 'is("foo", "foo")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is("foo", "foo")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="string_001"/>
+        <literalExpression>
+            <text>is("foo", "foo")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="string_002" id="_string_002">
+        <description>Tests FEEL expression: 'is("foo", "bar")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is("foo", "bar")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="string_002"/>
+        <literalExpression>
+            <text>is("foo", "bar")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="date_001" id="_date_001">
+        <description>Tests FEEL expression: 'is(@"2012-12-25", @"2012-12-25")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2012-12-25", @"2012-12-25")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="date_001"/>
+        <literalExpression>
+            <text>is(@"2012-12-25", @"2012-12-25")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="date_002" id="_date_002">
+        <description>Tests FEEL expression: 'is(@"2011-12-25", @"2012-12-25")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2011-12-25", @"2012-12-25")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="date_002"/>
+        <literalExpression>
+            <text>is(@"2011-12-25", @"2012-12-25")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="date_003" id="_date_003">
+        <description>Tests FEEL expression: 'is(@"2012-12-25", @"2012-11-25")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2012-12-25", @"2012-11-25")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="date_003"/>
+        <literalExpression>
+            <text>is(@"2012-12-25", @"2012-11-25")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="date_004" id="_date_004">
+        <description>Tests FEEL expression: 'is(@"2012-12-25", @"2012-12-26")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2012-12-25", @"2012-12-26")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="date_004"/>
+        <literalExpression>
+            <text>is(@"2012-12-25", @"2012-12-26")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="date_005" id="_date_005">
+        <description>Tests FEEL expression: 'is(@"2012-12-25", @"2012-12-25T00:00:00Z")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2012-12-25", @"2012-12-25T00:00:00Z")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="date_005"/>
+        <literalExpression>
+            <text>is(@"2012-12-25", @"2012-12-25T00:00:00Z")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_001" id="_time_001">
+        <description>Tests FEEL expression: 'is(@"23:00:50", @"23:00:50")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50", @"23:00:50")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="time_001"/>
+        <literalExpression>
+            <text>is(@"23:00:50", @"23:00:50")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_002" id="_time_002">
+        <description>Tests FEEL expression: 'is(@"23:00:50+11:00", @"23:00:50+11:00")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50+11:00", @"23:00:50+11:00")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="time_002"/>
+        <literalExpression>
+            <text>is(@"23:00:50+11:00", @"23:00:50+11:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_003" id="_time_003">
+        <description>Tests FEEL expression: 'is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Melbourne")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Melbourne")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="time_003"/>
+        <literalExpression>
+            <text>is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Melbourne")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_004" id="_time_004">
+        <description>Tests FEEL expression: 'is(@"23:00:50Z", @"23:00:50+00:00")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50Z", @"23:00:50+00:00")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="time_004"/>
+        <literalExpression>
+            <text>is(@"23:00:50Z", @"23:00:50+00:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_005" id="_time_005">
+        <description>Tests FEEL expression: 'is(@"23:00:50", @"23:00:50Z")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50", @"23:00:50Z")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="time_005"/>
+        <literalExpression>
+            <text>is(@"23:00:50", @"23:00:50Z")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_006" id="_time_006">
+        <description>Tests FEEL expression: 'is(@"23:00:50@Australia/Melbourne", @"23:00:50+10:00")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50@Australia/Melbourne", @"23:00:50+10:00")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="time_006"/>
+        <literalExpression>
+            <text>is(@"23:00:50@Australia/Melbourne", @"23:00:50+10:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_007" id="_time_007">
+        <description>Tests FEEL expression: 'is(@"23:00:50@Etc/GMT", @"23:00:50Z")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50@Etc/GMT", @"23:00:50Z")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="time_007"/>
+        <literalExpression>
+            <text>is(@"23:00:50@Etc/GMT", @"23:00:50Z")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_008" id="_time_008">
+        <description>Tests FEEL expression: 'is(@"22:00:50", @"23:00:50")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"22:00:50", @"23:00:50")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="time_008"/>
+        <literalExpression>
+            <text>is(@"22:00:50", @"23:00:50")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_009" id="_time_009">
+        <description>Tests FEEL expression: 'is(@"23:01:50", @"23:00:50")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:01:50", @"23:00:50")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="time_009"/>
+        <literalExpression>
+            <text>is(@"23:01:50", @"23:00:50")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_010" id="_time_010">
+        <description>Tests FEEL expression: 'is(@"23:00:51", @"23:00:50")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:51", @"23:00:50")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="time_010"/>
+        <literalExpression>
+            <text>is(@"23:00:51", @"23:00:50")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_011" id="_time_011">
+        <description>Tests FEEL expression: 'is(@"23:00:50+10:00", @"23:00:50+11:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50+10:00", @"23:00:50+11:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="time_011"/>
+        <literalExpression>
+            <text>is(@"23:00:50+10:00", @"23:00:50+11:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_012" id="_time_012">
+        <description>Tests FEEL expression: 'is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Sydney")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Sydney")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="time_012"/>
+        <literalExpression>
+            <text>is(@"23:00:50@Australia/Melbourne", @"23:00:50@Australia/Sydney")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="time_013" id="_time_013">
+        <description>Tests FEEL expression: 'is(@"20:00:50+00:00", @"21:00:50+01:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"20:00:50+00:00", @"21:00:50+01:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="time_013"/>
+        <literalExpression>
+            <text>is(@"20:00:50+00:00", @"21:00:50+01:00")</text>
+        </literalExpression>
+    </decision>
+
+
+    <decision name="datetime_001" id="_datetime_001">
+        <description>Tests FEEL expression: 'is(@"2012-12-25T10:10:10", @"2012-12-25T10:10:10")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2012-12-25T10:10:10", @"2012-12-25T10:10:10")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="datetime_001"/>
+        <literalExpression>
+            <text>is(@"2012-12-25T10:10:10", @"2012-12-25T10:10:10")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_002" id="_datetime_002">
+        <description>Tests FEEL expression: 'is(@"2012-12-25T10:10:10+11:00", @"2012-12-25T10:10:10+11:00")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2012-12-25T10:10:10+11:00", @"2012-12-25T10:10:10+11:00")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="datetime_002"/>
+        <literalExpression>
+            <text>is(@"2012-12-25T10:10:10+11:00", @"2012-12-25T10:10:10+11:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_003" id="_datetime_003">
+        <description>Tests FEEL expression: 'is(@"2012-12-25T10:10:10@Australia/Melbourne", @"2012-12-25T10:10:10@Australia/Melbourne")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2012-12-25T10:10:10@Australia/Melbourne", @"2012-12-25T10:10:10@Australia/Melbourne")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="datetime_003"/>
+        <literalExpression>
+            <text>is(@"2012-12-25T10:10:10@Australia/Melbourne", @"2012-12-25T10:10:10@Australia/Melbourne")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_004" id="_datetime_004">
+        <!-- example from https://www.w3.org/TR/xpath-functions-31/#func-dateTime-equal.  that spec says
+        equal, but not semantically equal, so asserting false here -->
+        <description>Tests FEEL expression: 'is(@"2002-04-02T12:00:00-01:00", @"2002-04-02T17:00:00+04:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T12:00:00-01:00", @"2002-04-02T17:00:00+04:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_004"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T12:00:00-01:00", @"2002-04-02T17:00:00+04:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_005" id="_datetime_005">
+        <!-- example from https://www.w3.org/TR/xpath-functions-31/#func-dateTime-equal.  that spec says
+        equal, but not semantically equal, so asserting false here -->
+        <description>Tests FEEL expression: 'is(@"2002-04-02T12:00:00-05:00", @"2002-04-02T23:00:00+06:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T12:00:00-05:00", @"2002-04-02T23:00:00+06:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_005"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T12:00:00-05:00", @"2002-04-02T23:00:00+06:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_006" id="_datetime_006">
+        <!-- example from https://www.w3.org/TR/xpath-functions-31/#func-dateTime-equal.  that spec says
+        equal, but not semantically equal, so asserting false here -->
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00-04:00", @"2002-04-03T02:00:00-01:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00-04:00", @"2002-04-03T02:00:00-01:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_006"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00-04:00", @"2002-04-03T02:00:00-01:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_007" id="_datetime_007">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00", @"2001-04-02T23:00:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00", @"2001-04-02T23:00:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_007"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00", @"2001-04-02T23:00:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_008" id="_datetime_008">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00", @"2002-05-02T23:00:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00", @"2002-05-02T23:00:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_008"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00", @"2002-05-02T23:00:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_009" id="_datetime_009">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00", @"2002-04-03T23:00:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00", @"2002-04-03T23:00:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_009"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00", @"2002-04-03T23:00:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_010" id="_datetime_010">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00", @"2002-04-02T22:00:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00", @"2002-04-02T22:00:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_010"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00", @"2002-04-02T22:00:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_011" id="_datetime_011">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00", @"2002-04-02T23:01:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00", @"2002-04-02T23:01:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_011"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00", @"2002-04-02T23:01:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_012" id="_datetime_012">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00", @"2002-04-02T23:00:01")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00", @"2002-04-02T23:00:01")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_012"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00", @"2002-04-02T23:00:01")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_013" id="_datetime_013">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00+10:00", @"2002-04-02T23:00:00+11:00")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00+10:00", @"2002-04-02T23:00:00+11:00")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="datetime_013"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00+10:00", @"2002-04-02T23:00:00+11:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_014" id="_datetime_014">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:00@Australia/Melbourne", @"2002-04-02T23:00:00@Australia/Sydney")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:00@Australia/Melbourne", @"2002-04-02T23:00:00@Australia/Sydney")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="datetime_014"/>
+        <literalExpression>
+            <text>is(@"2002-04-02T23:00:00@Australia/Melbourne", @"2002-04-02T23:00:00@Australia/Sydney")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_015" id="_datetime_015">
+        <description>Tests FEEL expression: 'is(@"2002-04-02T23:00:50Z", @"2002-04-02T23:00:50+00:00")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2002-04-02T23:00:50Z", @"2002-04-02T23:00:50+00:00")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="datetime_015"/>
+        <literalExpression>
+            <text>is(@"23:00:50Z", @"23:00:50+00:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_016" id="_datetime_016">
+        <description>Tests FEEL expression: 'is(@"2021-04-02T23:00:00@Australia/Melbourne", @"2021-04-02T23:00:00+11:00")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2021-04-02T23:00:00@Australia/Melbourne", @"2021-04-02T23:00:00+11:00")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="datetime_016"/>
+        <literalExpression>
+            <text>is(@"2021-04-02T23:00:00@Australia/Melbourne", @"2021-04-02T23:00:00+11:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="datetime_017" id="_datetime_017">
+        <description>Tests FEEL expression: 'is(@"2021-10-02T23:00:00@Australia/Melbourne", @"2021-10-02T23:00:00+10:00")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"2021-10-02T23:00:00@Australia/Melbourne", @"2021-10-02T23:00:00+10:00")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="datetime_017"/>
+        <literalExpression>
+            <text>is(@"2021-10-02T23:00:00@Australia/Melbourne", @"2021-10-02T23:00:00+10:00")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="dt_duration_001" id="_dt_duration_001">
+        <description>Tests FEEL expression: 'is(@"P1D", @"P1D")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"P1D", @"P1D")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="dt_duration_001"/>
+        <literalExpression>
+            <text>is(@"P1D", @"P1D")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="dt_duration_002" id="_dt_duration_002">
+        <description>Tests FEEL expression: 'is(@"P1D", @"PT24H")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"P1D", @"PT24H")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="dt_duration_002"/>
+        <literalExpression>
+            <text>is(@"P1D", @"PT24H")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="ym_duration_001" id="_ym_duration_001">
+        <description>Tests FEEL expression: 'is(@"P1Y", @"P1Y")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"P1Y", @"P1Y")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="ym_duration_001"/>
+        <literalExpression>
+            <text>is(@"P1Y", @"P1Y")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="ym_duration_002" id="_ym_duration_002">
+        <description>Tests FEEL expression: 'is(@"P1Y", @"P12M")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"P1Y", @"P12M")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="ym_duration_002"/>
+        <literalExpression>
+            <text>is(@"P1Y", @"P12M")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="zero_duration_001" id="_zero_duration_001">
+        <description>Tests FEEL expression: 'is(@"P0Y", @"P0D")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(@"P0Y", @"P0D")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
+        <variable name="zero_duration_001"/>
+        <literalExpression>
+            <text>is(@"P0Y", @"P0D")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="named_params_001" id="named_params_001">
+        <description>Tests FEEL expression: 'is(value1: @"2021-02-13" , value2: @"2021-02-13")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(value1: @"2021-02-13" , value2: @"2021-02-13")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="named_params_001"/>
+        <literalExpression>
+            <text>is(value1: @"2021-02-13" , value2: @"2021-02-13")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="named_params_002" id="named_params_002">
+        <description>Tests FEEL expression: 'is(value2: @"2021-02-13")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(value2: @"2021-02-13")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="named_params_002"/>
+        <literalExpression>
+            <text>is(value1: @"2021-02-13")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="named_params_003" id="named_params_003">
+        <description>Tests FEEL expression: 'is(value1: @"2021-02-13")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(value1: @"2021-02-13")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="named_params_003"/>
+        <literalExpression>
+            <text>is(value1: @"2021-02-13")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="named_params_004" id="named_params_004">
+        <description>Tests FEEL expression: 'is(value1: @"2021-02-13" , value2: @"2021-02-13", value3: @"2020-01-01")' and expects result: 'true (boolean)'</description>
+        <question>Result of FEEL expression 'is(value1: @"2021-02-13" , value2: @"2021-02-13", value3: @"2020-01-01")'?</question>
+        <allowedAnswers>true (boolean)</allowedAnswers>
+        <variable name="named_params_004"/>
+        <literalExpression>
+            <text>is(value1: @"2021-02-13" , value2: @"2021-02-13", value3: @"2020-01-01")</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function.dmn
+++ b/TestCases/compliance-level-3/0103-feel-is-function/0103-feel-is-function.dmn
@@ -487,9 +487,9 @@
     </decision>
 
     <decision name="named_params_002" id="named_params_002">
-        <description>Tests FEEL expression: 'is(value2: @"2021-02-13")' and expects result: 'true (boolean)'</description>
-        <question>Result of FEEL expression 'is(value2: @"2021-02-13")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <description>Tests FEEL expression: 'is(value1: @"2021-02-13")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(value1: @"2021-02-13")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
         <variable name="named_params_002"/>
         <literalExpression>
             <text>is(value1: @"2021-02-13")</text>
@@ -497,12 +497,12 @@
     </decision>
 
     <decision name="named_params_003" id="named_params_003">
-        <description>Tests FEEL expression: 'is(value1: @"2021-02-13")' and expects result: 'true (boolean)'</description>
-        <question>Result of FEEL expression 'is(value1: @"2021-02-13")'?</question>
-        <allowedAnswers>true (boolean)</allowedAnswers>
+        <description>Tests FEEL expression: 'is(value2: @"2021-02-13")' and expects result: 'false (boolean)'</description>
+        <question>Result of FEEL expression 'is(value2: @"2021-02-13")'?</question>
+        <allowedAnswers>false (boolean)</allowedAnswers>
         <variable name="named_params_003"/>
         <literalExpression>
-            <text>is(value1: @"2021-02-13")</text>
+            <text>is(value2: @"2021-02-13")</text>
         </literalExpression>
     </decision>
 


### PR DESCRIPTION
All, an initial suite of tests for the new DMN 1.3 is() function.  

This guy is not very well specified at all and it is not very clear what boundaries are on this guy - type the types it can operate on and so forth.  I have raised a issue with DMN seeking clarification.

But, I have some some assumptions that it operates on the types in section in 10.3.2.2 Equality, Identity and Equivalence.  To that end I have no tests covering other types until we know more.

Also, one thing in these tests is the notions that for types with zone/offset info, for the purposes of semantic equivalence we are interested in the _offset_.  The semantic fields given in 10.3.2.2 refer to an optional _offset_. So, two values being equal in all respects except for zone/offset will be semantically equal if they 'normalise' to the same offset value.  

The example in the spec `is(time("23:00:50z"),time("23:00:50+00:00”)) is false` is incorrect I believe.  @tarilabs - I saw an issue raised by you also on that test.  These tests assume that value should be true as `Z` and `+00:00` are the same offset.

Note also the comment i made on the equality tests regarding DMN 'zoned times' and how the time of year nay affect their offset value.  Repeated here:

> As a note, as DMN supports a time with at zone like 10:15:00@Europe/Paris - which is not a hard offset like +01:00 it is possible that some implementations may use the equivalent of now() to get a zoned date time to get an offset from. This is a little dangerous because the meaning of @Europe/Paris and its offset changes during the year. So a test like @"0:15:00+01:00" = @"10:15:00@Europe/Paris" will be correct only for some part of the year. At other times the offset will be +02:00. So, my suggestion is, do not use now() with DMN zoned times, use a standard epoch date like 1970-01-01T00:00:00 to get an offset, then it'll be constant. The spec does not say that, but, maybe it should.

Some of the tests here are purposely the inverse of the results they give in the equality test suite.

I have add some token tests for number/boolean/string more as a means of verifying the impl support those types passing through the is() function.  

All feedback appreciated.

Greg.