### PR TITLE
Fix typeRef for bkmn.encapsulatedLogic

### DIFF
--- a/TestCases/compliance-level-3/0082-feel-coercion/0082-feel-coercion.dmn
+++ b/TestCases/compliance-level-3/0082-feel-coercion/0082-feel-coercion.dmn
@@ -148,9 +148,9 @@
 
     <businessKnowledgeModel name="bkm_004" id="_bkm_004">
         <variable name="bkm_004"/>
-        <encapsulatedLogic typeRef="tNumberList">
+        <encapsulatedLogic>
             <formalParameter name="arg"/>
-            <literalExpression>
+            <literalExpression typeRef="tNumberList">
                 <text>arg</text>
             </literalExpression>
         </encapsulatedLogic>
@@ -158,9 +158,9 @@
 
     <businessKnowledgeModel name="bkm_005" id="_bkm_005">
         <variable name="bkm_005"/>
-        <encapsulatedLogic typeRef="number">
+        <encapsulatedLogic>
             <formalParameter name="arg"/>
-            <literalExpression>
+            <literalExpression typeRef="number">
                 <text>[arg]</text>
             </literalExpression>
         </encapsulatedLogic>

--- a/TestCases/compliance-level-3/0086-import/Imported_Model.dmn
+++ b/TestCases/compliance-level-3/0086-import/Imported_Model.dmn
@@ -21,9 +21,9 @@
     </itemDefinition>
     <businessKnowledgeModel id="_32543811-b499-4608-b784-6c6f294b1c58" name="Say Hello">
         <variable name="Say Hello" id="_a8eb10e1-30e6-40d8-a564-a868f4e0af34"/>
-        <encapsulatedLogic id="_acbb96c9-34a3-4628-8179-dfc5f583e695" kind="FEEL" typeRef="string" triso:expressionId="_39e3582e-df8d-44a4-8309-2d94bf4c0406">
+        <encapsulatedLogic id="_acbb96c9-34a3-4628-8179-dfc5f583e695" kind="FEEL" triso:expressionId="_39e3582e-df8d-44a4-8309-2d94bf4c0406">
             <formalParameter name="Person" typeRef="tPerson" id="_4a626f74-2ecc-4759-b76a-04baec6b795d"/>
-            <literalExpression id="_c173a894-3719-4d2f-a365-25850e217310">
+            <literalExpression id="_c173a894-3719-4d2f-a365-25850e217310" typeRef="string">
                 <text>"Hello " + Person.name + "!"</text>
             </literalExpression>
         </encapsulatedLogic>

--- a/TestCases/compliance-level-3/0087-chapter-11-example/0087-chapter-11-example.dmn
+++ b/TestCases/compliance-level-3/0087-chapter-11-example/0087-chapter-11-example.dmn
@@ -249,11 +249,11 @@
 	<semantic:businessKnowledgeModel id="_dc2ca64d-2044-4806-9d0e-e705b3b14447" name="Eligibility rules">
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Eligibility from Pre-Bureau Risk Category, Pre-Bureau Affordability and Age.&lt;/span&gt;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Eligibility rules" id="_fe2d2049-704b-4a88-88be-3d1a56c3d376"/>
-		<semantic:encapsulatedLogic typeRef="tEligibility">
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
 			<semantic:formalParameter name="Pre-Bureau Affordability" typeRef="boolean"/>
 			<semantic:formalParameter name="Age" typeRef="number"/>
-			<semantic:decisionTable id="_7d663660-b2e1-47d1-9870-777b5a695e7f" hitPolicy="PRIORITY" outputLabel="Eligibility rules">
+			<semantic:decisionTable id="_7d663660-b2e1-47d1-9870-777b5a695e7f" hitPolicy="PRIORITY" outputLabel="Eligibility rules" typeRef="tEligibility">
 				<semantic:input id="_2bab5dc0-be18-4098-b9b4-6b3486955d1b">
 					<semantic:inputExpression typeRef="tRiskCategory">
 						<semantic:text>Pre-Bureau Risk Category</semantic:text>
