### PR TITLE
Publishing website for the results of Mar 2021

### DIFF
--- a/docs/detail_ACTICO Platform_8.1.5.html
+++ b/docs/detail_ACTICO Platform_8.1.5.html
@@ -154,6 +154,7 @@
                                 <option value="tb70">Literal Expression</option>
                                 <option value="tb71">Literal Function Invocation</option>
                                 <option value="tb72">Relation</option>
+                                <option value="tb73">[no label]</option>
                             </select>
                         </td>
                         <td><span class="glyphicon glyphicon-ok" aria-hidden="true"> Succeeded</span></td>
@@ -1067,7 +1068,7 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                            <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                             <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                             <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -4447,11 +4448,11 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
@@ -4627,6 +4628,21 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">dt_duration_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_003</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6731,16 +6747,26 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
                             </td>
                         <td class="text-nowrap" scope="row">decision_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_a</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_b</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6791,6 +6817,11 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">endswith_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">substring_004</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -7178,6 +7209,110 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">018</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                            <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                            </td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        <td class="text-nowrap" scope="row">test_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_002</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -9548,7 +9683,7 @@
                     </tr>
                     <tr class="info">
                         <td colspan="5" style="vertical-align:middle">Total</td>
-                        <td align="center" style="vertical-align:middle">0/1637</td>
+                        <td align="center" style="vertical-align:middle">0/1662</td>
                         <td colspan="1" style="vertical-align:middle"></td>
                     </tr>
                     </tbody>
@@ -10970,7 +11105,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="1,467" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="1,473" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="2" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="2" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -14044,11 +14179,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -14224,6 +14359,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16328,16 +16478,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16388,6 +16548,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -19145,7 +19310,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/1467</td>
+                                <td align="center" style="vertical-align:middle">0/1473</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -25452,7 +25617,7 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="174" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="177" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -26088,16 +26253,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26148,6 +26323,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26655,7 +26835,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/213</td>
+                                <td align="center" style="vertical-align:middle">0/216</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -27760,7 +27940,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="455" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="458" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="100" style="vertical-align:middle">0070-feel-instance-of-test-01</td>
                                     <td align="center" rowspan="100" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
@@ -28270,11 +28450,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -28450,6 +28630,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -30082,7 +30277,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/455</td>
+                                <td align="center" style="vertical-align:middle">0/458</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -32723,7 +32918,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="320" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="323" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0004-lending-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0004-lending/0004-lending.pdf">
@@ -32821,11 +33016,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -33001,6 +33196,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -34385,7 +34595,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/320</td>
+                                <td align="center" style="vertical-align:middle">0/323</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -39030,7 +39240,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="47" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="50" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="8" style="vertical-align:middle">0002-string-functions-test-01</td>
                                     <td align="center" rowspan="8" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.pdf">
@@ -39242,16 +39452,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -39305,9 +39525,14 @@
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/47</td>
+                                <td align="center" style="vertical-align:middle">0/50</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -42303,12 +42528,12 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="399" style="vertical-align:middle">compliance-level-3</td>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="402" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -42484,6 +42709,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -44354,7 +44594,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/399</td>
+                                <td align="center" style="vertical-align:middle">0/402</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -50152,6 +50392,149 @@
                     </table>
                 </div>
             </div>
+            <div id="tb73">
+                <div class="table-responsive">
+                    <table class="table table-condensed table-bordered table-striped table-hover">
+                        <thead>
+                        <tr class="info">
+                                    <th style="vertical-align:middle"> Compliance <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test Suite <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Doc <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Source <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> ACTICO Platform <br/>
+                                        <small>8.1.5</small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Comment <br/>
+                                        <small></small>
+                                    </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                            <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                    </td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                        <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                            <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                        </a>
+                                    </td>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">test_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr class="info">
+                                <td colspan="5" style="vertical-align:middle">Total</td>
+                                <td align="center" style="vertical-align:middle">0/19</td>
+                                <td colspan="1" style="vertical-align:middle"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -50159,7 +50542,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Camunda BPM_7.13.0.html
+++ b/docs/detail_Camunda BPM_7.13.0.html
@@ -154,6 +154,7 @@
                                 <option value="tb70">Literal Expression</option>
                                 <option value="tb71">Literal Function Invocation</option>
                                 <option value="tb72">Relation</option>
+                                <option value="tb73">[no label]</option>
                             </select>
                         </td>
                         <td><span class="glyphicon glyphicon-ok" aria-hidden="true"> Succeeded</span></td>
@@ -1067,7 +1068,7 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                            <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                             <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                             <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -4447,11 +4448,11 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
@@ -4628,6 +4629,21 @@
                     <tr>
                         <td class="text-nowrap" scope="row">dt_duration_005</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
                     <tr>
@@ -6731,17 +6747,27 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
                             </td>
                         <td class="text-nowrap" scope="row">decision_001</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true" title="Not Supported"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_a</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_b</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
                     <tr>
@@ -6792,6 +6818,11 @@
                     <tr>
                         <td class="text-nowrap" scope="row">endswith_001</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">substring_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
                     <tr>
@@ -7178,6 +7209,110 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">018</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                            <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                            </td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        <td class="text-nowrap" scope="row">test_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_002</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -9548,7 +9683,7 @@
                     </tr>
                     <tr class="info">
                         <td colspan="5" style="vertical-align:middle">Total</td>
-                        <td align="center" style="vertical-align:middle">1311/1637</td>
+                        <td align="center" style="vertical-align:middle">1311/1662</td>
                         <td colspan="1" style="vertical-align:middle"></td>
                     </tr>
                     </tbody>
@@ -10970,7 +11105,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="1,467" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="1,473" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="2" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="2" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -14044,11 +14179,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -14225,6 +14360,21 @@
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -16328,17 +16478,27 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true" title="Not Supported"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -16389,6 +16549,11 @@
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -19145,7 +19310,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">1171/1467</td>
+                                <td align="center" style="vertical-align:middle">1171/1473</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -25452,7 +25617,7 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="174" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="177" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -26088,17 +26253,27 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true" title="Not Supported"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -26149,6 +26324,11 @@
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -26655,7 +26835,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">155/213</td>
+                                <td align="center" style="vertical-align:middle">155/216</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -27760,7 +27940,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="455" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="458" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="100" style="vertical-align:middle">0070-feel-instance-of-test-01</td>
                                     <td align="center" rowspan="100" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
@@ -28270,11 +28450,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -28451,6 +28631,21 @@
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -30082,7 +30277,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">410/455</td>
+                                <td align="center" style="vertical-align:middle">410/458</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -32723,7 +32918,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="320" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="323" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0004-lending-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0004-lending/0004-lending.pdf">
@@ -32821,11 +33016,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -33002,6 +33197,21 @@
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -34385,7 +34595,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">305/320</td>
+                                <td align="center" style="vertical-align:middle">305/323</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -39030,7 +39240,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="47" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="50" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="8" style="vertical-align:middle">0002-string-functions-test-01</td>
                                     <td align="center" rowspan="8" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.pdf">
@@ -39242,17 +39452,27 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true" title="Not Supported"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -39305,9 +39525,14 @@
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">34/47</td>
+                                <td align="center" style="vertical-align:middle">34/50</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -42303,12 +42528,12 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="399" style="vertical-align:middle">compliance-level-3</td>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="402" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -42485,6 +42710,21 @@
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
                             <tr>
@@ -44354,7 +44594,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">362/399</td>
+                                <td align="center" style="vertical-align:middle">362/402</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -50152,6 +50392,149 @@
                     </table>
                 </div>
             </div>
+            <div id="tb73">
+                <div class="table-responsive">
+                    <table class="table table-condensed table-bordered table-striped table-hover">
+                        <thead>
+                        <tr class="info">
+                                    <th style="vertical-align:middle"> Compliance <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test Suite <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Doc <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Source <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Camunda BPM <br/>
+                                        <small>7.13.0</small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Comment <br/>
+                                        <small></small>
+                                    </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                            <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                    </td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                        <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                            <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                        </a>
+                                    </td>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">test_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr class="info">
+                                <td colspan="5" style="vertical-align:middle">Total</td>
+                                <td align="center" style="vertical-align:middle">0/19</td>
+                                <td colspan="1" style="vertical-align:middle"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -50159,7 +50542,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Digital Transformation Platform (DXP)_2.4.html
+++ b/docs/detail_Digital Transformation Platform (DXP)_2.4.html
@@ -154,6 +154,7 @@
                                 <option value="tb70">Literal Expression</option>
                                 <option value="tb71">Literal Function Invocation</option>
                                 <option value="tb72">Relation</option>
+                                <option value="tb73">[no label]</option>
                             </select>
                         </td>
                         <td><span class="glyphicon glyphicon-ok" aria-hidden="true"> Succeeded</span></td>
@@ -1067,7 +1068,7 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                            <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                             <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                             <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -4447,11 +4448,11 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
@@ -4627,6 +4628,21 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">dt_duration_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_003</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6731,16 +6747,26 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
                             </td>
                         <td class="text-nowrap" scope="row">decision_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_a</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_b</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6791,6 +6817,11 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">endswith_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">substring_004</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -7178,6 +7209,110 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">018</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                            <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                            </td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        <td class="text-nowrap" scope="row">test_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_002</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -9548,7 +9683,7 @@
                     </tr>
                     <tr class="info">
                         <td colspan="5" style="vertical-align:middle">Total</td>
-                        <td align="center" style="vertical-align:middle">0/1637</td>
+                        <td align="center" style="vertical-align:middle">0/1662</td>
                         <td colspan="1" style="vertical-align:middle"></td>
                     </tr>
                     </tbody>
@@ -10970,7 +11105,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="1,467" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="1,473" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="2" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="2" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -14044,11 +14179,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -14224,6 +14359,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16328,16 +16478,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16388,6 +16548,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -19145,7 +19310,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/1467</td>
+                                <td align="center" style="vertical-align:middle">0/1473</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -25452,7 +25617,7 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="174" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="177" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -26088,16 +26253,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26148,6 +26323,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26655,7 +26835,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/213</td>
+                                <td align="center" style="vertical-align:middle">0/216</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -27760,7 +27940,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="455" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="458" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="100" style="vertical-align:middle">0070-feel-instance-of-test-01</td>
                                     <td align="center" rowspan="100" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
@@ -28270,11 +28450,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -28450,6 +28630,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -30082,7 +30277,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/455</td>
+                                <td align="center" style="vertical-align:middle">0/458</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -32723,7 +32918,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="320" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="323" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0004-lending-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0004-lending/0004-lending.pdf">
@@ -32821,11 +33016,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -33001,6 +33196,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -34385,7 +34595,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/320</td>
+                                <td align="center" style="vertical-align:middle">0/323</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -39030,7 +39240,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="47" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="50" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="8" style="vertical-align:middle">0002-string-functions-test-01</td>
                                     <td align="center" rowspan="8" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.pdf">
@@ -39242,16 +39452,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -39305,9 +39525,14 @@
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/47</td>
+                                <td align="center" style="vertical-align:middle">0/50</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -42303,12 +42528,12 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="399" style="vertical-align:middle">compliance-level-3</td>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="402" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -42484,6 +42709,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -44354,7 +44594,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/399</td>
+                                <td align="center" style="vertical-align:middle">0/402</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -50152,6 +50392,149 @@
                     </table>
                 </div>
             </div>
+            <div id="tb73">
+                <div class="table-responsive">
+                    <table class="table table-condensed table-bordered table-striped table-hover">
+                        <thead>
+                        <tr class="info">
+                                    <th style="vertical-align:middle"> Compliance <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test Suite <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Doc <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Source <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Digital Transformation Platform (DXP) <br/>
+                                        <small>2.4</small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Comment <br/>
+                                        <small></small>
+                                    </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                            <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                    </td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                        <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                            <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                        </a>
+                                    </td>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">test_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr class="info">
+                                <td colspan="5" style="vertical-align:middle">Total</td>
+                                <td align="center" style="vertical-align:middle">0/19</td>
+                                <td colspan="1" style="vertical-align:middle"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -50159,7 +50542,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Drools_7.51.0.Final.html
+++ b/docs/detail_Drools_7.51.0.Final.html
@@ -24,7 +24,7 @@
     <link href="css/lib.css" rel="stylesheet" media="screen, print">
 
     <!-- chart js -->
-    <title>DMN TCK results for Trisotech Digital Enterprise Suite 10.5.0</title>
+    <title>DMN TCK results for Drools 7.51.0.Final</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
@@ -66,7 +66,7 @@
                     <a href="index.html">Home</a>
                 </li>
                 <li>
-                    <a href="overview_Trisotech Digital Enterprise Suite_10.5.0.html">Trisotech Digital Enterprise Suite 10.5.0</a>
+                    <a href="overview_Drools_7.51.0.Final.html">Drools 7.51.0.Final</a>
                 </li>
                 <li class="active"><strong id="breadcrumb-value">Details by Label</strong></li>
             </ol>
@@ -154,6 +154,7 @@
                                 <option value="tb70">Literal Expression</option>
                                 <option value="tb71">Literal Function Invocation</option>
                                 <option value="tb72">Relation</option>
+                                <option value="tb73">[no label]</option>
                             </select>
                         </td>
                         <td><span class="glyphicon glyphicon-ok" aria-hidden="true"> Succeeded</span></td>
@@ -186,8 +187,8 @@
                             <th style="vertical-align:middle"> Test <br/>
                                 <small></small>
                             </th>
-                            <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                <small>10.5.0</small>
+                            <th style="vertical-align:middle"> Drools <br/>
+                                <small>7.51.0.Final</small>
                             </th>
                             <th style="vertical-align:middle"> Comment <br/>
                                 <small></small>
@@ -1067,7 +1068,7 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                            <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                             <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                             <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -4447,11 +4448,11 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
@@ -4627,6 +4628,21 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">dt_duration_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_003</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6731,16 +6747,26 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
                             </td>
                         <td class="text-nowrap" scope="row">decision_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_a</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_b</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6791,6 +6817,11 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">endswith_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">substring_004</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -7178,6 +7209,110 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">018</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                            <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                            </td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        <td class="text-nowrap" scope="row">test_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_002</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -9548,7 +9683,7 @@
                     </tr>
                     <tr class="info">
                         <td colspan="5" style="vertical-align:middle">Total</td>
