### PR TITLE
Augment TCK Validator detect duplicate id(s) in TCK xmls

### DIFF
--- a/runners/dmn-tck-validation/pom.xml
+++ b/runners/dmn-tck-validation/pom.xml
@@ -10,6 +10,12 @@
   <description>Validate testCase xml files for both DMN model and test case definition.</description>
   <dependencies>
     <dependency>
+      <groupId>org.omg.dmn</groupId>
+      <artifactId>tck-runner</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>


### PR DESCRIPTION
this should automatically perform some of the feedback I've seen in recent PRs :) 