@@ -343,12 +343,12 @@
 	<semantic:businessKnowledgeModel id="_536d7a39-87a6-4651-b743-6ee03e16e535" name="Routing rules">
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing Rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Routing from Post-Bureau Risk Category, Post-Bureau Affordability, Bankrupt and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Routing rules" id="_08f4f63e-54e4-4b19-b0d2-08aeed21605c"/>
-		<semantic:encapsulatedLogic typeRef="tRouting">
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="Post-bureau risk category" typeRef="tRiskCategory"/>
 			<semantic:formalParameter name="Post-bureau affordability" typeRef="boolean"/>
 			<semantic:formalParameter name="Bankrupt" typeRef="boolean"/>
 			<semantic:formalParameter name="Credit score" typeRef="number"/>
-			<semantic:decisionTable id="_4dfddea8-3c8e-400a-97bc-dcba00876c34" hitPolicy="PRIORITY" outputLabel="Routing rules">
+			<semantic:decisionTable id="_4dfddea8-3c8e-400a-97bc-dcba00876c34" hitPolicy="PRIORITY" outputLabel="Routing rules" typeRef="tRouting">
 				<semantic:input id="_b3bde44f-2274-41d5-8e04-5cb2f7529e6c">
 					<semantic:inputExpression typeRef="tRiskCategory">
 						<semantic:text>Post-bureau risk category</semantic:text>
@@ -519,9 +519,9 @@
 	<semantic:businessKnowledgeModel id="_a654be71-b54d-4d6e-90f0-ae505125e9a6" name="Bureau call type table">
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table deriving&amp;nbsp;&lt;/span&gt;Bureau Call Type from Pre-Bureau Risk Category.&lt;/span&gt;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Bureau call type table" id="_86c4fcfd-1e5a-41ec-9b62-966cf0eed2d3"/>
-		<semantic:encapsulatedLogic typeRef="tBureauCallType">
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
-			<semantic:decisionTable id="_ebd84888-6db0-4b91-94f4-b3a228bb2901" hitPolicy="UNIQUE" outputLabel="Bureau call type table">
+			<semantic:decisionTable id="_ebd84888-6db0-4b91-94f4-b3a228bb2901" hitPolicy="UNIQUE" outputLabel="Bureau call type table" typeRef="tBureauCallType">
 				<semantic:input id="_92e35546-27e5-43a5-b8e6-85a692f42eb8">
 					<semantic:inputExpression typeRef="tRiskCategory">
 						<semantic:text>Pre-Bureau Risk Category</semantic:text>
@@ -570,9 +570,9 @@
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;/span&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Credit contingency factor table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;decision&lt;/span&gt; logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Credit contingency factor from Risk Category.&lt;/p&gt;
 			&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Credit contingency factor table" id="_40c0f987-7b90-4c3e-9dcd-411e56f66c92"/>
-		<semantic:encapsulatedLogic typeRef="number">
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="Risk Category" typeRef="tRiskCategory"/>
-			<semantic:decisionTable id="_ad7c587e-64cc-47ec-adc4-515b586f9474" hitPolicy="UNIQUE" outputLabel="Credit contingency factor table">
+			<semantic:decisionTable id="_ad7c587e-64cc-47ec-adc4-515b586f9474" hitPolicy="UNIQUE" outputLabel="Credit contingency factor table" typeRef="number">
 				<semantic:input id="_2b8fecfd-e00f-4d4b-acf3-660ca3560ca0">
 					<semantic:inputExpression typeRef="tRiskCategory">
 						<semantic:text>Risk Category</semantic:text>
@@ -616,13 +616,13 @@
 	<semantic:businessKnowledgeModel id="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" name="Affordability calculation">
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Affordability calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a boxed function deriving Affordability from&amp;nbsp;&lt;/span&gt;Monthly Income, Monthly Repayments, Monthly Expenses and Required Monthly Installment. One step in this calculation derives Credit contingency factor by invoking the Credit contingency factor table business&lt;/span&gt;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Affordability calculation" id="_80af1aa7-e29c-47fc-9cce-1959a3e1e717"/>
-		<semantic:encapsulatedLogic id="_b3f131dd-5572-4d63-a693-05af46940267" kind="FEEL" typeRef="boolean">
+		<semantic:encapsulatedLogic id="_b3f131dd-5572-4d63-a693-05af46940267" kind="FEEL">
 			<semantic:formalParameter name="Monthly Income" typeRef="number" id="_f916b091-cd6d-44cb-b32b-cc83cc27e333"/>
 			<semantic:formalParameter name="Monthly Repayments" typeRef="number" id="_d68b6438-cba5-4c02-a708-bce0d2762d35"/>
 			<semantic:formalParameter name="Monthly Expenses" typeRef="number" id="_5fd5609d-89ce-463e-a882-6827921edf54"/>
 			<semantic:formalParameter name="Risk Category" typeRef="tRiskCategory" id="_2acfe2aa-892f-4a5c-b9ab-111c7a8bbd40"/>
 			<semantic:formalParameter name="Required Monthly Installment" typeRef="number" id="_3a423c76-11c7-4b66-b86a-07928181a631"/>