-                        <td align="center" style="vertical-align:middle">1637/1637</td>
+                        <td align="center" style="vertical-align:middle">1662/1662</td>
                         <td colspan="1" style="vertical-align:middle"></td>
                     </tr>
                     </tbody>
@@ -9575,8 +9710,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -9640,8 +9775,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -9705,8 +9840,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -9770,8 +9905,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -10051,8 +10186,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -10960,8 +11095,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -10970,7 +11105,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="1,467" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="1,473" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="2" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="2" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -14044,11 +14179,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -14224,6 +14359,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16328,16 +16478,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16388,6 +16548,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -19145,7 +19310,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">1467/1467</td>
+                                <td align="center" style="vertical-align:middle">1473/1473</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -19172,8 +19337,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -19391,8 +19556,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -19449,8 +19614,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -19529,8 +19694,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -20498,8 +20663,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -20934,8 +21099,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -21027,8 +21192,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -21176,8 +21341,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -21239,8 +21404,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -21302,8 +21467,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -22065,8 +22230,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -22663,8 +22828,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -25098,8 +25263,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -25452,7 +25617,7 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="174" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="177" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -26088,16 +26253,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26148,6 +26323,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26655,7 +26835,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">213/213</td>
+                                <td align="center" style="vertical-align:middle">216/216</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -26682,8 +26862,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27352,8 +27532,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27417,8 +27597,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27496,8 +27676,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27750,8 +27930,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27760,7 +27940,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="455" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="458" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="100" style="vertical-align:middle">0070-feel-instance-of-test-01</td>
                                     <td align="center" rowspan="100" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
@@ -28270,11 +28450,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -28450,6 +28630,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -30082,7 +30277,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">455/455</td>
+                                <td align="center" style="vertical-align:middle">458/458</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -30109,8 +30304,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -30256,8 +30451,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -30451,8 +30646,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -30516,8 +30711,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -31109,8 +31304,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -32713,8 +32908,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -32723,7 +32918,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="320" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="323" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0004-lending-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0004-lending/0004-lending.pdf">
@@ -32821,11 +33016,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -33001,6 +33196,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -34385,7 +34595,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">320/320</td>
+                                <td align="center" style="vertical-align:middle">323/323</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -34412,8 +34622,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -34707,8 +34917,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -34845,8 +35055,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -34966,8 +35176,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -35091,8 +35301,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -35244,8 +35454,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -36739,8 +36949,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -36882,8 +37092,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -37597,8 +37807,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -37806,8 +38016,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -37948,8 +38158,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -38026,8 +38236,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -38924,8 +39134,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -39020,8 +39230,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -39030,7 +39240,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="47" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="50" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="8" style="vertical-align:middle">0002-string-functions-test-01</td>
                                     <td align="center" rowspan="8" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.pdf">
@@ -39242,16 +39452,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -39305,9 +39525,14 @@
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">47/47</td>
+                                <td align="center" style="vertical-align:middle">50/50</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -39334,8 +39559,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40015,8 +40240,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40181,8 +40406,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40467,8 +40692,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40558,8 +40783,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40626,8 +40851,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40694,8 +40919,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40759,8 +40984,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40814,8 +41039,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -41233,8 +41458,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -41441,8 +41666,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -41504,8 +41729,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -41912,8 +42137,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -42175,8 +42400,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -42293,8 +42518,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -42303,12 +42528,12 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="399" style="vertical-align:middle">compliance-level-3</td>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="402" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -42484,6 +42709,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -44354,7 +44594,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">399/399</td>
+                                <td align="center" style="vertical-align:middle">402/402</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -44381,8 +44621,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -44474,8 +44714,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -44609,8 +44849,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -44700,8 +44940,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -44962,8 +45202,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45027,8 +45267,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45118,8 +45358,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45209,8 +45449,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45374,8 +45614,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45465,8 +45705,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45696,8 +45936,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -46764,8 +47004,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -49979,8 +50219,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -50091,8 +50331,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
-                                        <small>10.5.0</small>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -50152,6 +50392,149 @@
                     </table>
                 </div>
             </div>
+            <div id="tb73">
+                <div class="table-responsive">
+                    <table class="table table-condensed table-bordered table-striped table-hover">
+                        <thead>
+                        <tr class="info">
+                                    <th style="vertical-align:middle"> Compliance <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test Suite <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Doc <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Source <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Drools <br/>
+                                        <small>7.51.0.Final</small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Comment <br/>
+                                        <small></small>
+                                    </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                            <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                    </td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                        <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                            <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                        </a>
+                                    </td>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">test_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr class="info">
+                                <td colspan="5" style="vertical-align:middle">Total</td>
+                                <td align="center" style="vertical-align:middle">19/19</td>
+                                <td colspan="1" style="vertical-align:middle"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -50159,7 +50542,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_OpenRules_7.0.0.html
+++ b/docs/detail_OpenRules_7.0.0.html
@@ -154,6 +154,7 @@
                                 <option value="tb70">Literal Expression</option>
                                 <option value="tb71">Literal Function Invocation</option>
                                 <option value="tb72">Relation</option>
+                                <option value="tb73">[no label]</option>
                             </select>
                         </td>
                         <td><span class="glyphicon glyphicon-ok" aria-hidden="true"> Succeeded</span></td>
@@ -1067,7 +1068,7 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                            <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                             <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                             <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -4447,11 +4448,11 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
@@ -4627,6 +4628,21 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">dt_duration_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_003</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6731,16 +6747,26 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
                             </td>
                         <td class="text-nowrap" scope="row">decision_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_a</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_b</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6791,6 +6817,11 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">endswith_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">substring_004</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -7178,6 +7209,110 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">018</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                            <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                            </td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        <td class="text-nowrap" scope="row">test_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_002</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -9548,7 +9683,7 @@
                     </tr>
                     <tr class="info">
                         <td colspan="5" style="vertical-align:middle">Total</td>
-                        <td align="center" style="vertical-align:middle">0/1637</td>
+                        <td align="center" style="vertical-align:middle">0/1662</td>
                         <td colspan="1" style="vertical-align:middle"></td>
                     </tr>
                     </tbody>
@@ -10970,7 +11105,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="1,467" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="1,473" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="2" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="2" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -14044,11 +14179,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -14224,6 +14359,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16328,16 +16478,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16388,6 +16548,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -19145,7 +19310,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/1467</td>
+                                <td align="center" style="vertical-align:middle">0/1473</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -25452,7 +25617,7 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="174" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="177" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -26088,16 +26253,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26148,6 +26323,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26655,7 +26835,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/213</td>
+                                <td align="center" style="vertical-align:middle">0/216</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -27760,7 +27940,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="455" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="458" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="100" style="vertical-align:middle">0070-feel-instance-of-test-01</td>
                                     <td align="center" rowspan="100" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
@@ -28270,11 +28450,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -28450,6 +28630,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -30082,7 +30277,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/455</td>
+                                <td align="center" style="vertical-align:middle">0/458</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -32723,7 +32918,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="320" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="323" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0004-lending-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0004-lending/0004-lending.pdf">
@@ -32821,11 +33016,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -33001,6 +33196,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -34385,7 +34595,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/320</td>
+                                <td align="center" style="vertical-align:middle">0/323</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -39030,7 +39240,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="47" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="50" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="8" style="vertical-align:middle">0002-string-functions-test-01</td>
                                     <td align="center" rowspan="8" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.pdf">
@@ -39242,16 +39452,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -39305,9 +39525,14 @@
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/47</td>
+                                <td align="center" style="vertical-align:middle">0/50</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -42303,12 +42528,12 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="399" style="vertical-align:middle">compliance-level-3</td>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="402" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -42484,6 +42709,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -44354,7 +44594,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/399</td>
+                                <td align="center" style="vertical-align:middle">0/402</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -50152,6 +50392,149 @@
                     </table>
                 </div>
             </div>
+            <div id="tb73">
+                <div class="table-responsive">
+                    <table class="table table-condensed table-bordered table-striped table-hover">
+                        <thead>
+                        <tr class="info">
+                                    <th style="vertical-align:middle"> Compliance <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test Suite <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Doc <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Source <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> OpenRules <br/>
+                                        <small>7.0.0</small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Comment <br/>
+                                        <small></small>
+                                    </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                            <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                    </td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                        <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                            <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                        </a>
+                                    </td>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">test_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr class="info">
+                                <td colspan="5" style="vertical-align:middle">Total</td>
+                                <td align="center" style="vertical-align:middle">0/19</td>
+                                <td colspan="1" style="vertical-align:middle"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -50159,7 +50542,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Oracle Process Cloud_17.3.3.html
+++ b/docs/detail_Oracle Process Cloud_17.3.3.html
@@ -154,6 +154,7 @@
                                 <option value="tb70">Literal Expression</option>
                                 <option value="tb71">Literal Function Invocation</option>
                                 <option value="tb72">Relation</option>
+                                <option value="tb73">[no label]</option>
                             </select>
                         </td>
                         <td><span class="glyphicon glyphicon-ok" aria-hidden="true"> Succeeded</span></td>
@@ -1067,7 +1068,7 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                            <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                             <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                             <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -4447,11 +4448,11 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
@@ -4627,6 +4628,21 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">dt_duration_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_003</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6731,16 +6747,26 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
                             </td>
                         <td class="text-nowrap" scope="row">decision_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_a</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_b</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6791,6 +6817,11 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">endswith_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">substring_004</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -7178,6 +7209,110 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">018</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                            <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                            </td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        <td class="text-nowrap" scope="row">test_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_002</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -9548,7 +9683,7 @@
                     </tr>
                     <tr class="info">
                         <td colspan="5" style="vertical-align:middle">Total</td>
-                        <td align="center" style="vertical-align:middle">0/1637</td>
+                        <td align="center" style="vertical-align:middle">0/1662</td>
                         <td colspan="1" style="vertical-align:middle"></td>
                     </tr>
                     </tbody>
@@ -10970,7 +11105,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="1,467" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="1,473" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="2" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="2" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -14044,11 +14179,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -14224,6 +14359,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16328,16 +16478,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16388,6 +16548,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -19145,7 +19310,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/1467</td>
+                                <td align="center" style="vertical-align:middle">0/1473</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -25452,7 +25617,7 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="174" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="177" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -26088,16 +26253,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26148,6 +26323,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26655,7 +26835,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/213</td>
+                                <td align="center" style="vertical-align:middle">0/216</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -27760,7 +27940,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="455" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="458" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="100" style="vertical-align:middle">0070-feel-instance-of-test-01</td>
                                     <td align="center" rowspan="100" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
@@ -28270,11 +28450,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -28450,6 +28630,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -30082,7 +30277,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/455</td>
+                                <td align="center" style="vertical-align:middle">0/458</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -32723,7 +32918,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="320" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="323" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0004-lending-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0004-lending/0004-lending.pdf">
@@ -32821,11 +33016,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -33001,6 +33196,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -34385,7 +34595,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/320</td>
+                                <td align="center" style="vertical-align:middle">0/323</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -39030,7 +39240,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="47" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="50" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="8" style="vertical-align:middle">0002-string-functions-test-01</td>
                                     <td align="center" rowspan="8" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.pdf">
@@ -39242,16 +39452,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -39305,9 +39525,14 @@
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/47</td>
+                                <td align="center" style="vertical-align:middle">0/50</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -42303,12 +42528,12 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="399" style="vertical-align:middle">compliance-level-3</td>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="402" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -42484,6 +42709,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -44354,7 +44594,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/399</td>
+                                <td align="center" style="vertical-align:middle">0/402</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -50152,6 +50392,149 @@
                     </table>
                 </div>
             </div>
+            <div id="tb73">
+                <div class="table-responsive">
+                    <table class="table table-condensed table-bordered table-striped table-hover">
+                        <thead>
+                        <tr class="info">
+                                    <th style="vertical-align:middle"> Compliance <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test Suite <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Doc <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Source <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Oracle Process Cloud <br/>
+                                        <small>17.3.3</small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Comment <br/>
+                                        <small></small>
+                                    </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                            <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                    </td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                        <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                            <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                        </a>
+                                    </td>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">test_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr class="info">
+                                <td colspan="5" style="vertical-align:middle">Total</td>
+                                <td align="center" style="vertical-align:middle">0/19</td>
+                                <td colspan="1" style="vertical-align:middle"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -50159,7 +50542,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Trisotech Digital Enterprise Suite_10.6.0.html
+++ b/docs/detail_Trisotech Digital Enterprise Suite_10.6.0.html
@@ -24,7 +24,7 @@
     <link href="css/lib.css" rel="stylesheet" media="screen, print">
 
     <!-- chart js -->
-    <title>DMN TCK results for Drools 7.50.0.Final</title>
+    <title>DMN TCK results for Trisotech Digital Enterprise Suite 10.6.0</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
@@ -66,7 +66,7 @@
                     <a href="index.html">Home</a>
                 </li>
                 <li>
-                    <a href="overview_Drools_7.50.0.Final.html">Drools 7.50.0.Final</a>
+                    <a href="overview_Trisotech Digital Enterprise Suite_10.6.0.html">Trisotech Digital Enterprise Suite 10.6.0</a>
                 </li>
                 <li class="active"><strong id="breadcrumb-value">Details by Label</strong></li>
             </ol>
@@ -154,6 +154,7 @@
                                 <option value="tb70">Literal Expression</option>
                                 <option value="tb71">Literal Function Invocation</option>
                                 <option value="tb72">Relation</option>
+                                <option value="tb73">[no label]</option>
                             </select>
                         </td>
                         <td><span class="glyphicon glyphicon-ok" aria-hidden="true"> Succeeded</span></td>
@@ -186,8 +187,8 @@
                             <th style="vertical-align:middle"> Test <br/>
                                 <small></small>
                             </th>
