### PR TITLE
DMN1-3 exponent. Checking for decimal values.

### DIFF
--- a/TestCases/compliance-level-3/0075-feel-exponent/0075-feel-exponent-test-01.xml
+++ b/TestCases/compliance-level-3/0075-feel-exponent/0075-feel-exponent-test-01.xml
@@ -27,6 +27,33 @@
         </resultNode>
     </testCase>
 
+    <testCase id="decision_001_b">
+        <description>exponent may not have decimals</description>
+        <resultNode name="decision_001_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_001_c">
+        <description>exponent may have decimals if zero</description>
+        <resultNode name="decision_001_c" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">9</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="decision_001_d">
+        <description>base may be a decimal number</description>
+        <resultNode name="decision_001_d" type="decision">
+            <expected>
+                <value xsi:type="xsd:decimal">10.3684</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
     <testCase id="decision_002">
         <description>string exponent is null</description>
         <resultNode errorResult="true" name="decision_002" type="decision">

--- a/TestCases/compliance-level-3/0075-feel-exponent/0075-feel-exponent.dmn
+++ b/TestCases/compliance-level-3/0075-feel-exponent/0075-feel-exponent.dmn
@@ -16,6 +16,27 @@
         </literalExpression>
     </decision>
 
+    <decision name="decision_001_b" id="_decision_001_b">
+        <variable name="decision_001_b"/>
+        <literalExpression>
+            <text>3 ** 2.55</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_001_c" id="_decision_001_c">
+        <variable name="decision_001_c"/>
+        <literalExpression>
+            <text>3 ** 2.00</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_001_d" id="_decision_001_d">
+        <variable name="decision_001_d"/>
+        <literalExpression>
+            <text>3.22 ** 2</text>
+        </literalExpression>
+    </decision>
+
     <decision name="decision_002" id="_decision_002">
         <variable name="decision_002"/>
         <literalExpression>


### PR DESCRIPTION
DMN 1.3 Made a small change the exponent spec replacing 'integer' with 'number' for the exponent - the range remains the same but nothing about it being an integral number.

As it was explicit before that an expression like `2 ** 1.5` was not legal, it now is not explicit.  So some tests here to verify that     `2 ** 1.5` returns null, but something `2 ** 1.0` is okay.  Additionally, added a test that the base may also be a decimal like `2.5 ** 3`. 

Comments welcome.