-			<semantic:context id="_2f1ed114-938b-49ac-b696-9c1a1ceb0256">
+			<semantic:context id="_2f1ed114-938b-49ac-b696-9c1a1ceb0256" typeRef="boolean">
 				<semantic:contextEntry id="_ec37158d-b49b-4ffd-88e0-1e2f05c9a023">
 					<semantic:variable name="Disposable Income" id="_3cc56162-97c1-416e-acb9-3ae81d692e58" typeRef="number"/>
 					<semantic:literalExpression id="_2fcda742-6d7b-49c5-afe6-6b334c8f049b">
@@ -812,11 +812,11 @@
 	<semantic:businessKnowledgeModel id="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" name="Post-bureau risk category table">
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Post-Bureau Risk Category from Existing Customer, Application Risk Score and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Post-bureau risk category table" id="_689c96f3-6dd3-4c74-9a8f-721a966eb1af"/>
-		<semantic:encapsulatedLogic typeRef="tRiskCategory">
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
 			<semantic:formalParameter name="Application Risk Score" typeRef="number"/>
 			<semantic:formalParameter name="Credit Score" typeRef="number"/>
-			<semantic:decisionTable id="_c494b824-7c60-4115-8773-00f103b636a0" hitPolicy="UNIQUE" outputLabel="Post-bureau risk category table">
+			<semantic:decisionTable id="_c494b824-7c60-4115-8773-00f103b636a0" hitPolicy="UNIQUE" outputLabel="Post-bureau risk category table" typeRef="tRiskCategory">
 				<semantic:input id="_fc4cfa6b-926b-4751-81d9-d363b6f19299">
 					<semantic:inputExpression typeRef="boolean">
 						<semantic:text>Existing Customer</semantic:text>
@@ -1058,10 +1058,10 @@
 	<semantic:businessKnowledgeModel id="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" name="Pre-bureau risk category table">
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Pre-bureau risk category from Existing Customer and Application Risk Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Pre-bureau risk category table" id="_cfb1bb8c-ad27-42e2-b52a-50eadea198a6"/>
-		<semantic:encapsulatedLogic typeRef="tRiskCategory">
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
 			<semantic:formalParameter name="Application Risk Score" typeRef="number"/>
-			<semantic:decisionTable id="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" hitPolicy="UNIQUE" outputLabel="Pre-bureau risk category table">
+			<semantic:decisionTable id="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" hitPolicy="UNIQUE" outputLabel="Pre-bureau risk category table" typeRef="tRiskCategory">
 				<semantic:input id="_1ee6291f-423f-47d9-8774-858b392d4762">
 					<semantic:inputExpression typeRef="boolean">
 						<semantic:text>Existing Customer</semantic:text>
@@ -1208,11 +1208,11 @@
 	<semantic:businessKnowledgeModel id="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" name="Application risk score model">
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application risk score model&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, no-order multiple-hit table&amp;nbsp;&lt;/span&gt;with aggregation, deriving Application risk score from Age, Marital Status and Employment Status, as the sum of the Partial scores of all matching rows (this is therefore a predictive scorecard represented as a decision table).&lt;/span&gt;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Application risk score model" id="_645f4911-6a95-4dbd-8efb-13fac8154fa2"/>
-		<semantic:encapsulatedLogic typeRef="number">
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="Age" typeRef="number"/>
 			<semantic:formalParameter name="Marital Status" typeRef="string"/>
 			<semantic:formalParameter name="Employment Status" typeRef="string"/>
-			<semantic:decisionTable id="_26378922-484b-42f3-a609-5aecb81afbd2" hitPolicy="COLLECT" outputLabel="Application risk score model" aggregation="SUM">
+			<semantic:decisionTable id="_26378922-484b-42f3-a609-5aecb81afbd2" hitPolicy="COLLECT" outputLabel="Application risk score model" aggregation="SUM" typeRef="number">
 				<semantic:input id="_09b90043-cccb-4cf7-b8bc-44e97787443f">
 					<semantic:inputExpression typeRef="number">
 						<semantic:text>Age</semantic:text>