-                            <th style="vertical-align:middle"> Drools <br/>
-                                <small>7.50.0.Final</small>
+                            <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                <small>10.6.0</small>
                             </th>
                             <th style="vertical-align:middle"> Comment <br/>
                                 <small></small>
@@ -1067,7 +1068,7 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                            <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                             <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                             <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -4447,11 +4448,11 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
@@ -4627,6 +4628,21 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">dt_duration_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_003</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6731,16 +6747,26 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
                             </td>
                         <td class="text-nowrap" scope="row">decision_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_a</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_b</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6791,6 +6817,11 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">endswith_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">substring_004</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -7178,6 +7209,110 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">018</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                            <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                            </td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        <td class="text-nowrap" scope="row">test_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_002</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -9548,7 +9683,7 @@
                     </tr>
                     <tr class="info">
                         <td colspan="5" style="vertical-align:middle">Total</td>
-                        <td align="center" style="vertical-align:middle">1637/1637</td>
+                        <td align="center" style="vertical-align:middle">1662/1662</td>
                         <td colspan="1" style="vertical-align:middle"></td>
                     </tr>
                     </tbody>
@@ -9575,8 +9710,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -9640,8 +9775,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -9705,8 +9840,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -9770,8 +9905,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -10051,8 +10186,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -10960,8 +11095,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -10970,7 +11105,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="1,467" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="1,473" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="2" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="2" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -14044,11 +14179,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -14224,6 +14359,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16328,16 +16478,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16388,6 +16548,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -19145,7 +19310,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">1467/1467</td>
+                                <td align="center" style="vertical-align:middle">1473/1473</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -19172,8 +19337,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -19391,8 +19556,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -19449,8 +19614,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -19529,8 +19694,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -20498,8 +20663,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -20934,8 +21099,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -21027,8 +21192,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -21176,8 +21341,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -21239,8 +21404,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -21302,8 +21467,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -22065,8 +22230,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -22663,8 +22828,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -25098,8 +25263,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -25452,7 +25617,7 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="174" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="177" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -26088,16 +26253,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26148,6 +26323,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26655,7 +26835,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">213/213</td>
+                                <td align="center" style="vertical-align:middle">216/216</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -26682,8 +26862,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27352,8 +27532,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27417,8 +27597,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27496,8 +27676,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27750,8 +27930,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -27760,7 +27940,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="455" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="458" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="100" style="vertical-align:middle">0070-feel-instance-of-test-01</td>
                                     <td align="center" rowspan="100" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
@@ -28270,11 +28450,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -28450,6 +28630,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -30082,7 +30277,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">455/455</td>
+                                <td align="center" style="vertical-align:middle">458/458</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -30109,8 +30304,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -30256,8 +30451,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -30451,8 +30646,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -30516,8 +30711,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -31109,8 +31304,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -32713,8 +32908,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -32723,7 +32918,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="320" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="323" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0004-lending-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0004-lending/0004-lending.pdf">
@@ -32821,11 +33016,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -33001,6 +33196,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -34385,7 +34595,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">320/320</td>
+                                <td align="center" style="vertical-align:middle">323/323</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -34412,8 +34622,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -34707,8 +34917,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -34845,8 +35055,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -34966,8 +35176,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -35091,8 +35301,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -35244,8 +35454,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -36739,8 +36949,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -36882,8 +37092,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -37597,8 +37807,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -37806,8 +38016,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -37948,8 +38158,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -38026,8 +38236,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -38924,8 +39134,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -39020,8 +39230,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -39030,7 +39240,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="47" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="50" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="8" style="vertical-align:middle">0002-string-functions-test-01</td>
                                     <td align="center" rowspan="8" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.pdf">
@@ -39242,16 +39452,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -39305,9 +39525,14 @@
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">47/47</td>
+                                <td align="center" style="vertical-align:middle">50/50</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -39334,8 +39559,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40015,8 +40240,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40181,8 +40406,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40467,8 +40692,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40558,8 +40783,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40626,8 +40851,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40694,8 +40919,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40759,8 +40984,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -40814,8 +41039,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -41233,8 +41458,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -41441,8 +41666,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -41504,8 +41729,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -41912,8 +42137,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -42175,8 +42400,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -42293,8 +42518,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -42303,12 +42528,12 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="399" style="vertical-align:middle">compliance-level-3</td>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="402" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -42484,6 +42709,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -44354,7 +44594,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">399/399</td>
+                                <td align="center" style="vertical-align:middle">402/402</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -44381,8 +44621,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -44474,8 +44714,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -44609,8 +44849,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -44700,8 +44940,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -44962,8 +45202,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45027,8 +45267,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45118,8 +45358,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45209,8 +45449,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45374,8 +45614,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45465,8 +45705,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -45696,8 +45936,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -46764,8 +47004,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -49979,8 +50219,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -50091,8 +50331,8 @@
                                     <th style="vertical-align:middle"> Test <br/>
                                         <small></small>
                                     </th>
-                                    <th style="vertical-align:middle"> Drools <br/>
-                                        <small>7.50.0.Final</small>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
                                     </th>
                                     <th style="vertical-align:middle"> Comment <br/>
                                         <small></small>
@@ -50152,6 +50392,149 @@
                     </table>
                 </div>
             </div>
+            <div id="tb73">
+                <div class="table-responsive">
+                    <table class="table table-condensed table-bordered table-striped table-hover">
+                        <thead>
+                        <tr class="info">
+                                    <th style="vertical-align:middle"> Compliance <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test Suite <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Doc <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Source <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Trisotech Digital Enterprise Suite <br/>
+                                        <small>10.6.0</small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Comment <br/>
+                                        <small></small>
+                                    </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                            <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                    </td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                        <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                            <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                        </a>
+                                    </td>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">test_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-ok icon-green" aria-hidden="true" title="Succeeded"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr class="info">
+                                <td colspan="5" style="vertical-align:middle">Total</td>
+                                <td align="center" style="vertical-align:middle">19/19</td>
+                                <td colspan="1" style="vertical-align:middle"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -50159,7 +50542,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_jDMN_3.4.1.html
+++ b/docs/detail_jDMN_3.4.1.html
@@ -154,6 +154,7 @@
                                 <option value="tb70">Literal Expression</option>
                                 <option value="tb71">Literal Function Invocation</option>
                                 <option value="tb72">Relation</option>
+                                <option value="tb73">[no label]</option>
                             </select>
                         </td>
                         <td><span class="glyphicon glyphicon-ok" aria-hidden="true"> Succeeded</span></td>
@@ -1067,7 +1068,7 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                            <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                             <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                             <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -4447,11 +4448,11 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="35" style="vertical-align:middle">
+                            <td align="center" rowspan="38" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
@@ -4627,6 +4628,21 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">dt_duration_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">null_003</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6731,16 +6747,26 @@
                         <td scope="row"></td>
                     </tr>
                     <tr>
-                            <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                             </td>
-                            <td align="center" rowspan="11" style="vertical-align:middle">
+                            <td align="center" rowspan="14" style="vertical-align:middle">
                                 <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                     <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                 </a>
                             </td>
                         <td class="text-nowrap" scope="row">decision_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_a</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">decision_001_b</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -6791,6 +6817,11 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">endswith_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">substring_004</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -7178,6 +7209,110 @@
                     </tr>
                     <tr>
                         <td class="text-nowrap" scope="row">018</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                            <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                            </td>
+                            <td align="center" rowspan="19" style="vertical-align:middle">
+                                <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        <td class="text-nowrap" scope="row">test_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">date_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">datetime_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_003</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_004</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_005</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">time_006</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">dt_duration_002</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_001</td>
+                        <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                        <td scope="row"></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap" scope="row">ym_duration_002</td>
                         <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                         <td scope="row"></td>
                     </tr>
@@ -9548,7 +9683,7 @@
                     </tr>
                     <tr class="info">
                         <td colspan="5" style="vertical-align:middle">Total</td>
-                        <td align="center" style="vertical-align:middle">0/1637</td>
+                        <td align="center" style="vertical-align:middle">0/1662</td>
                         <td colspan="1" style="vertical-align:middle"></td>
                     </tr>
                     </tbody>
@@ -10970,7 +11105,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="1,467" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="1,473" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="2" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="2" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -14044,11 +14179,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -14224,6 +14359,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16328,16 +16478,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -16388,6 +16548,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -19145,7 +19310,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/1467</td>
+                                <td align="center" style="vertical-align:middle">0/1473</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -25452,7 +25617,7 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="174" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="177" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -26088,16 +26253,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26148,6 +26323,11 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">endswith_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -26655,7 +26835,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/213</td>
+                                <td align="center" style="vertical-align:middle">0/216</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -27760,7 +27940,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="455" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="458" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="100" style="vertical-align:middle">0070-feel-instance-of-test-01</td>
                                     <td align="center" rowspan="100" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
@@ -28270,11 +28450,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -28450,6 +28630,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -30082,7 +30277,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/455</td>
+                                <td align="center" style="vertical-align:middle">0/458</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -32723,7 +32918,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="320" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="323" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0004-lending-test-01</td>
                                     <td align="center" rowspan="1" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0004-lending/0004-lending.pdf">
@@ -32821,11 +33016,11 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -33001,6 +33196,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -34385,7 +34595,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/320</td>
+                                <td align="center" style="vertical-align:middle">0/323</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -39030,7 +39240,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="47" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="50" style="vertical-align:middle">compliance-level-3</td>
                                     <td class="text-nowrap" scope="row" rowspan="8" style="vertical-align:middle">0002-string-functions-test-01</td>
                                     <td align="center" rowspan="8" style="vertical-align:middle">
                                             <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0002-string-functions/0002-string-functions.pdf">
@@ -39242,16 +39452,26 @@
                                 <td scope="row"></td>
                             </tr>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="11" style="vertical-align:middle">
+                                    <td align="center" rowspan="14" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
                                     </td>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_a</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">decision_001_b</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -39305,9 +39525,14 @@
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">substring_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/47</td>
+                                <td align="center" style="vertical-align:middle">0/50</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -42303,12 +42528,12 @@
                         </thead>
                         <tbody>
                             <tr>
-                                    <td class="text-nowrap" scope="row" rowspan="399" style="vertical-align:middle">compliance-level-3</td>
-                                    <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td class="text-nowrap" scope="row" rowspan="402" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                             <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                     </td>
-                                    <td align="center" rowspan="35" style="vertical-align:middle">
+                                    <td align="center" rowspan="38" style="vertical-align:middle">
                                         <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                             <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                         </a>
@@ -42484,6 +42709,21 @@
                             </tr>
                             <tr>
                                 <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">null_003</td>
                                 <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
                                 <td scope="row"></td>
                             </tr>
@@ -44354,7 +44594,7 @@
                             </tr>
                             <tr class="info">
                                 <td colspan="5" style="vertical-align:middle">Total</td>
-                                <td align="center" style="vertical-align:middle">0/399</td>
+                                <td align="center" style="vertical-align:middle">0/402</td>
                                 <td colspan="1" style="vertical-align:middle"></td>
                             </tr>
                         </tbody>
@@ -50152,6 +50392,149 @@
                     </table>
                 </div>
             </div>
+            <div id="tb73">
+                <div class="table-responsive">
+                    <table class="table table-condensed table-bordered table-striped table-hover">
+                        <thead>
+                        <tr class="info">
+                                    <th style="vertical-align:middle"> Compliance <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test Suite <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Doc <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Source <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Test <br/>
+                                        <small></small>
+                                    </th>
+                                    <th style="vertical-align:middle"> jDMN <br/>
+                                        <small>3.4.1</small>
+                                    </th>
+                                    <th style="vertical-align:middle"> Comment <br/>
+                                        <small></small>
+                                    </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">compliance-level-3</td>
+                                    <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                            <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                    </td>
+                                    <td align="center" rowspan="19" style="vertical-align:middle">
+                                        <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                            <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                        </a>
+                                    </td>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">test_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">date_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">datetime_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_003</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_004</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_005</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">time_006</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">dt_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_001</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap" scope="row" style="vertical-align:middle">ym_duration_002</td>
+                                <td align="center" style="vertical-align:middle"><span class="glyphicon glyphicon-minus icon-black" aria-hidden="true" title="Missing"></span></td>
+                                <td scope="row"></td>
+                            </tr>
+                            <tr class="info">
+                                <td colspan="5" style="vertical-align:middle">Total</td>
+                                <td align="center" style="vertical-align:middle">0/19</td>
+                                <td colspan="1" style="vertical-align:middle"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -50159,7 +50542,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -311,7 +311,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@
                 ],
                 borderWidth: 1,
                 data: [
-                    0, 0, 0, 1637
+                    0, 0, 0, 1662
                 ]
             }
         ]
@@ -85,7 +85,7 @@
                 ],
                 borderWidth: 1,
                 data: [
-                    1311, 0, 288, 38
+                    1311, 0, 288, 63
                 ]
             }
         ]
@@ -110,7 +110,7 @@
                 ],
                 borderWidth: 1,
                 data: [
-                    0, 0, 0, 1637
+                    0, 0, 0, 1662
                 ]
             }
         ]
@@ -135,7 +135,7 @@
                 ],
                 borderWidth: 1,
                 data: [
-                    0, 0, 0, 1637
+                    0, 0, 0, 1662
                 ]
             }
         ]
@@ -160,7 +160,7 @@
                 ],
                 borderWidth: 1,
                 data: [
-                    0, 0, 0, 1637
+                    0, 0, 0, 1662
                 ]
             }
         ]
@@ -185,7 +185,7 @@
                 ],
                 borderWidth: 1,
                 data: [
-                    0, 0, 0, 1637
+                    0, 0, 0, 1662
                 ]
             }
         ]
@@ -210,7 +210,7 @@
                 ],
                 borderWidth: 1,
                 data: [
-                    1637, 0, 0, 0
+                    1662, 0, 0, 0
                 ]
             }
         ]
@@ -235,7 +235,7 @@
                 ],
                 borderWidth: 1,
                 data: [
-                    1637, 0, 0, 0
+                    1662, 0, 0, 0
                 ]
             }
         ]
