### PR TITLE
change inputData typeRef to 'string' (from 'Any')

### DIFF
--- a/TestCases/compliance-level-3/0080-feel-getvalue-function/0080-feel-getvalue-function.dmn
+++ b/TestCases/compliance-level-3/0080-feel-getvalue-function/0080-feel-getvalue-function.dmn
@@ -10,7 +10,7 @@
     <description>FEEL built-in function 'get value(m, key)' in unspecified category</description>
 
     <inputData name="input_001" id="_input_001">
-        <variable name="input_001" typeRef="Any"/> <!-- used to externally supply FEEL:string or other type of values defined in the TCK test file -->
+        <variable name="input_001" typeRef="string"/> <!-- used to externally supply FEEL:string or other type of values defined in the TCK test file -->
     </inputData>
 
     <decision name="decision_001" id="_decision_001">


### PR DESCRIPTION
Hi @tarilabs / @opatrascoiu - modding the recent inputData typeRef change to the 'get value' function to be 'string'.  Having it as 'Any' will give a `null` result, not what is expected.  Apols, I should have jumped on it earlier.

Why `null`?  When the typeRef was empty the input had no explicit type, but now we have given it 'Any' - so it now has an explicit type.

The parameter domain for the `get value` function is `context, string`.  `Any` does not conform to `string`.  So giving the inputData `Any` does mean it can accept a string value (as `string` conforms to `Any`).  But, in turn, it means it cannot be used where a string parameter is required because `Any` does not conform to `string`.

Yes, the _value_ of the input is a string, but as we've given an _explicit_ type to the inputData that really is `Any` and not based on the runtime content of it.

That is my take - hopefully that makes sense.

Greg.

PS: Octavian, I guess that underlines the differences between not having a type, and having an 'Any' type as per a previous discussion as to why they are not the same thing.