@@ -1446,12 +1446,12 @@
 	<semantic:businessKnowledgeModel id="_7235d875-2426-4869-b6df-92ca06ae80c5" name="Installment calculation">
 		<semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Installment calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a boxed function deriving monthly installment&amp;nbsp;&lt;/span&gt;from Product Type, Rate, Term and Amount.&lt;/span&gt;&lt;/p&gt;</semantic:description>
 		<semantic:variable name="Installment calculation" id="_c02274e9-a6c8-4498-9d43-eaa33be7a0d9"/>
-		<semantic:encapsulatedLogic id="_5362b6d5-9520-4081-809c-ee85881e2dfa" kind="FEEL" typeRef="number">
+		<semantic:encapsulatedLogic id="_5362b6d5-9520-4081-809c-ee85881e2dfa" kind="FEEL">
 			<semantic:formalParameter name="Product Type" typeRef="string" id="_f6831cd9-3eab-4399-8d29-42b141fd9968"/>
 			<semantic:formalParameter name="Rate" typeRef="number" id="_c6f48aeb-b65d-4307-8722-dd44f7335566"/>
 			<semantic:formalParameter name="Term" typeRef="number" id="_708eb9af-fe19-418c-8547-1647cb50f596"/>
 			<semantic:formalParameter name="Amount" typeRef="number" id="_fddc99bb-3be6-45b0-bf8c-d8d4c016a90b"/>
-			<semantic:context id="_2661f418-77f3-4bab-824a-a4968b8a96d4">
+			<semantic:context id="_2661f418-77f3-4bab-824a-a4968b8a96d4" typeRef="number">
 				<semantic:contextEntry id="_d773da17-a45c-4a3b-8b70-565058cb6e1d">
 					<semantic:variable name="Monthly Fee" id="_2db6ada1-2a67-4c84-bb31-e78178cf6b32" typeRef="number"/>
 					<semantic:literalExpression id="_ad1e4499-e806-42f1-8069-254e98f5d498">

--- a/TestCases/non-compliant/0019-flight-rebooking/0019-flight-rebooking.dmn
+++ b/TestCases/non-compliant/0019-flight-rebooking/0019-flight-rebooking.dmn
@@ -132,10 +132,10 @@
 	
 	<businessKnowledgeModel id="b_PassengerPriority" name="passenger priority">
 		<variable name="passenger priority"/>
-		<encapsulatedLogic typeRef="boolean">
+		<encapsulatedLogic>
 			<formalParameter name="Passenger1" typeRef="tPassenger"/>
 		    <formalParameter name="Passenger2" typeRef="tPassenger"/>
-		    <decisionTable hitPolicy="UNIQUE">
+		    <decisionTable hitPolicy="UNIQUE" typeRef="boolean">
 				<input id="b_Passenger_Priority_dt_i_P1_Status" label="Passenger1.Status">
 					<inputExpression typeRef="string">
 						<text>Passenger1.Status</text>
@@ -241,11 +241,11 @@
 	
 	<businessKnowledgeModel id="b_ReassignNextPassenger" name="reassign next passenger">
 	    <variable name="reassign next passenger"/>
-	    <encapsulatedLogic typeRef="tPassengerTable">
+	    <encapsulatedLogic>
 			<formalParameter name="Waiting List" typeRef="tPassengerTable"/>
 			<formalParameter name="Reassigned Passengers List" typeRef="tPassengerTable"/>
 			<formalParameter name="Flights" typeRef="tFlightTable"/>
-			<context>
+			<context typeRef="tPassengerTable">
 				<contextEntry>
 					<variable name="Next Passenger" typeRef="tPassenger"/>
 					<literalExpression>


### PR DESCRIPTION
@StrayAlien @tarilabs 

Based on the discussions we had as part of PR #385 I believe that:

1. `bkm.variable.typeRef` and `bkm.encapsulatedLogic.typeRef`, when present should be function type
2. `bkm.encapsultatedLogic.expression.typeRef` (function definition body) is the output type of the BKM

Looking forward for your comments.
Octavian