@@ -443,7 +443,7 @@
                                 </div>
                                 <div class="list-view-pf-additional-info">
                                     <div class="list-view-pf-additional-info-item">
-                                        Submitted:&nbsp;<b>0/1637</b>
+                                        Submitted:&nbsp;<b>0/1662</b>
                                     </div>
                                     <div class="list-view-pf-additional-info-item">
                                         Last Submission:&nbsp;<b>2019-01-30</b>
@@ -465,12 +465,12 @@
                             <div class="col-md-10">
                                 <dl class="dl-horizontal">
                                     <dt>Last Submission: </dt><dd>2019-01-30</dd>
-                                    <dt>Tests: </dt><dd>1637</dd>
-                                    <dt>Labels: </dt><dd>73</dd>
+                                    <dt>Tests: </dt><dd>1662</dd>
+                                    <dt>Labels: </dt><dd>74</dd>
                                     <dt>Succeeded: </dt><dd>0</dd>
                                     <dt>Failed: </dt><dd>0</dd>
                                     <dt>Not Supported: </dt><dd>0</dd>
-                                    <dt>Missing: </dt><dd>1637</dd>
+                                    <dt>Missing: </dt><dd>1662</dd>
                                     <dt>Info: </dt><dd>ACTICO Platform includes a DMN 1.1 compliance level 3 modeling environment and engine</dd>
                                     <dt>Instructions: </dt><dd>
                                                                     to execute the tests and reproduce the results, please follow the vendor provided instructions <a href="https://github.com/dmn-tck/tck/blob/master/runners/dmn-tck-runner-actico/README.md" target="_blank">at this link <span class="fa fa-external-link"></span></a>.
@@ -515,7 +515,7 @@
                                 </div>
                                 <div class="list-view-pf-additional-info">
                                     <div class="list-view-pf-additional-info-item">
-                                        Submitted:&nbsp;<b>1599/1637</b>
+                                        Submitted:&nbsp;<b>1599/1662</b>
                                     </div>
                                     <div class="list-view-pf-additional-info-item">
                                         Last Submission:&nbsp;<b>2020-06-30</b>
@@ -537,12 +537,12 @@
                             <div class="col-md-10">
                                 <dl class="dl-horizontal">
                                     <dt>Last Submission: </dt><dd>2020-06-30</dd>
-                                    <dt>Tests: </dt><dd>1637</dd>
-                                    <dt>Labels: </dt><dd>73</dd>
+                                    <dt>Tests: </dt><dd>1662</dd>
+                                    <dt>Labels: </dt><dd>74</dd>
                                     <dt>Succeeded: </dt><dd>1311</dd>
                                     <dt>Failed: </dt><dd>0</dd>
                                     <dt>Not Supported: </dt><dd>288</dd>
-                                    <dt>Missing: </dt><dd>38</dd>
+                                    <dt>Missing: </dt><dd>63</dd>
                                     <dt>Info: </dt><dd>Camunda BPM provides an Open Source engine that integrates DMN with BPMN & CMMN.</dd>
                                     <dt>Instructions: </dt><dd>
                                                                     to execute the tests and reproduce the results, please follow the vendor provided instructions <a href="https://github.com/dmn-tck/tck/blob/master/runners/dmn-tck-runner-camunda/" target="_blank">at this link <span class="fa fa-external-link"></span></a>.
@@ -587,7 +587,7 @@
                                 </div>
                                 <div class="list-view-pf-additional-info">
                                     <div class="list-view-pf-additional-info-item">
-                                        Submitted:&nbsp;<b>0/1637</b>
+                                        Submitted:&nbsp;<b>0/1662</b>
                                     </div>
                                     <div class="list-view-pf-additional-info-item">
                                         Last Submission:&nbsp;<b>2019-07-22</b>
@@ -609,12 +609,12 @@
                             <div class="col-md-10">
                                 <dl class="dl-horizontal">
                                     <dt>Last Submission: </dt><dd>2019-07-22</dd>
-                                    <dt>Tests: </dt><dd>1637</dd>
-                                    <dt>Labels: </dt><dd>73</dd>
+                                    <dt>Tests: </dt><dd>1662</dd>
+                                    <dt>Labels: </dt><dd>74</dd>
                                     <dt>Succeeded: </dt><dd>0</dd>
                                     <dt>Failed: </dt><dd>0</dd>
                                     <dt>Not Supported: </dt><dd>0</dd>
-                                    <dt>Missing: </dt><dd>1637</dd>
+                                    <dt>Missing: </dt><dd>1662</dd>
                                     <dt>Info: </dt><dd>Fujitsu DXP includes REST API for DMN using DROOLS for execution of DMN models included in applications</dd>
                                     <dt>Instructions: </dt><dd>
                                                                     to execute the tests and reproduce the results, please follow the vendor provided instructions <a href="http://dist.interstagebpm.com/tck/" target="_blank">at this link <span class="fa fa-external-link"></span></a>.
@@ -659,7 +659,7 @@
                                 </div>
                                 <div class="list-view-pf-additional-info">
                                     <div class="list-view-pf-additional-info-item">
-                                        Submitted:&nbsp;<b>0/1637</b>
+                                        Submitted:&nbsp;<b>0/1662</b>
                                     </div>
                                     <div class="list-view-pf-additional-info-item">
                                         Last Submission:&nbsp;<b>2020-02-24</b>
@@ -681,12 +681,12 @@
                             <div class="col-md-10">
                                 <dl class="dl-horizontal">
                                     <dt>Last Submission: </dt><dd>2020-02-24</dd>
-                                    <dt>Tests: </dt><dd>1637</dd>
-                                    <dt>Labels: </dt><dd>73</dd>
+                                    <dt>Tests: </dt><dd>1662</dd>
+                                    <dt>Labels: </dt><dd>74</dd>
                                     <dt>Succeeded: </dt><dd>0</dd>
                                     <dt>Failed: </dt><dd>0</dd>
                                     <dt>Not Supported: </dt><dd>0</dd>
-                                    <dt>Missing: </dt><dd>1637</dd>
+                                    <dt>Missing: </dt><dd>1662</dd>
                                     <dt>Info: </dt><dd>jDMN provides a runtime compliance level 3 engine (interpreter and translator to Java)</dd>
                                     <dt>Instructions: </dt><dd>
                                                                     to execute the tests and reproduce the results, please follow the vendor provided instructions <a href="https://github.com/dmn-tck/tck/tree/master/runners/dmn-tck-runner-jdmn/README.md" target="_blank">at this link <span class="fa fa-external-link"></span></a>.
@@ -731,7 +731,7 @@
                                 </div>
                                 <div class="list-view-pf-additional-info">
                                     <div class="list-view-pf-additional-info-item">
-                                        Submitted:&nbsp;<b>0/1637</b>
+                                        Submitted:&nbsp;<b>0/1662</b>
                                     </div>
                                     <div class="list-view-pf-additional-info-item">
                                         Last Submission:&nbsp;<b>2017-07-05</b>
@@ -753,12 +753,12 @@
                             <div class="col-md-10">
                                 <dl class="dl-horizontal">
                                     <dt>Last Submission: </dt><dd>2017-07-05</dd>
-                                    <dt>Tests: </dt><dd>1637</dd>
-                                    <dt>Labels: </dt><dd>73</dd>
+                                    <dt>Tests: </dt><dd>1662</dd>
+                                    <dt>Labels: </dt><dd>74</dd>
                                     <dt>Succeeded: </dt><dd>0</dd>
                                     <dt>Failed: </dt><dd>0</dd>
                                     <dt>Not Supported: </dt><dd>0</dd>
-                                    <dt>Missing: </dt><dd>1637</dd>
+                                    <dt>Missing: </dt><dd>1662</dd>
                                     <dt>Info: </dt><dd>OpenRules provides a runtime compliance level 2 engine</dd>
                                     <dt>Instructions: </dt><dd>
                                                                     this vendor did not provide instructions to execute the tests and reproduce the results. Please contact the vendor directly.
@@ -803,7 +803,7 @@
                                 </div>
                                 <div class="list-view-pf-additional-info">
                                     <div class="list-view-pf-additional-info-item">
-                                        Submitted:&nbsp;<b>0/1637</b>
+                                        Submitted:&nbsp;<b>0/1662</b>
                                     </div>
                                     <div class="list-view-pf-additional-info-item">
                                         Last Submission:&nbsp;<b>2017-07-21</b>
@@ -825,12 +825,12 @@
                             <div class="col-md-10">
                                 <dl class="dl-horizontal">
                                     <dt>Last Submission: </dt><dd>2017-07-21</dd>
-                                    <dt>Tests: </dt><dd>1637</dd>
-                                    <dt>Labels: </dt><dd>73</dd>
+                                    <dt>Tests: </dt><dd>1662</dd>
+                                    <dt>Labels: </dt><dd>74</dd>
                                     <dt>Succeeded: </dt><dd>0</dd>
                                     <dt>Failed: </dt><dd>0</dd>
                                     <dt>Not Supported: </dt><dd>0</dd>
-                                    <dt>Missing: </dt><dd>1637</dd>
+                                    <dt>Missing: </dt><dd>1662</dd>
                                     <dt>Info: </dt><dd>Oracle Process Cloud provides BPMN, DMN, and Workflow modeling and execution.</dd>
                                     <dt>Instructions: </dt><dd>
                                                                     this vendor did not provide instructions to execute the tests and reproduce the results. Please contact the vendor directly.
@@ -840,12 +840,12 @@
                         </div>
                     </div>
                 </div>
-                <!-- Drools 7.50.0.Final -->
+                <!-- Drools 7.51.0.Final -->
                 <div class="list-group-item">
                     <div class="list-group-item-header">
                         <div class="list-view-pf-actions">
-                            <a href="overview_Drools_7.50.0.Final.html" class="btn btn-default">Overview</a>
-                            <a href="detail_Drools_7.50.0.Final.html?label_id=all-tests&breadcrumb_label=All%20Tests" class="btn btn-default">All Tests</a>
+                            <a href="overview_Drools_7.51.0.Final.html" class="btn btn-default">Overview</a>
+                            <a href="detail_Drools_7.51.0.Final.html?label_id=all-tests&breadcrumb_label=All%20Tests" class="btn btn-default">All Tests</a>
                             <!--div class="dropdown pull-right dropdown-kebab-pf">
                                 <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight6" data-toggle="dropdown" aria-haspopup="true"
                                         aria-expanded="true">
@@ -870,15 +870,15 @@
                                         Red Hat
                                     </div>
                                     <div class="list-group-item-text">
-                                        Drools 7.50.0.Final
+                                        Drools 7.51.0.Final
                                     </div>
                                 </div>
                                 <div class="list-view-pf-additional-info">
                                     <div class="list-view-pf-additional-info-item">
-                                        Submitted:&nbsp;<b>1637/1637</b>
+                                        Submitted:&nbsp;<b>1662/1662</b>
                                     </div>
                                     <div class="list-view-pf-additional-info-item">
-                                        Last Submission:&nbsp;<b>2021-02-27</b>
+                                        Last Submission:&nbsp;<b>2021-03-30</b>
                                     </div>
                                 </div>
                             </div>
@@ -896,10 +896,10 @@
 
                             <div class="col-md-10">
                                 <dl class="dl-horizontal">
-                                    <dt>Last Submission: </dt><dd>2021-02-27</dd>
-                                    <dt>Tests: </dt><dd>1637</dd>
-                                    <dt>Labels: </dt><dd>73</dd>
-                                    <dt>Succeeded: </dt><dd>1637</dd>
+                                    <dt>Last Submission: </dt><dd>2021-03-30</dd>
+                                    <dt>Tests: </dt><dd>1662</dd>
+                                    <dt>Labels: </dt><dd>74</dd>
+                                    <dt>Succeeded: </dt><dd>1662</dd>
                                     <dt>Failed: </dt><dd>0</dd>
                                     <dt>Not Supported: </dt><dd>0</dd>
                                     <dt>Missing: </dt><dd>0</dd>
@@ -912,12 +912,12 @@
                         </div>
                     </div>
                 </div>
-                <!-- Trisotech Digital Enterprise Suite 10.5.0 -->
+                <!-- Trisotech Digital Enterprise Suite 10.6.0 -->
                 <div class="list-group-item">
                     <div class="list-group-item-header">
                         <div class="list-view-pf-actions">
-                            <a href="overview_Trisotech Digital Enterprise Suite_10.5.0.html" class="btn btn-default">Overview</a>
-                            <a href="detail_Trisotech Digital Enterprise Suite_10.5.0.html?label_id=all-tests&breadcrumb_label=All%20Tests" class="btn btn-default">All Tests</a>
+                            <a href="overview_Trisotech Digital Enterprise Suite_10.6.0.html" class="btn btn-default">Overview</a>
+                            <a href="detail_Trisotech Digital Enterprise Suite_10.6.0.html?label_id=all-tests&breadcrumb_label=All%20Tests" class="btn btn-default">All Tests</a>
                             <!--div class="dropdown pull-right dropdown-kebab-pf">
                                 <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight7" data-toggle="dropdown" aria-haspopup="true"
                                         aria-expanded="true">
@@ -942,15 +942,15 @@
                                         Trisotech
                                     </div>
                                     <div class="list-group-item-text">
-                                        Trisotech Digital Enterprise Suite 10.5.0
+                                        Trisotech Digital Enterprise Suite 10.6.0
                                     </div>
                                 </div>
                                 <div class="list-view-pf-additional-info">
                                     <div class="list-view-pf-additional-info-item">
-                                        Submitted:&nbsp;<b>1637/1637</b>
+                                        Submitted:&nbsp;<b>1662/1662</b>
                                     </div>
                                     <div class="list-view-pf-additional-info-item">
-                                        Last Submission:&nbsp;<b>2021-02-15</b>
+                                        Last Submission:&nbsp;<b>2021-03-30</b>
                                     </div>
                                 </div>
                             </div>
@@ -968,10 +968,10 @@
 
                             <div class="col-md-10">
                                 <dl class="dl-horizontal">
-                                    <dt>Last Submission: </dt><dd>2021-02-15</dd>
-                                    <dt>Tests: </dt><dd>1637</dd>
-                                    <dt>Labels: </dt><dd>73</dd>
-                                    <dt>Succeeded: </dt><dd>1637</dd>
+                                    <dt>Last Submission: </dt><dd>2021-03-30</dd>
+                                    <dt>Tests: </dt><dd>1662</dd>
+                                    <dt>Labels: </dt><dd>74</dd>
+                                    <dt>Succeeded: </dt><dd>1662</dd>
                                     <dt>Failed: </dt><dd>0</dd>
                                     <dt>Not Supported: </dt><dd>0</dd>
                                     <dt>Missing: </dt><dd>0</dd>
@@ -988,7 +988,7 @@
             <div class="row">
               <div class="container-fluid">
                 <div class="panel-body">
-                  <p>This website is updated to reflect DMNv1.2.<br />For archived versions of the website you can refer to: <a href="archive-DMNv1.1/index.html">Archived DMNv1.1</a>.</p>
+                  <p>This website is updated to reflect DMNv1.3.<br />For archived versions of the website you can refer to: <a href="archive-DMNv1.2/index.html">Archived DMNv1.2</a>, <a href="archive-DMNv1.1/index.html">Archived DMNv1.1</a>.</p>
                 </div>
               </div>
             </div>
@@ -998,7 +998,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:04 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:26 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_ACTICO Platform_8.1.5.html
+++ b/docs/overview_ACTICO Platform_8.1.5.html
@@ -92,12 +92,12 @@
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                 var color = Chart.helpers.color;
                 var cbl0_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -125,6 +125,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -278,6 +279,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         },
@@ -287,6 +289,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -373,7 +376,7 @@
                                 3,
                                 24,
                                 116,
-                                1,467,
+                                1,473,
                                 17,
                                 2,
                                 6,
@@ -386,18 +389,18 @@
                                 130,
                                 101,
                                 356,
-                                213,
+                                216,
                                 67,
                                 3,
                                 4,
                                 39,
-                                455,
+                                458,
                                 18,
                                 18,
                                 3,
                                 67,
                                 251,
-                                320,
+                                323,
                                 44,
                                 18,
                                 8,
@@ -411,7 +414,7 @@
                                 6,
                                 149,
                                 7,
-                                47,
+                                50,
                                 102,
                                 17,
                                 34,
@@ -426,7 +429,7 @@
                                 72,
                                 43,
                                 14,
-                                399,
+                                402,
                                 5,
                                 9,
                                 6,
@@ -440,14 +443,15 @@
                                 121,
                                 524,
                                 8,
-                                4
+                                4,
+                                19
                             ]
                         }
                     ]
                 };
                 var cblp0_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -456,6 +460,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                            0,
                             0,
                             0,
                             0,
@@ -609,6 +614,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -690,6 +696,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -699,6 +706,7 @@
                             borderColor: window.chartColors.purple,
                             borderWidth: 1,
                             data: [
+                            100,
                             100,
                             100,
                             100,
@@ -912,7 +920,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_ACTICO Platform_8.1.5.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1467</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1473</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -990,7 +998,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_ACTICO Platform_8.1.5.html', 'tb18','Data Type: String')">Data Type: String</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/213</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/216</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1020,7 +1028,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_ACTICO Platform_8.1.5.html', 'tb23','Data Type: any')">Data Type: any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/455</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/458</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1056,7 +1064,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_ACTICO Platform_8.1.5.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/320</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/323</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1140,7 +1148,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_ACTICO Platform_8.1.5.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/47</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/50</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1230,7 +1238,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_ACTICO Platform_8.1.5.html', 'tb58','Feel : any')">Feel : any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/399</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/402</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1317,6 +1325,12 @@
                                         <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/4</small></span>
                                     </td>
                                 </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_ACTICO Platform_8.1.5.html', 'tb73','[no label]')">[no label]</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/19</small></span>
+                                    </td>
+                                </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -1338,7 +1352,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:04 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:26 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Camunda BPM_7.13.0.html
+++ b/docs/overview_Camunda BPM_7.13.0.html
@@ -92,12 +92,12 @@
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                 var color = Chart.helpers.color;
                 var cbl1_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -197,6 +197,7 @@
                                 59,
                                 442,
                                 3,
+                                0,
                                 0
                             ]
                         },
@@ -278,7 +279,8 @@
                                 60,
                                 80,
                                 5,
-                                2
+                                2,
+                                0
                             ]
                         },
                         {
@@ -287,6 +289,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -373,7 +376,7 @@
                                 0,
                                 2,
                                 0,
-                                38,
+                                44,
                                 0,
                                 0,
                                 0,
@@ -386,18 +389,18 @@
                                 2,
                                 0,
                                 4,
+                                5,
                                 2,
-                                2,
-                                0,
-                                0,
-                                0,
-                                0,
-                                0,
                                 0,
                                 0,
                                 0,
                                 3,
                                 0,
+                                0,
+                                0,
+                                0,
+                                3,
+                                3,
                                 0,
                                 0,
                                 0,
@@ -411,7 +414,7 @@
                                 0,
                                 2,
                                 0,
-                                0,
+                                3,
                                 0,
                                 1,
                                 0,
@@ -426,7 +429,7 @@
                                 0,
                                 0,
                                 14,
-                                0,
+                                3,
                                 0,
                                 0,
                                 0,
@@ -440,14 +443,15 @@
                                 2,
                                 2,
                                 0,
-                                2
+                                2,
+                                19
                             ]
                         }
                     ]
                 };
                 var cblp1_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -474,18 +478,18 @@
                             91,
                             88,
                             76,
-                            72,
+                            71,
                             29,
                             100,
                             0,
                             93,
-                            91,
+                            89,
                             0,
                             34,
                             100,
                             42,
                             82,
-                            96,
+                            94,
                             100,
                             0,
                             63,
@@ -499,7 +503,7 @@
                             100,
                             92,
                             43,
-                            73,
+                            68,
                             92,
                             76,
                             92,
@@ -514,7 +518,7 @@
                             64,
                             96,
                             0,
-                            91,
+                            90,
                             0,
                             0,
                             100,
@@ -528,6 +532,7 @@
                             48,
                             84,
                             38,
+                            0,
                             0
                             ]
                         },
@@ -555,7 +560,7 @@
                             6,
                             12,
                             22,
-                            26,
+                            25,
                             67,
                             0,
                             100,
@@ -580,7 +585,7 @@
                             0,
                             6,
                             57,
-                            27,
+                            26,
                             8,
                             17,
                             8,
@@ -609,7 +614,8 @@
                             49,
                             15,
                             62,
-                            50
+                            50,
+                            0
                             ]
                         },
                         {
@@ -618,6 +624,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                            0,
                             0,
                             0,
                             0,
@@ -717,18 +724,18 @@
                             3,
                             0,
                             2,
-                            2,
+                            4,
                             4,
                             0,
                             0,
                             0,
-                            0,
+                            2,
                             0,
                             0,
                             0,
                             0,
                             2,
-                            0,
+                            2,
                             0,
                             0,
                             0,
@@ -742,7 +749,7 @@
                             0,
                             2,
                             0,
-                            0,
+                            6,
                             0,
                             7,
                             0,
@@ -757,7 +764,7 @@
                             0,
                             0,
                             100,
-                            0,
+                            1,
                             0,
                             0,
                             0,
@@ -771,7 +778,8 @@
                             3,
                             1,
                             0,
-                            50
+                            50,
+                            100
                             ]
                         }
                     ]
@@ -912,7 +920,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Camunda BPM_7.13.0.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>1171/1467</small></span>
+                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>1171/1473</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -990,7 +998,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Camunda BPM_7.13.0.html', 'tb18','Data Type: String')">Data Type: String</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>155/213</small></span>
+                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>155/216</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1020,7 +1028,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Camunda BPM_7.13.0.html', 'tb23','Data Type: any')">Data Type: any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>410/455</small></span>
+                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>410/458</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1056,7 +1064,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Camunda BPM_7.13.0.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>305/320</small></span>
+                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>305/323</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1140,7 +1148,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Camunda BPM_7.13.0.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>34/47</small></span>
+                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>34/50</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1230,7 +1238,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Camunda BPM_7.13.0.html', 'tb58','Feel : any')">Feel : any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>362/399</small></span>
+                                        <span class="glyphicon glyphicon-alert icon-yellow" aria-hidden="true"><br/><small>362/402</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1317,6 +1325,12 @@
                                         <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/4</small></span>
                                     </td>
                                 </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Camunda BPM_7.13.0.html', 'tb73','[no label]')">[no label]</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/19</small></span>
+                                    </td>
+                                </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -1338,7 +1352,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Digital Transformation Platform (DXP)_2.4.html
+++ b/docs/overview_Digital Transformation Platform (DXP)_2.4.html
@@ -92,12 +92,12 @@
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                 var color = Chart.helpers.color;
                 var cbl2_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -125,6 +125,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -278,6 +279,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         },
@@ -287,6 +289,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -373,7 +376,7 @@
                                 3,
                                 24,
                                 116,
-                                1,467,
+                                1,473,
                                 17,
                                 2,
                                 6,
@@ -386,18 +389,18 @@
                                 130,
                                 101,
                                 356,
-                                213,
+                                216,
                                 67,
                                 3,
                                 4,
                                 39,
-                                455,
+                                458,
                                 18,
                                 18,
                                 3,
                                 67,
                                 251,
-                                320,
+                                323,
                                 44,
                                 18,
                                 8,
@@ -411,7 +414,7 @@
                                 6,
                                 149,
                                 7,
-                                47,
+                                50,
                                 102,
                                 17,
                                 34,
@@ -426,7 +429,7 @@
                                 72,
                                 43,
                                 14,
-                                399,
+                                402,
                                 5,
                                 9,
                                 6,
@@ -440,14 +443,15 @@
                                 121,
                                 524,
                                 8,
-                                4
+                                4,
+                                19
                             ]
                         }
                     ]
                 };
                 var cblp2_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -456,6 +460,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                            0,
                             0,
                             0,
                             0,
@@ -609,6 +614,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -690,6 +696,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -699,6 +706,7 @@
                             borderColor: window.chartColors.purple,
                             borderWidth: 1,
                             data: [
+                            100,
                             100,
                             100,
                             100,
@@ -912,7 +920,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Digital Transformation Platform (DXP)_2.4.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1467</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1473</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -990,7 +998,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Digital Transformation Platform (DXP)_2.4.html', 'tb18','Data Type: String')">Data Type: String</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/213</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/216</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1020,7 +1028,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Digital Transformation Platform (DXP)_2.4.html', 'tb23','Data Type: any')">Data Type: any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/455</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/458</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1056,7 +1064,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Digital Transformation Platform (DXP)_2.4.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/320</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/323</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1140,7 +1148,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Digital Transformation Platform (DXP)_2.4.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/47</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/50</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1230,7 +1238,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Digital Transformation Platform (DXP)_2.4.html', 'tb58','Feel : any')">Feel : any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/399</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/402</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1317,6 +1325,12 @@
                                         <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/4</small></span>
                                     </td>
                                 </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Digital Transformation Platform (DXP)_2.4.html', 'tb73','[no label]')">[no label]</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/19</small></span>
+                                    </td>
+                                </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -1338,7 +1352,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Drools_7.51.0.Final.html
+++ b/docs/overview_Drools_7.51.0.Final.html
@@ -30,7 +30,7 @@
     <link href="css/lib.css" rel="stylesheet" media="screen, print">
 
     <!-- chart js -->
-    <title>DMN TCK results overview for Red Hat 7.50.0.Final</title>
+    <title>DMN TCK results overview for Red Hat 7.51.0.Final</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.bundle.js"></script>
@@ -72,7 +72,7 @@
                 <li>
                     <a href="index.html">Home</a>
                 </li>
-                <li class="active"><strong>Drools 7.50.0.Final</strong></li>
+                <li class="active"><strong>Drools 7.51.0.Final</strong></li>
             </ol>
         </div>
     </div>
@@ -81,23 +81,23 @@
             <div class="report-header ">
                 <div class="row">
                     <div class="col-md-12">
-                        <h1>DMN TCK Results Overview for Drools 7.50.0.Final</h1>
+                        <h1>DMN TCK Results Overview for Drools 7.51.0.Final</h1>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Date:</strong> 2021-02-27</p>
+                            <p><strong>Date:</strong> 2021-03-30</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                 var color = Chart.helpers.color;
                 var cbl6_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -130,7 +130,7 @@
                                 3,
                                 24,
                                 116,
-                                1,467,
+                                1,473,
                                 17,
                                 2,
                                 6,
@@ -143,18 +143,18 @@
                                 130,
                                 101,
                                 356,
-                                213,
+                                216,
                                 67,
                                 3,
                                 4,
                                 39,
-                                455,
+                                458,
                                 18,
                                 18,
                                 3,
                                 67,
                                 251,
-                                320,
+                                323,
                                 44,
                                 18,
                                 8,
@@ -168,7 +168,7 @@
                                 6,
                                 149,
                                 7,
-                                47,
+                                50,
                                 102,
                                 17,
                                 34,
@@ -183,7 +183,7 @@
                                 72,
                                 43,
                                 14,
-                                399,
+                                402,
                                 5,
                                 9,
                                 6,
@@ -197,7 +197,8 @@
                                 121,
                                 524,
                                 8,
-                                4
+                                4,
+                                19
                             ]
                         },
                         {
@@ -206,6 +207,7 @@
                             borderColor: window.chartColors.yellow,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -359,6 +361,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         },
@@ -440,6 +443,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         }
@@ -447,7 +451,7 @@
                 };
                 var cblp6_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -456,6 +460,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                            100,
                             100,
                             100,
                             100,
@@ -609,6 +614,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -618,6 +624,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                            0,
                             0,
                             0,
                             0,
@@ -771,6 +778,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         }
@@ -797,7 +805,7 @@
                             },
                             title: {
                                 display: true,
-                                text: 'Test results for Red Hat 7.50.0.Final (by number of tests)'
+                                text: 'Test results for Red Hat 7.51.0.Final (by number of tests)'
                             },
                             scales: {
                                 xAxes: [{
@@ -829,7 +837,7 @@
                             },
                             title: {
                                 display: true,
-                                text: 'Test results for Red Hat 7.50.0.Final (by percentage of tests)'
+                                text: 'Test results for Red Hat 7.51.0.Final (by percentage of tests)'
                             },
                             scales: {
                                 xAxes: [{
@@ -874,447 +882,453 @@
                                         <small></small>
                                     </th>
                                     <th> Red Hat <br/>
-                                        <small>7.50.0.Final</small>
+                                        <small>7.51.0.Final</small>
                                     </th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb0','Aggregator: COUNT')">Aggregator: COUNT</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb0','Aggregator: COUNT')">Aggregator: COUNT</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb1','Aggregator: MIN')">Aggregator: MIN</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb1','Aggregator: MIN')">Aggregator: MIN</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb2','Aggregator: SUM')">Aggregator: SUM</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb2','Aggregator: SUM')">Aggregator: SUM</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb3','Business Knowledge Model')">Business Knowledge Model</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb3','Business Knowledge Model')">Business Knowledge Model</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>24/24</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb4','Compliance Level 2')">Compliance Level 2</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb4','Compliance Level 2')">Compliance Level 2</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>116/116</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>1467/1467</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>1473/1473</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb6','Context')">Context</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb6','Context')">Context</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>17/17</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb7','DMN Import')">DMN Import</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb7','DMN Import')">DMN Import</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>2/2</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb8','Data Type : String')">Data Type : String</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb8','Data Type : String')">Data Type : String</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb9','Data Type: Boolean')">Data Type: Boolean</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb9','Data Type: Boolean')">Data Type: Boolean</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>134/134</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb10','Data Type: Collection')">Data Type: Collection</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb10','Data Type: Collection')">Data Type: Collection</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>49/49</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb11','Data Type: Context')">Data Type: Context</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb11','Data Type: Context')">Data Type: Context</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>9/9</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb12','Data Type: Date')">Data Type: Date</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb12','Data Type: Date')">Data Type: Date</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>14/14</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb13','Data Type: Date and Time')">Data Type: Date and Time</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb13','Data Type: Date and Time')">Data Type: Date and Time</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb14','Data Type: Days and Time Duration')">Data Type: Days and Time Duration</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb14','Data Type: Days and Time Duration')">Data Type: Days and Time Duration</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb15','Data Type: Function')">Data Type: Function</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb15','Data Type: Function')">Data Type: Function</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>130/130</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb16','Data Type: List')">Data Type: List</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb16','Data Type: List')">Data Type: List</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>101/101</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb17','Data Type: Number')">Data Type: Number</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb17','Data Type: Number')">Data Type: Number</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>356/356</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb18','Data Type: String')">Data Type: String</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb18','Data Type: String')">Data Type: String</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>213/213</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>216/216</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb19','Data Type: Structure')">Data Type: Structure</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb19','Data Type: Structure')">Data Type: Structure</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>67/67</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb20','Data Type: Text')">Data Type: Text</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb20','Data Type: Text')">Data Type: Text</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb21','Data Type: Time')">Data Type: Time</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb21','Data Type: Time')">Data Type: Time</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>4/4</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb22','Data Type: Years and Months Duration')">Data Type: Years and Months Duration</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb22','Data Type: Years and Months Duration')">Data Type: Years and Months Duration</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>39/39</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb23','Data Type: any')">Data Type: any</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb23','Data Type: any')">Data Type: any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>455/455</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>458/458</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb24','Decision Services')">Decision Services</a></th>
-                                    <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>18/18</small></span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb25','Decision Table: Multiple Output')">Decision Table: Multiple Output</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb24','Decision Services')">Decision Services</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>18/18</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb26','Decision Table: Multiple Output Columns')">Decision Table: Multiple Output Columns</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb25','Decision Table: Multiple Output')">Decision Table: Multiple Output</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>18/18</small></span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb26','Decision Table: Multiple Output Columns')">Decision Table: Multiple Output Columns</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb27','Decision Table: Single Output')">Decision Table: Single Output</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb27','Decision Table: Single Output')">Decision Table: Single Output</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>67/67</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb28','FEEL Arithmetic')">FEEL Arithmetic</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb28','FEEL Arithmetic')">FEEL Arithmetic</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>251/251</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>320/320</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>323/323</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb30','FEEL Constants')">FEEL Constants</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb30','FEEL Constants')">FEEL Constants</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>44/44</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb31','FEEL External Java')">FEEL External Java</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb31','FEEL External Java')">FEEL External Java</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>18/18</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb32','FEEL Filter (10.3.2.5)')">FEEL Filter (10.3.2.5)</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb32','FEEL Filter (10.3.2.5)')">FEEL Filter (10.3.2.5)</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>8/8</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb33','FEEL Function Literals')">FEEL Function Literals</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb33','FEEL Function Literals')">FEEL Function Literals</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>7/7</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb34','FEEL Functions: conversion')">FEEL Functions: conversion</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb34','FEEL Functions: conversion')">FEEL Functions: conversion</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>21/21</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb35','FEEL Functions: date and time')">FEEL Functions: date and time</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb35','FEEL Functions: date and time')">FEEL Functions: date and time</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>278/278</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb36','FEEL Functions: lambda')">FEEL Functions: lambda</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb36','FEEL Functions: lambda')">FEEL Functions: lambda</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>19/19</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb37','FEEL Functions: list')">FEEL Functions: list</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb37','FEEL Functions: list')">FEEL Functions: list</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>113/113</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb38','FEEL Functions: lists')">FEEL Functions: lists</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb38','FEEL Functions: lists')">FEEL Functions: lists</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>23/23</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb39','FEEL Functions: map')">FEEL Functions: map</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb39','FEEL Functions: map')">FEEL Functions: map</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>17/17</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb40','FEEL Functions: negation')">FEEL Functions: negation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb40','FEEL Functions: negation')">FEEL Functions: negation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb41','FEEL Functions: number')">FEEL Functions: number</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb41','FEEL Functions: number')">FEEL Functions: number</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>149/149</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb42','FEEL Functions: numeric')">FEEL Functions: numeric</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb42','FEEL Functions: numeric')">FEEL Functions: numeric</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>7/7</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>47/47</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>50/50</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb44','FEEL Functions: strings')">FEEL Functions: strings</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb44','FEEL Functions: strings')">FEEL Functions: strings</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>102/102</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb45','FEEL Iteration')">FEEL Iteration</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb45','FEEL Iteration')">FEEL Iteration</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>17/17</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb46','FEEL List')">FEEL List</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb46','FEEL List')">FEEL List</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>34/34</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb47','FEEL List Operator')">FEEL List Operator</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb47','FEEL List Operator')">FEEL List Operator</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb48','FEEL Paths')">FEEL Paths</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb48','FEEL Paths')">FEEL Paths</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>4/4</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb49','FEEL Qualified Names')">FEEL Qualified Names</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb49','FEEL Qualified Names')">FEEL Qualified Names</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>4/4</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb50','FEEL Quantifiers')">FEEL Quantifiers</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb50','FEEL Quantifiers')">FEEL Quantifiers</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb51','FEEL Relation')">FEEL Relation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb51','FEEL Relation')">FEEL Relation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>1/1</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb52','FEEL Special-character Names')">FEEL Special-character Names</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb52','FEEL Special-character Names')">FEEL Special-character Names</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>43/43</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb53','FEEL TYpe Conformance')">FEEL TYpe Conformance</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb53','FEEL TYpe Conformance')">FEEL TYpe Conformance</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>32/32</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb54','FEEL comments')">FEEL comments</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb54','FEEL comments')">FEEL comments</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb55','FEEL equality')">FEEL equality</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb55','FEEL equality')">FEEL equality</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>72/72</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb56','FEEL properties')">FEEL properties</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb56','FEEL properties')">FEEL properties</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>43/43</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb57','FEEL: Interval functions')">FEEL: Interval functions</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb57','FEEL: Interval functions')">FEEL: Interval functions</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>14/14</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb58','Feel : any')">Feel : any</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb58','Feel : any')">Feel : any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>399/399</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>402/402</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb59','Function Definition')">Function Definition</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb59','Function Definition')">Function Definition</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>5/5</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb60','Function Invocation')">Function Invocation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb60','Function Invocation')">Function Invocation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>9/9</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb61','Hit Policy: ANY')">Hit Policy: ANY</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb61','Hit Policy: ANY')">Hit Policy: ANY</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb62','Hit Policy: COLLECT')">Hit Policy: COLLECT</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb62','Hit Policy: COLLECT')">Hit Policy: COLLECT</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>29/29</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb63','Hit Policy: Collect')">Hit Policy: Collect</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb63','Hit Policy: Collect')">Hit Policy: Collect</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb64','Hit Policy: FIRST')">Hit Policy: FIRST</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb64','Hit Policy: FIRST')">Hit Policy: FIRST</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb65','Hit Policy: OUTPUT ORDER')">Hit Policy: OUTPUT ORDER</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb65','Hit Policy: OUTPUT ORDER')">Hit Policy: OUTPUT ORDER</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb66','Hit Policy: PRIORITY')">Hit Policy: PRIORITY</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb66','Hit Policy: PRIORITY')">Hit Policy: PRIORITY</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>14/14</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb67','Hit Policy: RULE ORDER')">Hit Policy: RULE ORDER</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb67','Hit Policy: RULE ORDER')">Hit Policy: RULE ORDER</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb68','Hit Policy: UNIQUE')">Hit Policy: UNIQUE</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb68','Hit Policy: UNIQUE')">Hit Policy: UNIQUE</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>21/21</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb69','Item Definition')">Item Definition</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb69','Item Definition')">Item Definition</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>121/121</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb70','Literal Expression')">Literal Expression</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb70','Literal Expression')">Literal Expression</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>524/524</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb71','Literal Function Invocation')">Literal Function Invocation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb71','Literal Function Invocation')">Literal Function Invocation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>8/8</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.50.0.Final.html', 'tb72','Relation')">Relation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb72','Relation')">Relation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>4/4</small></span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Drools_7.51.0.Final.html', 'tb73','[no label]')">[no label]</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>19/19</small></span>
                                     </td>
                                 </tr>
                                 </tbody>
@@ -1338,7 +1352,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_OpenRules_7.0.0.html
+++ b/docs/overview_OpenRules_7.0.0.html
@@ -92,12 +92,12 @@
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                 var color = Chart.helpers.color;
                 var cbl4_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -125,6 +125,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -278,6 +279,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         },
@@ -287,6 +289,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -373,7 +376,7 @@
                                 3,
                                 24,
                                 116,
-                                1,467,
+                                1,473,
                                 17,
                                 2,
                                 6,
@@ -386,18 +389,18 @@
                                 130,
                                 101,
                                 356,
-                                213,
+                                216,
                                 67,
                                 3,
                                 4,
                                 39,
-                                455,
+                                458,
                                 18,
                                 18,
                                 3,
                                 67,
                                 251,
-                                320,
+                                323,
                                 44,
                                 18,
                                 8,
@@ -411,7 +414,7 @@
                                 6,
                                 149,
                                 7,
-                                47,
+                                50,
                                 102,
                                 17,
                                 34,
@@ -426,7 +429,7 @@
                                 72,
                                 43,
                                 14,
-                                399,
+                                402,
                                 5,
                                 9,
                                 6,
@@ -440,14 +443,15 @@
                                 121,
                                 524,
                                 8,
-                                4
+                                4,
+                                19
                             ]
                         }
                     ]
                 };
                 var cblp4_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -456,6 +460,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                            0,
                             0,
                             0,
                             0,
@@ -609,6 +614,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -690,6 +696,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -699,6 +706,7 @@
                             borderColor: window.chartColors.purple,
                             borderWidth: 1,
                             data: [
+                            100,
                             100,
                             100,
                             100,
@@ -912,7 +920,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_OpenRules_7.0.0.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1467</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1473</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -990,7 +998,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_OpenRules_7.0.0.html', 'tb18','Data Type: String')">Data Type: String</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/213</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/216</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1020,7 +1028,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_OpenRules_7.0.0.html', 'tb23','Data Type: any')">Data Type: any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/455</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/458</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1056,7 +1064,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_OpenRules_7.0.0.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/320</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/323</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1140,7 +1148,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_OpenRules_7.0.0.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/47</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/50</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1230,7 +1238,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_OpenRules_7.0.0.html', 'tb58','Feel : any')">Feel : any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/399</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/402</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1317,6 +1325,12 @@
                                         <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/4</small></span>
                                     </td>
                                 </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_OpenRules_7.0.0.html', 'tb73','[no label]')">[no label]</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/19</small></span>
+                                    </td>
+                                </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -1338,7 +1352,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Oracle Process Cloud_17.3.3.html
+++ b/docs/overview_Oracle Process Cloud_17.3.3.html
@@ -92,12 +92,12 @@
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                 var color = Chart.helpers.color;
                 var cbl5_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -125,6 +125,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -278,6 +279,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         },
@@ -287,6 +289,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -373,7 +376,7 @@
                                 3,
                                 24,
                                 116,
-                                1,467,
+                                1,473,
                                 17,
                                 2,
                                 6,
@@ -386,18 +389,18 @@
                                 130,
                                 101,
                                 356,
-                                213,
+                                216,
                                 67,
                                 3,
                                 4,
                                 39,
-                                455,
+                                458,
                                 18,
                                 18,
                                 3,
                                 67,
                                 251,
-                                320,
+                                323,
                                 44,
                                 18,
                                 8,
@@ -411,7 +414,7 @@
                                 6,
                                 149,
                                 7,
-                                47,
+                                50,
                                 102,
                                 17,
                                 34,
@@ -426,7 +429,7 @@
                                 72,
                                 43,
                                 14,
-                                399,
+                                402,
                                 5,
                                 9,
                                 6,
@@ -440,14 +443,15 @@
                                 121,
                                 524,
                                 8,
-                                4
+                                4,
+                                19
                             ]
                         }
                     ]
                 };
                 var cblp5_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -456,6 +460,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                            0,
                             0,
                             0,
                             0,
@@ -609,6 +614,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -690,6 +696,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -699,6 +706,7 @@
                             borderColor: window.chartColors.purple,
                             borderWidth: 1,
                             data: [
+                            100,
                             100,
                             100,
                             100,
@@ -912,7 +920,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Oracle Process Cloud_17.3.3.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1467</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1473</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -990,7 +998,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Oracle Process Cloud_17.3.3.html', 'tb18','Data Type: String')">Data Type: String</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/213</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/216</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1020,7 +1028,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Oracle Process Cloud_17.3.3.html', 'tb23','Data Type: any')">Data Type: any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/455</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/458</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1056,7 +1064,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Oracle Process Cloud_17.3.3.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/320</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/323</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1140,7 +1148,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Oracle Process Cloud_17.3.3.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/47</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/50</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1230,7 +1238,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Oracle Process Cloud_17.3.3.html', 'tb58','Feel : any')">Feel : any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/399</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/402</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1317,6 +1325,12 @@
                                         <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/4</small></span>
                                     </td>
                                 </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Oracle Process Cloud_17.3.3.html', 'tb73','[no label]')">[no label]</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/19</small></span>
+                                    </td>
+                                </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -1338,7 +1352,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Trisotech Digital Enterprise Suite_10.6.0.html
+++ b/docs/overview_Trisotech Digital Enterprise Suite_10.6.0.html
@@ -30,7 +30,7 @@
     <link href="css/lib.css" rel="stylesheet" media="screen, print">
 
     <!-- chart js -->
-    <title>DMN TCK results overview for Trisotech 10.5.0</title>
+    <title>DMN TCK results overview for Trisotech 10.6.0</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.bundle.js"></script>
@@ -72,7 +72,7 @@
                 <li>
                     <a href="index.html">Home</a>
                 </li>
-                <li class="active"><strong>Trisotech Digital Enterprise Suite 10.5.0</strong></li>
+                <li class="active"><strong>Trisotech Digital Enterprise Suite 10.6.0</strong></li>
             </ol>
         </div>
     </div>
@@ -81,23 +81,23 @@
             <div class="report-header ">
                 <div class="row">
                     <div class="col-md-12">
-                        <h1>DMN TCK Results Overview for Trisotech Digital Enterprise Suite 10.5.0</h1>
+                        <h1>DMN TCK Results Overview for Trisotech Digital Enterprise Suite 10.6.0</h1>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Date:</strong> 2021-02-15</p>
+                            <p><strong>Date:</strong> 2021-03-30</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                 var color = Chart.helpers.color;
                 var cbl7_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -130,7 +130,7 @@
                                 3,
                                 24,
                                 116,
-                                1,467,
+                                1,473,
                                 17,
                                 2,
                                 6,
@@ -143,18 +143,18 @@
                                 130,
                                 101,
                                 356,
-                                213,
+                                216,
                                 67,
                                 3,
                                 4,
                                 39,
-                                455,
+                                458,
                                 18,
                                 18,
                                 3,
                                 67,
                                 251,
-                                320,
+                                323,
                                 44,
                                 18,
                                 8,
@@ -168,7 +168,7 @@
                                 6,
                                 149,
                                 7,
-                                47,
+                                50,
                                 102,
                                 17,
                                 34,
@@ -183,7 +183,7 @@
                                 72,
                                 43,
                                 14,
-                                399,
+                                402,
                                 5,
                                 9,
                                 6,
@@ -197,7 +197,8 @@
                                 121,
                                 524,
                                 8,
-                                4
+                                4,
+                                19
                             ]
                         },
                         {
@@ -206,6 +207,7 @@
                             borderColor: window.chartColors.yellow,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -359,6 +361,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         },
@@ -440,6 +443,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         }
@@ -447,7 +451,7 @@
                 };
                 var cblp7_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -456,6 +460,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                            100,
                             100,
                             100,
                             100,
@@ -609,6 +614,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -618,6 +624,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                            0,
                             0,
                             0,
                             0,
@@ -771,6 +778,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         }
@@ -797,7 +805,7 @@
                             },
                             title: {
                                 display: true,
-                                text: 'Test results for Trisotech 10.5.0 (by number of tests)'
+                                text: 'Test results for Trisotech 10.6.0 (by number of tests)'
                             },
                             scales: {
                                 xAxes: [{
@@ -829,7 +837,7 @@
                             },
                             title: {
                                 display: true,
-                                text: 'Test results for Trisotech 10.5.0 (by percentage of tests)'
+                                text: 'Test results for Trisotech 10.6.0 (by percentage of tests)'
                             },
                             scales: {
                                 xAxes: [{
@@ -874,447 +882,453 @@
                                         <small></small>
                                     </th>
                                     <th> Trisotech <br/>
-                                        <small>10.5.0</small>
+                                        <small>10.6.0</small>
                                     </th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb0','Aggregator: COUNT')">Aggregator: COUNT</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb0','Aggregator: COUNT')">Aggregator: COUNT</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb1','Aggregator: MIN')">Aggregator: MIN</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb1','Aggregator: MIN')">Aggregator: MIN</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb2','Aggregator: SUM')">Aggregator: SUM</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb2','Aggregator: SUM')">Aggregator: SUM</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb3','Business Knowledge Model')">Business Knowledge Model</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb3','Business Knowledge Model')">Business Knowledge Model</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>24/24</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb4','Compliance Level 2')">Compliance Level 2</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb4','Compliance Level 2')">Compliance Level 2</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>116/116</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>1467/1467</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>1473/1473</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb6','Context')">Context</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb6','Context')">Context</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>17/17</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb7','DMN Import')">DMN Import</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb7','DMN Import')">DMN Import</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>2/2</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb8','Data Type : String')">Data Type : String</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb8','Data Type : String')">Data Type : String</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb9','Data Type: Boolean')">Data Type: Boolean</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb9','Data Type: Boolean')">Data Type: Boolean</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>134/134</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb10','Data Type: Collection')">Data Type: Collection</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb10','Data Type: Collection')">Data Type: Collection</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>49/49</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb11','Data Type: Context')">Data Type: Context</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb11','Data Type: Context')">Data Type: Context</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>9/9</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb12','Data Type: Date')">Data Type: Date</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb12','Data Type: Date')">Data Type: Date</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>14/14</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb13','Data Type: Date and Time')">Data Type: Date and Time</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb13','Data Type: Date and Time')">Data Type: Date and Time</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb14','Data Type: Days and Time Duration')">Data Type: Days and Time Duration</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb14','Data Type: Days and Time Duration')">Data Type: Days and Time Duration</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb15','Data Type: Function')">Data Type: Function</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb15','Data Type: Function')">Data Type: Function</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>130/130</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb16','Data Type: List')">Data Type: List</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb16','Data Type: List')">Data Type: List</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>101/101</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb17','Data Type: Number')">Data Type: Number</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb17','Data Type: Number')">Data Type: Number</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>356/356</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb18','Data Type: String')">Data Type: String</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb18','Data Type: String')">Data Type: String</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>213/213</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>216/216</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb19','Data Type: Structure')">Data Type: Structure</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb19','Data Type: Structure')">Data Type: Structure</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>67/67</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb20','Data Type: Text')">Data Type: Text</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb20','Data Type: Text')">Data Type: Text</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb21','Data Type: Time')">Data Type: Time</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb21','Data Type: Time')">Data Type: Time</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>4/4</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb22','Data Type: Years and Months Duration')">Data Type: Years and Months Duration</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb22','Data Type: Years and Months Duration')">Data Type: Years and Months Duration</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>39/39</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb23','Data Type: any')">Data Type: any</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb23','Data Type: any')">Data Type: any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>455/455</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>458/458</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb24','Decision Services')">Decision Services</a></th>
-                                    <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>18/18</small></span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb25','Decision Table: Multiple Output')">Decision Table: Multiple Output</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb24','Decision Services')">Decision Services</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>18/18</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb26','Decision Table: Multiple Output Columns')">Decision Table: Multiple Output Columns</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb25','Decision Table: Multiple Output')">Decision Table: Multiple Output</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>18/18</small></span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb26','Decision Table: Multiple Output Columns')">Decision Table: Multiple Output Columns</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb27','Decision Table: Single Output')">Decision Table: Single Output</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb27','Decision Table: Single Output')">Decision Table: Single Output</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>67/67</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb28','FEEL Arithmetic')">FEEL Arithmetic</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb28','FEEL Arithmetic')">FEEL Arithmetic</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>251/251</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>320/320</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>323/323</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb30','FEEL Constants')">FEEL Constants</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb30','FEEL Constants')">FEEL Constants</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>44/44</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb31','FEEL External Java')">FEEL External Java</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb31','FEEL External Java')">FEEL External Java</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>18/18</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb32','FEEL Filter (10.3.2.5)')">FEEL Filter (10.3.2.5)</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb32','FEEL Filter (10.3.2.5)')">FEEL Filter (10.3.2.5)</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>8/8</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb33','FEEL Function Literals')">FEEL Function Literals</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb33','FEEL Function Literals')">FEEL Function Literals</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>7/7</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb34','FEEL Functions: conversion')">FEEL Functions: conversion</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb34','FEEL Functions: conversion')">FEEL Functions: conversion</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>21/21</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb35','FEEL Functions: date and time')">FEEL Functions: date and time</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb35','FEEL Functions: date and time')">FEEL Functions: date and time</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>278/278</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb36','FEEL Functions: lambda')">FEEL Functions: lambda</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb36','FEEL Functions: lambda')">FEEL Functions: lambda</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>19/19</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb37','FEEL Functions: list')">FEEL Functions: list</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb37','FEEL Functions: list')">FEEL Functions: list</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>113/113</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb38','FEEL Functions: lists')">FEEL Functions: lists</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb38','FEEL Functions: lists')">FEEL Functions: lists</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>23/23</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb39','FEEL Functions: map')">FEEL Functions: map</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb39','FEEL Functions: map')">FEEL Functions: map</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>17/17</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb40','FEEL Functions: negation')">FEEL Functions: negation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb40','FEEL Functions: negation')">FEEL Functions: negation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb41','FEEL Functions: number')">FEEL Functions: number</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb41','FEEL Functions: number')">FEEL Functions: number</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>149/149</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb42','FEEL Functions: numeric')">FEEL Functions: numeric</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb42','FEEL Functions: numeric')">FEEL Functions: numeric</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>7/7</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>47/47</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>50/50</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb44','FEEL Functions: strings')">FEEL Functions: strings</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb44','FEEL Functions: strings')">FEEL Functions: strings</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>102/102</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb45','FEEL Iteration')">FEEL Iteration</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb45','FEEL Iteration')">FEEL Iteration</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>17/17</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb46','FEEL List')">FEEL List</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb46','FEEL List')">FEEL List</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>34/34</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb47','FEEL List Operator')">FEEL List Operator</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb47','FEEL List Operator')">FEEL List Operator</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb48','FEEL Paths')">FEEL Paths</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb48','FEEL Paths')">FEEL Paths</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>4/4</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb49','FEEL Qualified Names')">FEEL Qualified Names</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb49','FEEL Qualified Names')">FEEL Qualified Names</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>4/4</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb50','FEEL Quantifiers')">FEEL Quantifiers</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb50','FEEL Quantifiers')">FEEL Quantifiers</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb51','FEEL Relation')">FEEL Relation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb51','FEEL Relation')">FEEL Relation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>1/1</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb52','FEEL Special-character Names')">FEEL Special-character Names</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb52','FEEL Special-character Names')">FEEL Special-character Names</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>43/43</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb53','FEEL TYpe Conformance')">FEEL TYpe Conformance</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb53','FEEL TYpe Conformance')">FEEL TYpe Conformance</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>32/32</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb54','FEEL comments')">FEEL comments</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb54','FEEL comments')">FEEL comments</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb55','FEEL equality')">FEEL equality</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb55','FEEL equality')">FEEL equality</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>72/72</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb56','FEEL properties')">FEEL properties</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb56','FEEL properties')">FEEL properties</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>43/43</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb57','FEEL: Interval functions')">FEEL: Interval functions</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb57','FEEL: Interval functions')">FEEL: Interval functions</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>14/14</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb58','Feel : any')">Feel : any</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb58','Feel : any')">Feel : any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>399/399</small></span>
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>402/402</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb59','Function Definition')">Function Definition</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb59','Function Definition')">Function Definition</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>5/5</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb60','Function Invocation')">Function Invocation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb60','Function Invocation')">Function Invocation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>9/9</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb61','Hit Policy: ANY')">Hit Policy: ANY</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb61','Hit Policy: ANY')">Hit Policy: ANY</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb62','Hit Policy: COLLECT')">Hit Policy: COLLECT</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb62','Hit Policy: COLLECT')">Hit Policy: COLLECT</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>29/29</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb63','Hit Policy: Collect')">Hit Policy: Collect</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb63','Hit Policy: Collect')">Hit Policy: Collect</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>3/3</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb64','Hit Policy: FIRST')">Hit Policy: FIRST</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb64','Hit Policy: FIRST')">Hit Policy: FIRST</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb65','Hit Policy: OUTPUT ORDER')">Hit Policy: OUTPUT ORDER</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb65','Hit Policy: OUTPUT ORDER')">Hit Policy: OUTPUT ORDER</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb66','Hit Policy: PRIORITY')">Hit Policy: PRIORITY</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb66','Hit Policy: PRIORITY')">Hit Policy: PRIORITY</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>14/14</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb67','Hit Policy: RULE ORDER')">Hit Policy: RULE ORDER</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb67','Hit Policy: RULE ORDER')">Hit Policy: RULE ORDER</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>6/6</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb68','Hit Policy: UNIQUE')">Hit Policy: UNIQUE</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb68','Hit Policy: UNIQUE')">Hit Policy: UNIQUE</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>21/21</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb69','Item Definition')">Item Definition</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb69','Item Definition')">Item Definition</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>121/121</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb70','Literal Expression')">Literal Expression</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb70','Literal Expression')">Literal Expression</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>524/524</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb71','Literal Function Invocation')">Literal Function Invocation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb71','Literal Function Invocation')">Literal Function Invocation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>8/8</small></span>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.5.0.html', 'tb72','Relation')">Relation</a></th>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb72','Relation')">Relation</a></th>
                                     <td align="center">
                                         <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>4/4</small></span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_Trisotech Digital Enterprise Suite_10.6.0.html', 'tb73','[no label]')">[no label]</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-ok icon-green" aria-hidden="true"><br/><small>19/19</small></span>
                                     </td>
                                 </tr>
                                 </tbody>
@@ -1338,7 +1352,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_jDMN_3.4.1.html
+++ b/docs/overview_jDMN_3.4.1.html
@@ -92,12 +92,12 @@
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                 var color = Chart.helpers.color;
                 var cbl3_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -125,6 +125,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -278,6 +279,7 @@
                                 0,
                                 0,
                                 0,
+                                0,
                                 0
                             ]
                         },
@@ -287,6 +289,7 @@
                             borderColor: window.chartColors.red,
                             borderWidth: 1,
                             data: [
+                                0,
                                 0,
                                 0,
                                 0,
@@ -373,7 +376,7 @@
                                 3,
                                 24,
                                 116,
-                                1,467,
+                                1,473,
                                 17,
                                 2,
                                 6,
@@ -386,18 +389,18 @@
                                 130,
                                 101,
                                 356,
-                                213,
+                                216,
                                 67,
                                 3,
                                 4,
                                 39,
-                                455,
+                                458,
                                 18,
                                 18,
                                 3,
                                 67,
                                 251,
-                                320,
+                                323,
                                 44,
                                 18,
                                 8,
@@ -411,7 +414,7 @@
                                 6,
                                 149,
                                 7,
-                                47,
+                                50,
                                 102,
                                 17,
                                 34,
@@ -426,7 +429,7 @@
                                 72,
                                 43,
                                 14,
-                                399,
+                                402,
                                 5,
                                 9,
                                 6,
@@ -440,14 +443,15 @@
                                 121,
                                 524,
                                 8,
-                                4
+                                4,
+                                19
                             ]
                         }
                     ]
                 };
                 var cblp3_data = {
                     labels: [
-                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation"
+                        "Aggregator: COUNT","Aggregator: MIN","Aggregator: SUM","Business Knowledge Model","Compliance Level 2","Compliance Level 3","Context","DMN Import","Data Type : String","Data Type: Boolean","Data Type: Collection","Data Type: Context","Data Type: Date","Data Type: Date and Time","Data Type: Days and Time Duration","Data Type: Function","Data Type: List","Data Type: Number","Data Type: String","Data Type: Structure","Data Type: Text","Data Type: Time","Data Type: Years and Months Duration","Data Type: any","Decision Services","Decision Table: Multiple Output","Decision Table: Multiple Output Columns","Decision Table: Single Output","FEEL Arithmetic","FEEL Conditionals","FEEL Constants","FEEL External Java","FEEL Filter (10.3.2.5)","FEEL Function Literals","FEEL Functions: conversion","FEEL Functions: date and time","FEEL Functions: lambda","FEEL Functions: list","FEEL Functions: lists","FEEL Functions: map","FEEL Functions: negation","FEEL Functions: number","FEEL Functions: numeric","FEEL Functions: string","FEEL Functions: strings","FEEL Iteration","FEEL List","FEEL List Operator","FEEL Paths","FEEL Qualified Names","FEEL Quantifiers","FEEL Relation","FEEL Special-character Names","FEEL TYpe Conformance","FEEL comments","FEEL equality","FEEL properties","FEEL: Interval functions","Feel : any","Function Definition","Function Invocation","Hit Policy: ANY","Hit Policy: COLLECT","Hit Policy: Collect","Hit Policy: FIRST","Hit Policy: OUTPUT ORDER","Hit Policy: PRIORITY","Hit Policy: RULE ORDER","Hit Policy: UNIQUE","Item Definition","Literal Expression","Literal Function Invocation","Relation","[no label]"
                     ],
                     datasets: [
                         {
@@ -456,6 +460,7 @@
                             borderColor: window.chartColors.green,
                             borderWidth: 1,
                             data: [
+                            0,
                             0,
                             0,
                             0,
@@ -609,6 +614,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -690,6 +696,7 @@
                             0,
                             0,
                             0,
+                            0,
                             0
                             ]
                         },
@@ -699,6 +706,7 @@
                             borderColor: window.chartColors.purple,
                             borderWidth: 1,
                             data: [
+                            100,
                             100,
                             100,
                             100,
@@ -912,7 +920,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_jDMN_3.4.1.html', 'tb5','Compliance Level 3')">Compliance Level 3</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1467</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/1473</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -990,7 +998,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_jDMN_3.4.1.html', 'tb18','Data Type: String')">Data Type: String</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/213</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/216</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1020,7 +1028,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_jDMN_3.4.1.html', 'tb23','Data Type: any')">Data Type: any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/455</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/458</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1056,7 +1064,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_jDMN_3.4.1.html', 'tb29','FEEL Conditionals')">FEEL Conditionals</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/320</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/323</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1140,7 +1148,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_jDMN_3.4.1.html', 'tb43','FEEL Functions: string')">FEEL Functions: string</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/47</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/50</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1230,7 +1238,7 @@
                                 <tr>
                                     <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_jDMN_3.4.1.html', 'tb58','Feel : any')">Feel : any</a></th>
                                     <td align="center">
-                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/399</small></span>
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/402</small></span>
                                     </td>
                                 </tr>
                                 <tr>
@@ -1317,6 +1325,12 @@
                                         <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/4</small></span>
                                     </td>
                                 </tr>
+                                <tr>
+                                    <th class="text-nowrap text-small" scope="row"><a onclick="labelDetail('detail_jDMN_3.4.1.html', 'tb73','[no label]')">[no label]</a></th>
+                                    <td align="center">
+                                        <span class="glyphicon glyphicon-remove icon-red" aria-hidden="true"><br/><small>0/19</small></span>
+                                    </td>
+                                </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -1338,7 +1352,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/tests.html
+++ b/docs/tests.html
@@ -75,12 +75,12 @@
                 <div class="row">
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Tests:</strong> 1637</p>
+                            <p><strong>Tests:</strong> 1662</p>
                         </small>
                     </div>
                     <div class="col-md-2">
                         <small>
-                            <p><strong>Labels:</strong> 73</p>
+                            <p><strong>Labels:</strong> 74</p>
                         </small>
                     </div>
                 </div>
@@ -868,7 +868,7 @@
                             <td scope="row"></td>
                         </tr>
                         <tr>
-                                <td class="text-nowrap" scope="row" rowspan="1,521" style="vertical-align:middle">compliance-level-3</td>
+                                <td class="text-nowrap" scope="row" rowspan="1,546" style="vertical-align:middle">compliance-level-3</td>
                                 <td class="text-nowrap" scope="row" rowspan="1" style="vertical-align:middle">0001-filter-test-01</td>
                                 <td align="center" rowspan="1" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/blob/master/TestCases/compliance-level-3/0001-filter/0001-filter.pdf">
@@ -3689,11 +3689,11 @@
                             <td scope="row">function instance of days and time duration is false</td>
                         </tr>
                         <tr>
-                                <td class="text-nowrap" scope="row" rowspan="35" style="vertical-align:middle">0071-feel-between-test-01</td>
-                                <td align="center" rowspan="35" style="vertical-align:middle">
+                                <td class="text-nowrap" scope="row" rowspan="38" style="vertical-align:middle">0071-feel-between-test-01</td>
+                                <td align="center" rowspan="38" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                 </td>
-                                <td align="center" rowspan="35" style="vertical-align:middle">
+                                <td align="center" rowspan="38" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0071-feel-between">
                                         <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                     </a>
@@ -3836,6 +3836,18 @@
                         <tr>
                             <td class="text-nowrap" scope="row">dt_duration_005</td>
                             <td scope="row">after</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">null_001</td>
+                            <td scope="row">null test value</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">null_002</td>
+                            <td scope="row">null start value</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">null_003</td>
+                            <td scope="row">null end value</td>
                         </tr>
                         <tr>
                                 <td class="text-nowrap" scope="row" rowspan="274" style="vertical-align:middle">0072-feel-in-test-01</td>
@@ -5542,17 +5554,25 @@
                             <td scope="row">Indirect invocation: Decision service has string input but we pass in singleton list of correct type - input is coerced to string</td>
                         </tr>
                         <tr>
-                                <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0083-feel-unicode-test-01</td>
-                                <td align="center" rowspan="11" style="vertical-align:middle">
+                                <td class="text-nowrap" scope="row" rowspan="14" style="vertical-align:middle">0083-feel-unicode-test-01</td>
+                                <td align="center" rowspan="14" style="vertical-align:middle">
                                     <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
                                 </td>
-                                <td align="center" rowspan="11" style="vertical-align:middle">
+                                <td align="center" rowspan="14" style="vertical-align:middle">
                                     <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0083-feel-unicode">
                                         <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
                                     </a>
                                 </td>
                             <td class="text-nowrap" scope="row">decision_001</td>
-                            <td scope="row">Assert length of string with unicode char</td>
+                            <td scope="row">Assert length of string with 4 digit unicode char</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">decision_001_a</td>
+                            <td scope="row">Assert length of string with 6 digit unicode char</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">decision_001_b</td>
+                            <td scope="row">Assert string with 6 digit unicode char</td>
                         </tr>
                         <tr>
                             <td class="text-nowrap" scope="row">decision_002</td>
@@ -5593,6 +5613,10 @@
                         <tr>
                             <td class="text-nowrap" scope="row">endswith_001</td>
                             <td scope="row">literal unicode - string ends with with supplementary chars</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">substring_004</td>
+                            <td scope="row">escape 6 digit unicode substring</td>
                         </tr>
                         <tr>
                                 <td class="text-nowrap" scope="row" rowspan="11" style="vertical-align:middle">0084-feel-for-loops-test-01</td>
@@ -5917,6 +5941,91 @@
                         <tr>
                             <td class="text-nowrap" scope="row">018</td>
                             <td scope="row">BKM may be passed to sort func</td>
+                        </tr>
+                        <tr>
+                                <td class="text-nowrap" scope="row" rowspan="19" style="vertical-align:middle">0093-feel-at-literals-test-01</td>
+                                <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <span class="glyphicon glyphicon-book text-muted" aria-hidden="true"></span>
+                                </td>
+                                <td align="center" rowspan="19" style="vertical-align:middle">
+                                    <a target="_blank" href="https://github.com/dmn-tck/tck/tree/master/TestCases/compliance-level-3/0093-feel-at-literals">
+                                        <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+                                    </a>
+                                </td>
+                            <td class="text-nowrap" scope="row">test_001</td>
+                            <td scope="row">invalid value has null value</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">date_001</td>
+                            <td scope="row">will parse date to date type</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">date_002</td>
+                            <td scope="row">will parse date value</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">datetime_001</td>
+                            <td scope="row">will parse to date time type</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">datetime_002</td>
+                            <td scope="row">will parse date time value</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">datetime_003</td>
+                            <td scope="row">will parse to date time with zone</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">datetime_004</td>
+                            <td scope="row">will parse date time value with zone</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">datetime_005</td>
+                            <td scope="row">will parse to date time value with offset</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">datetime_006</td>
+                            <td scope="row">will parse date time value with offset</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">time_001</td>
+                            <td scope="row">will parse to time type</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">time_002</td>
+                            <td scope="row">will parse time value</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">time_003</td>
+                            <td scope="row">will parse to time + offset</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">time_004</td>
+                            <td scope="row">will parse time value + offset</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">time_005</td>
+                            <td scope="row">will parse to time + zone</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">time_006</td>
+                            <td scope="row">will parse time value + zone</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">dt_duration_001</td>
+                            <td scope="row">will parse to days and time duration type</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">dt_duration_002</td>
+                            <td scope="row">will parse days and time duration value</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">ym_duration_001</td>
+                            <td scope="row">will parse to years and months duration type</td>
+                        </tr>
+                        <tr>
+                            <td class="text-nowrap" scope="row">ym_duration_002</td>
+                            <td scope="row">will parse years and months duration value</td>
                         </tr>
                         <tr>
                                 <td class="text-nowrap" scope="row" rowspan="10" style="vertical-align:middle">1100-feel-decimal-function-test-01</td>
@@ -7857,7 +7966,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Mar 1, 2021, 5:20:05 PM</p>
+        <p>Last updated:</strong> Apr 1, 2021, 10:16:27 AM</p>
     </div>
 </div>
 <div class="footer">

--- a/runners/dmn-tck-reporter/src/main/resources/templates/index.ftl
+++ b/runners/dmn-tck-reporter/src/main/resources/templates/index.ftl
@@ -216,7 +216,7 @@
             <div class="row">
               <div class="container-fluid">
                 <div class="panel-body">
-                  <p>This website is updated to reflect DMNv1.2.<br />For archived versions of the website you can refer to: <a href="archive-DMNv1.1/index.html">Archived DMNv1.1</a>.</p>
+                  <p>This website is updated to reflect DMNv1.3.<br />For archived versions of the website you can refer to: <a href="archive-DMNv1.2/index.html">Archived DMNv1.2</a>, <a href="archive-DMNv1.1/index.html">Archived DMNv1.1</a>.</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Usual refresh of the website.
In a couple of previous iterations, the website footer was reporting wrong links to archives and erroneously mentioning v1.2 instead of v1.3. I'm sorry for that. This should fix it going forward too.
![image](https://user-images.githubusercontent.com/1699252/113265704-bd34ac80-92d4-11eb-9a81-d35c3d931f58.png)
