### PR TITLE
DMN TCK About page (README.md and website about.html)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,11 @@ $ mvn clean install -P camunda,drools,jdmn
 5. Check the log output for errors or exceptions and compare number of errors or skipped tests reported for each vendor with what's on the [TCK website](https://dmn-tck.github.io/tck/). For details on failed tests you can also look into the `target/surefire-reports` directory within each executed runner's sub-directory.
 
 If you have trouble executing a runner consult the `README.md` file in its sub-directory or contact the vendor.
+
+## Some DMN TCK presentations
+
+* Keith Swenson: Close is not Close Enough ([DecisionCamp 2019](https://decisioncamp2019.wordpress.com/program/#KeithSwenson))
+* Keith Swenson: DMN TCK Working Group ([bpmNEXT 2019](https://www.youtube.com/watch?v=75fk-i3K9U0))
+* Matteo Mortari: Introduction and Updates on DMN TCK ([DecisionCamp 2018](https://decisioncamp2018.wordpress.com/program/#DMNTCK))
+* Keith Swenson: DMN Technology Compatiability Toolkit (TCK) ([bpmNEXT 2018](https://www.youtube.com/watch?v=MqSbBtY2dKQ))
+* Keith Swenson: Making the Standard Real: The DMN TCK ([bpmNEXT 2017](https://www.youtube.com/watch?v=M8goCq72lbo))

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Caveat: ~~at the current~~ at the very beginning of this project, there were no 
 * Similarly, we strive to implement as much of the spec as possible, but if the spec is too expansive we may limit the scope to a subset that we all agree upon.
 * If the spec is ambiguous, we will make an interpretation of the spec according to what can actually be realized in running code, document that, and remain consistent to that in the future.
 
+Reasons to be interested in this community-led project:
+
+* A way for Vendors to **demonstrate** their compliance to the Standard
+* Provide files to **help** Vendors test for error and become compliant
+* A way for Customers and Users to **assess** how compliant a Vendor is
+
 ## How to run the tests youself
 
 A couple of vendors provide [Java-based runners](/runners), which you can run using the following steps:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 # Technology Compatibility Kit for the Decision Model and Notation (DMN) standard
 
+The **Decision Model and Notation Technology Compatibility Kit** (DMN TCK) is a community-led proposal for a verifiable and executable method to demonstrate the Conformance level of support provided by a Vendor-supplied DMN implementation.
+
+In addition, this method provides more finer-grained details on the actual support for specific DMN constructs for each implementation.
+
+The DMN TCK working group is composed by vendors and practitioners of DMN, with the goal to assist and ensure Conformance to the specification, by defining test cases and expected results, by providing tools to run these tests and validate results; the outcome also represent an additional and pragmatical way to recognize and publicize vendor success.
+
+Joining the TCK is free, it also holds regular conference calls, and new members are always welcome.
+
 ## Current Result Web Site
 
 * https://dmn-tck.github.io/tck/
@@ -22,7 +30,18 @@ ReferenceTests - the actual collection of reference tests.
 
 Eventually we will have folders for every tool (software product, SaaS service, etc) that claims conformance that will hold the output of their test run.
 
+## Scope of work
 
+Goals:
+* 📝 Define a set of test cases
+* 🔬 Carefully assure conformance to the spec
+* 🛠️ Provide tools to run the tests
+* 👏 Recognize vendor successes
+
+NON-Goals:
+* 🚫 Extend or enhance the DMN Spec; instead, RTF is responsible for that
+* 🚫 Focus on esoteric features; instead, focus Only features that exist in one or more implementations
+* 🚫 Favor an implementation over another; instead, Remain technology and vendor neutral
 
 For this effort, here are the goals to achieve in order to consider this a success
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ To be clear, there are several things that are not the goals of this group
 
 * We will not be involved in defining or extending the DMN specification -- this is the job of the OMG committee.
 * We will focus on concrete input and output examples. We will avoid general discussion about what should and should not generally be true.
-* We will include only test cases that are known to pass on at least one implementation. Caveat: at the current time there are no known implementations at conformance level 3, so necessarily there are tests that no implementation can run today, but once CL3 has been attained it will not be our practice to invent new, far-reaching tests for abstract situations.
+* We will include only test cases that are known to pass on at least one implementation.
+Caveat: ~~at the current~~ at the very beginning of this project, there were no known implementations at conformance level 3, so necessarily there has been tests that no implementation could run, but once CL3 has been attained it will not be our practice to invent new, far-reaching tests for abstract situations.
 * We will strive to get close to the spec, but if parts of the spec prove impossible to implement, we will not get involved correcting the specification.
 * Similarly, we strive to implement as much of the spec as possible, but if the spec is too expansive we may limit the scope to a subset that we all agree upon.
 * If the spec is ambiguous, we will make an interpretation of the spec according to what can actually be realized in running code, document that, and remain consistent to that in the future.

--- a/docs/about.html
+++ b/docs/about.html
@@ -1,0 +1,268 @@
+<html lang="en" xmlns="http://www.w3.org/1999/html">
+
+<head>
+    <!-- PatternFly Styles -->
+    <link href="css/patternfly.min.css" rel="stylesheet" media="screen, print">
+    <link href="css/patternfly-additions.min.css" rel="stylesheet" media="screen, print">
+    <!-- jQuery -->
+    <script src="js/jquery.min.js"></script>
+    <!-- Bootstrap -->
+    <script src="js/bootstrap.min.js"></script>
+    <!-- PatternFly -->
+    <script src="js/patternfly.min.js"></script>
+    <!-- c3 -->
+    <script src="js/c3.min.js"></script>
+    <!-- c3 -->
+    <script src="js/d3.min.js"></script>
+    <!-- jquery max height -->
+    <script src="js/jquery.matchHeight-min.js"></script>
+
+    <!-- site libs -->
+    <script src="js/lib.js"></script>
+    <link href="css/lib.css" rel="stylesheet" media="screen, print">
+
+    <title>DMN TCK Glossary</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+
+    <div class="wrapper">
+        <div class="header">
+            <nav class="navbar navbar-default navbar-pf" role="navigation">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <a class="navbar-brand" href="index.html">
+                        <img src="images/logo.png" alt="DMN Technology Compatibility Kit" />
+                    </a>
+                </div>
+                <div class="collapse navbar-collapse navbar-collapse-1">
+                    <ul class="nav navbar-nav navbar-primary">
+                        <li>
+                            <a href="index.html">Submitters</a>
+                        </li>
+                        <li>
+                            <a href="glossary.html">Glossary</a>
+                        </li>
+                        <li>
+                            <a href="tests.html">Tests</a>
+                        </li>
+                        <li class="active">
+                            <a href="about.html">About</a>
+                        </li>
+
+                    </ul>
+                </div>
+            </nav>
+            <div class="breadcrumbs">
+                <ol class="breadcrumb">
+                    <li>
+                        <a href="index.html">Home</a>
+                    </li>
+                    <li class="active"><strong>About</strong></li>
+                </ol>
+            </div>
+        </div>
+        <div class="container" style="font-size: larger;">
+            <div class="row">
+                <h1>Technology Compatibility Kit for the Decision Model and Notation (DMN) standard
+                </h1>
+                <p class="lead">The Decision Model and Notation Technology Compatibility Kit (DMN TCK) is a
+                    community-led proposal for a verifiable and executable method to demonstrate the Conformance level
+                    of support provided by a Vendor-supplied DMN implementation.
+                </p>
+                <p>In addition, this method provides more finer-grained details on the actual support for specific DMN
+                    constructs for each implementation.
+                </p>
+                <p>The DMN TCK working group is composed by vendors and practitioners of DMN, with the goal to assist
+                    and ensure Conformance to the specification, by defining test cases and expected results, by
+                    providing tools to run these tests and validate results; the outcome also represent an additional
+                    and pragmatical way to recognize and publicize vendor success.
+                </p>
+                <p>Joining the TCK is free, it also holds regular conference calls, and new members are always welcome.
+                </p>
+            </div>
+            <div class="row">
+                <h2>Scope of work
+                </h2>
+                <p>Goals:
+                <ul>
+                    <li>📝 Define a set of test cases</li>
+                    <li>🔬 Carefully assure conformance to the spec</li>
+                    <li>🛠️ Provide tools to run the tests</li>
+                    <li>👏 Recognize vendor successes</li>
+                </ul>
+                NON-Goals:
+                <ul>
+                    <li>🚫 Extend or enhance the DMN Spec; instead, RTF is responsible for that</li>
+                    <li>🚫 Focus on esoteric features; instead, focus Only features that exist in one or more
+                        implementations</li>
+                    <li>🚫 Favor an implementation over another; instead, Remain technology and vendor neutral</li>
+                </ul>
+                For this effort, here are the goals to achieve in order to consider this a success
+
+                <ul>
+                    <li><strong>Deliverables</strong>: We will collect and organize test cases that can be used by
+                        implementers to
+                        demonstrate compliance to the spec when evaluating a DMN model.</li>
+                    <li><strong>Format</strong>: A single DMN model might be tested with any number of different inputs,
+                        and each
+                        combination of model and input data is considered a test case.. A test case consists of
+                        <ul>
+                            <li>Some document on what the test is designed to test,
+                            <li>Human readible / end user visual representation of the decision: a screen shot at the
+                                minimum,
+                                <ul>
+                                    <li>a serialized DMN model,
+                                    <li>a serialized set of input data,</li>
+                                    <li>serialized set of output/response data.</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                    <li><strong>Availability</strong>: Test cases will be files that can be accessed freely by anyone
+                        using a creative
+                        commons Share-Alike-With-Attribution license.</li>
+                    <li><strong>Conformance</strong>: Test cases will be associated to specific elements of the spec so
+                        it is clear what
+                        aspect of conformance is being tested.</li>
+                    <li><strong>Promotion</strong>: We will promote the tests in order to assure that potential users of
+                        DMN are aware.
+                    </li>
+                    <li><strong>Completeness</strong>: we will aim to test all aspects of conformance level 3.</li>
+                    <li><strong>Uniformity</strong>: We will strive to eliminate contradictory tests. That is, if there
+                        is a test which
+                        according to two different parts of the spec would produce two different outputs, then the
+                        correct test output will be chosen so that a single consistent implementation might generate all
+                        the test responses.</li>
+                </ul>
+                To be clear, there are several things that are not the goals of this group
+                <ul>
+                    <li>We will not be involved in defining or extending the DMN specification -- this is the job of the
+                        OMG
+                        committee.</li>
+                    <li>We will focus on concrete input and output examples. We will avoid general discussion about what
+                        should
+                        and should not generally be true.</li>
+                    <li>We will include only test cases that are known to pass on at least one implementation.
+                        <del>Caveat:
+                            at the
+                            current</del> at the very beginning of this project, there were no known implementations at
+                        conformance level
+                        3, so necessarily there has been tests that no implementation could run, but once CL3 has been
+                        attained
+                        it will not be our practice to invent new, far-reaching tests for abstract situations.
+                    </li>
+                    <li>We will strive to get close to the spec, but if parts of the spec prove impossible to implement,
+                        we will
+                        not get involved correcting the specification.</li>
+                    <li>Similarly, we strive to implement as much of the spec as possible, but if the spec is too
+                        expansive we
+                        may limit the scope to a subset that we all agree upon.</li>
+                    <li>If the spec is ambiguous, we will make an interpretation of the spec according to what can
+                        actually be
+                        realized in running code, document that, and remain consistent to that in the future.</li>
+                </ul>
+                Reasons to be interested in this community-led project:
+                <ul>
+                    <li>A way for Vendors to <strong>demonstrate</strong> their compliance to the Standard</li>
+                    <li>Provide files to <strong>help</strong> Vendors test for error and become compliant</li>
+                    <li>A way for Customers and Users to <strong>assess</strong> how compliant a Vendor is</li>
+                </ul>
+                </p>
+            </div>
+            <div class="row">
+                <h2>Some DMN TCK presentations
+                </h2>
+                <p>
+                <ul>
+                    <li>Keith Swenson: Close is not Close Enough (<a
+                            href="https://decisioncamp2019.wordpress.com/program/#KeithSwenson">DecisionCamp 2019</a>)
+                    </li>
+                    <li>Keith Swenson: DMN TCK Working Group (<a
+                            href="https://www.youtube.com/watch?v=75fk-i3K9U0)">bpmNEXT 2019</a>)</li>
+                    <li>Matteo Mortari: Introduction and Updates on DMN TCK (<a
+                            href="https://decisioncamp2018.wordpress.com/program/#DMNTCK">DecisionCamp 2018</a>)</li>
+                    <li>Keith Swenson: DMN Technology Compatiability Toolkit (TCK) (<a
+                            href="https://www.youtube.com/watch?v=MqSbBtY2dKQ">bpmNEXT 2018</a>)</li>
+                    <li>Keith Swenson: Making the Standard Real: The DMN TCK (<a
+                            href="https://www.youtube.com/watch?v=M8goCq72lbo">bpmNEXT 2017</a>)</li>
+                </ul>
+                </p>
+            </div>
+        </div>
+
+        <!-- pre-footer -->
+<div class="pre-footer">
+    <div class="last-updated">
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:30 PM</p>
+    </div>
+</div>
+<div class="footer">
+    <div class="container-fluid">
+        <div class="row">
+            <div class="container-fluid">
+                <div class="panel-heading">
+                    <h3 class="panel-title">The DMN TCK is supported by:</h3>
+                </div>
+                <div class="panel-body">
+                    <div style="display: flex; justify-content: space-around; flex-wrap: wrap;">
+                        <div style="display:inline-block; margin-top:10px;">
+                            <a href="https://www.actico.com" target="_newtab">
+                                <img alt="actico" class="img-thumbnail" src="images/actico-logo.png" style="height: 60px"/>
+                            </a>
+                        </div>
+                        <div style="display:inline-block; margin-top:10px;">
+                            <a href="http://www.camunda.com" target="_newtab">
+                                <img alt="camunda" class="img-thumbnail" src="images/camunda_logo.png" style="height: 60px"/>
+                            </a>
+                        </div>
+                        <div style="display:inline-block; margin-top:10px;">
+                            <a href="http://www.fujitsu.com/" target="_newtab">
+                                <img alt="fujitsu" class="img-thumbnail" src="images/Fujitsu.jpg" style="height: 60px"/>
+                            </a>
+                        </div>
+                        <div style="display:inline-block; margin-top:10px;">
+                            <a href="http://methodandstyle.com/" target="_newtab">
+                                <img alt="methodandstyle" class="img-thumbnail" src="images/MSlogo4x.jpg" style="height: 60px"/>
+                            </a>
+                        </div>
+                        <div style="display:inline-block; margin-top:10px;">
+                            <a href="http://openrules.com/" target="_newtab">
+                                <img alt="openrules" class="img-thumbnail" src="images/openruleslogo.jpg" style="height: 60px"/>
+                            </a>
+                        </div>
+                        <div style="display:inline-block; margin-top:10px;">
+                            <a href="http://oracle.com/" target="_newtab">
+                                <img alt="oracle" class="img-thumbnail" src="images/oracle.png" style="height: 60px"/>
+                            </a>
+                        </div>
+                        <div style="display:inline-block; margin-top:10px;">
+                            <a href="http://www.redhat.com" target="_newtab">
+                                <img alt="redhat" class="img-thumbnail" src="images/redhat3.png" style="height: 60px"/>
+                            </a>
+                        </div>
+                        <div style="display:inline-block; margin-top:10px;">
+                            <a href="http://www.trisotech.com" target="_newtab">
+                                <img alt="trisotech" class="img-thumbnail" src="images/trisotech3.jpg" style="height: 60px"/>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- container -->
+</div>
+<!-- footer -->
+
+    </div>
+</body>
+
+</html>

--- a/docs/detail_ACTICO Platform_8.1.5.html
+++ b/docs/detail_ACTICO Platform_8.1.5.html
@@ -56,6 +56,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -51472,7 +51475,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Camunda DMN-Scala Extension_1.7.0.html
+++ b/docs/detail_Camunda DMN-Scala Extension_1.7.0.html
@@ -56,6 +56,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -51472,7 +51475,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Digital Transformation Platform (DXP)_2.4.html
+++ b/docs/detail_Digital Transformation Platform (DXP)_2.4.html
@@ -56,6 +56,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -51472,7 +51475,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Drools_7.58.0.Beta1.html
+++ b/docs/detail_Drools_7.58.0.Beta1.html
@@ -56,6 +56,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -51472,7 +51475,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:30 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_OpenRules_7.0.0.html
+++ b/docs/detail_OpenRules_7.0.0.html
@@ -56,6 +56,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -51472,7 +51475,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Oracle Process Cloud_17.3.3.html
+++ b/docs/detail_Oracle Process Cloud_17.3.3.html
@@ -56,6 +56,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -51472,7 +51475,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_Trisotech Digital Enterprise Suite_10.11.0.html
+++ b/docs/detail_Trisotech Digital Enterprise Suite_10.11.0.html
@@ -56,6 +56,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -51472,7 +51475,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:30 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/detail_jDMN_5.0.0.html
+++ b/docs/detail_jDMN_5.0.0.html
@@ -56,6 +56,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -51472,7 +51475,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -51,6 +51,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -311,7 +314,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:30 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/index.html
+++ b/docs/index.html
@@ -432,6 +432,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1110,7 +1113,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_ACTICO Platform_8.1.5.html
+++ b/docs/overview_ACTICO Platform_8.1.5.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Camunda DMN-Scala Extension_1.7.0.html
+++ b/docs/overview_Camunda DMN-Scala Extension_1.7.0.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Camunda Platform_7.15.0.html
+++ b/docs/overview_Camunda Platform_7.15.0.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Digital Transformation Platform (DXP)_2.4.html
+++ b/docs/overview_Digital Transformation Platform (DXP)_2.4.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Drools_7.58.0.Beta1.html
+++ b/docs/overview_Drools_7.58.0.Beta1.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:30 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_OpenRules_7.0.0.html
+++ b/docs/overview_OpenRules_7.0.0.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Oracle Process Cloud_17.3.3.html
+++ b/docs/overview_Oracle Process Cloud_17.3.3.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_Trisotech Digital Enterprise Suite_10.11.0.html
+++ b/docs/overview_Trisotech Digital Enterprise Suite_10.11.0.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:30 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/overview_jDMN_5.0.0.html
+++ b/docs/overview_jDMN_5.0.0.html
@@ -63,6 +63,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -1352,7 +1355,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:29 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/docs/tests.html
+++ b/docs/tests.html
@@ -51,6 +51,9 @@
                     <li class="active">
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>
@@ -8335,7 +8338,7 @@
 <!-- pre-footer -->
 <div class="pre-footer">
     <div class="last-updated">
-        <p>Last updated:</strong> Oct 1, 2021, 6:01:59 PM</p>
+        <p>Last updated:</strong> Oct 5, 2021, 3:00:30 PM</p>
     </div>
 </div>
 <div class="footer">

--- a/runners/dmn-tck-reporter/src/main/java/org/omg/dmn/tck/AboutGenerator.java
+++ b/runners/dmn-tck-reporter/src/main/java/org/omg/dmn/tck/AboutGenerator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.omg.dmn.tck;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+
+/**
+ * generates the about.html page
+ */
+public class AboutGenerator {
+    private static final Logger logger = LoggerFactory.getLogger( AboutGenerator.class);
+
+    public static void generatePage(Reporter.Parameters params, Configuration cfg, ReportHeader header ) {
+        logger.info( "Generating about.html" );
+        try {
+            Template temp = cfg.getTemplate( "/templates/about.ftl" );
+
+            Map<String, Object> data = new HashMap<>(  );
+
+            Writer out = new FileWriter( params.output.getAbsolutePath() + "/about.html" );
+            temp.process( data, out );
+            out.close();
+        } catch ( IOException e ) {
+            e.printStackTrace();
+        } catch ( TemplateException e ) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/runners/dmn-tck-reporter/src/main/java/org/omg/dmn/tck/Reporter.java
+++ b/runners/dmn-tck-reporter/src/main/java/org/omg/dmn/tck/Reporter.java
@@ -75,6 +75,7 @@ public class Reporter {
         }
         TestsGenerator.generatePage( params, cfg, header, tableAllTests );
         GlossaryGenerator.generatePage( params, cfg, header );
+        AboutGenerator.generatePage( params, cfg, header );
     }
 
     private static ReportHeader createReportHeader(Map<String, TestCasesData> tests, Map<String, List<TestCasesData>> labels, Map<String, Vendor> results) {

--- a/runners/dmn-tck-reporter/src/main/resources/templates/about.ftl
+++ b/runners/dmn-tck-reporter/src/main/resources/templates/about.ftl
@@ -151,8 +151,8 @@
                         should
                         and should not generally be true.</li>
                     <li>We will include only test cases that are known to pass on at least one implementation.
-                        <del>Caveat:
-                            at the
+                        Caveat:
+                        <del>at the
                             current</del> at the very beginning of this project, there were no known implementations at
                         conformance level
                         3, so necessarily there has been tests that no implementation could run, but once CL3 has been

--- a/runners/dmn-tck-reporter/src/main/resources/templates/about.ftl
+++ b/runners/dmn-tck-reporter/src/main/resources/templates/about.ftl
@@ -1,0 +1,206 @@
+<html lang="en" xmlns="http://www.w3.org/1999/html">
+
+<head>
+    <!-- PatternFly Styles -->
+    <link href="css/patternfly.min.css" rel="stylesheet" media="screen, print">
+    <link href="css/patternfly-additions.min.css" rel="stylesheet" media="screen, print">
+    <!-- jQuery -->
+    <script src="js/jquery.min.js"></script>
+    <!-- Bootstrap -->
+    <script src="js/bootstrap.min.js"></script>
+    <!-- PatternFly -->
+    <script src="js/patternfly.min.js"></script>
+    <!-- c3 -->
+    <script src="js/c3.min.js"></script>
+    <!-- c3 -->
+    <script src="js/d3.min.js"></script>
+    <!-- jquery max height -->
+    <script src="js/jquery.matchHeight-min.js"></script>
+
+    <!-- site libs -->
+    <script src="js/lib.js"></script>
+    <link href="css/lib.css" rel="stylesheet" media="screen, print">
+
+    <title>DMN TCK Glossary</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+
+    <div class="wrapper">
+        <div class="header">
+            <nav class="navbar navbar-default navbar-pf" role="navigation">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <a class="navbar-brand" href="index.html">
+                        <img src="images/logo.png" alt="DMN Technology Compatibility Kit" />
+                    </a>
+                </div>
+                <div class="collapse navbar-collapse navbar-collapse-1">
+                    <ul class="nav navbar-nav navbar-primary">
+                        <li>
+                            <a href="index.html">Submitters</a>
+                        </li>
+                        <li>
+                            <a href="glossary.html">Glossary</a>
+                        </li>
+                        <li>
+                            <a href="tests.html">Tests</a>
+                        </li>
+                        <li class="active">
+                            <a href="about.html">About</a>
+                        </li>
+
+                    </ul>
+                </div>
+            </nav>
+            <div class="breadcrumbs">
+                <ol class="breadcrumb">
+                    <li>
+                        <a href="index.html">Home</a>
+                    </li>
+                    <li class="active"><strong>About</strong></li>
+                </ol>
+            </div>
+        </div>
+        <div class="container" style="font-size: larger;">
+            <div class="row">
+                <h1>Technology Compatibility Kit for the Decision Model and Notation (DMN) standard
+                </h1>
+                <p class="lead">The Decision Model and Notation Technology Compatibility Kit (DMN TCK) is a
+                    community-led proposal for a verifiable and executable method to demonstrate the Conformance level
+                    of support provided by a Vendor-supplied DMN implementation.
+                </p>
+                <p>In addition, this method provides more finer-grained details on the actual support for specific DMN
+                    constructs for each implementation.
+                </p>
+                <p>The DMN TCK working group is composed by vendors and practitioners of DMN, with the goal to assist
+                    and ensure Conformance to the specification, by defining test cases and expected results, by
+                    providing tools to run these tests and validate results; the outcome also represent an additional
+                    and pragmatical way to recognize and publicize vendor success.
+                </p>
+                <p>Joining the TCK is free, it also holds regular conference calls, and new members are always welcome.
+                </p>
+            </div>
+            <div class="row">
+                <h2>Scope of work
+                </h2>
+                <p>Goals:
+                <ul>
+                    <li>📝 Define a set of test cases</li>
+                    <li>🔬 Carefully assure conformance to the spec</li>
+                    <li>🛠️ Provide tools to run the tests</li>
+                    <li>👏 Recognize vendor successes</li>
+                </ul>
+                NON-Goals:
+                <ul>
+                    <li>🚫 Extend or enhance the DMN Spec; instead, RTF is responsible for that</li>
+                    <li>🚫 Focus on esoteric features; instead, focus Only features that exist in one or more
+                        implementations</li>
+                    <li>🚫 Favor an implementation over another; instead, Remain technology and vendor neutral</li>
+                </ul>
+                For this effort, here are the goals to achieve in order to consider this a success
+
+                <ul>
+                    <li><strong>Deliverables</strong>: We will collect and organize test cases that can be used by
+                        implementers to
+                        demonstrate compliance to the spec when evaluating a DMN model.</li>
+                    <li><strong>Format</strong>: A single DMN model might be tested with any number of different inputs,
+                        and each
+                        combination of model and input data is considered a test case.. A test case consists of
+                        <ul>
+                            <li>Some document on what the test is designed to test,
+                            <li>Human readible / end user visual representation of the decision: a screen shot at the
+                                minimum,
+                                <ul>
+                                    <li>a serialized DMN model,
+                                    <li>a serialized set of input data,</li>
+                                    <li>serialized set of output/response data.</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                    <li><strong>Availability</strong>: Test cases will be files that can be accessed freely by anyone
+                        using a creative
+                        commons Share-Alike-With-Attribution license.</li>
+                    <li><strong>Conformance</strong>: Test cases will be associated to specific elements of the spec so
+                        it is clear what
+                        aspect of conformance is being tested.</li>
+                    <li><strong>Promotion</strong>: We will promote the tests in order to assure that potential users of
+                        DMN are aware.
+                    </li>
+                    <li><strong>Completeness</strong>: we will aim to test all aspects of conformance level 3.</li>
+                    <li><strong>Uniformity</strong>: We will strive to eliminate contradictory tests. That is, if there
+                        is a test which
+                        according to two different parts of the spec would produce two different outputs, then the
+                        correct test output will be chosen so that a single consistent implementation might generate all
+                        the test responses.</li>
+                </ul>
+                To be clear, there are several things that are not the goals of this group
+                <ul>
+                    <li>We will not be involved in defining or extending the DMN specification -- this is the job of the
+                        OMG
+                        committee.</li>
+                    <li>We will focus on concrete input and output examples. We will avoid general discussion about what
+                        should
+                        and should not generally be true.</li>
+                    <li>We will include only test cases that are known to pass on at least one implementation.
+                        <del>Caveat:
+                            at the
+                            current</del> at the very beginning of this project, there were no known implementations at
+                        conformance level
+                        3, so necessarily there has been tests that no implementation could run, but once CL3 has been
+                        attained
+                        it will not be our practice to invent new, far-reaching tests for abstract situations.
+                    </li>
+                    <li>We will strive to get close to the spec, but if parts of the spec prove impossible to implement,
+                        we will
+                        not get involved correcting the specification.</li>
+                    <li>Similarly, we strive to implement as much of the spec as possible, but if the spec is too
+                        expansive we
+                        may limit the scope to a subset that we all agree upon.</li>
+                    <li>If the spec is ambiguous, we will make an interpretation of the spec according to what can
+                        actually be
+                        realized in running code, document that, and remain consistent to that in the future.</li>
+                </ul>
+                Reasons to be interested in this community-led project:
+                <ul>
+                    <li>A way for Vendors to <strong>demonstrate</strong> their compliance to the Standard</li>
+                    <li>Provide files to <strong>help</strong> Vendors test for error and become compliant</li>
+                    <li>A way for Customers and Users to <strong>assess</strong> how compliant a Vendor is</li>
+                </ul>
+                </p>
+            </div>
+            <div class="row">
+                <h2>Some DMN TCK presentations
+                </h2>
+                <p>
+                <ul>
+                    <li>Keith Swenson: Close is not Close Enough (<a
+                            href="https://decisioncamp2019.wordpress.com/program/#KeithSwenson">DecisionCamp 2019</a>)
+                    </li>
+                    <li>Keith Swenson: DMN TCK Working Group (<a
+                            href="https://www.youtube.com/watch?v=75fk-i3K9U0)">bpmNEXT 2019</a>)</li>
+                    <li>Matteo Mortari: Introduction and Updates on DMN TCK (<a
+                            href="https://decisioncamp2018.wordpress.com/program/#DMNTCK">DecisionCamp 2018</a>)</li>
+                    <li>Keith Swenson: DMN Technology Compatiability Toolkit (TCK) (<a
+                            href="https://www.youtube.com/watch?v=MqSbBtY2dKQ">bpmNEXT 2018</a>)</li>
+                    <li>Keith Swenson: Making the Standard Real: The DMN TCK (<a
+                            href="https://www.youtube.com/watch?v=M8goCq72lbo">bpmNEXT 2017</a>)</li>
+                </ul>
+                </p>
+            </div>
+        </div>
+
+        <#include "footer.ftl">
+
+    </div>
+</body>
+
+</html>

--- a/runners/dmn-tck-reporter/src/main/resources/templates/detail.ftl
+++ b/runners/dmn-tck-reporter/src/main/resources/templates/detail.ftl
@@ -62,6 +62,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>

--- a/runners/dmn-tck-reporter/src/main/resources/templates/glossary.ftl
+++ b/runners/dmn-tck-reporter/src/main/resources/templates/glossary.ftl
@@ -53,6 +53,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>

--- a/runners/dmn-tck-reporter/src/main/resources/templates/index.ftl
+++ b/runners/dmn-tck-reporter/src/main/resources/templates/index.ftl
@@ -118,6 +118,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>

--- a/runners/dmn-tck-reporter/src/main/resources/templates/overview.ftl
+++ b/runners/dmn-tck-reporter/src/main/resources/templates/overview.ftl
@@ -68,6 +68,9 @@
                     <li>
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>

--- a/runners/dmn-tck-reporter/src/main/resources/templates/tests.ftl
+++ b/runners/dmn-tck-reporter/src/main/resources/templates/tests.ftl
@@ -53,6 +53,9 @@
                     <li class="active">
                         <a href="tests.html">Tests</a>
                     </li>
+                    <li>
+                        <a href="about.html">About</a>
+                    </li>
 
                 </ul>
             </div>


### PR DESCRIPTION
(had inadvertently touched the Return key too soon).

This updates this repo README.md and creates a website About page with aligned information.
I seized the chance to implement suggestion from Denis and James, incorporating materials also from past TCK presentations at various conferences like Keith, in order to valorise all contributions as possible.

example:
![image](https://user-images.githubusercontent.com/1699252/136030382-eedb25ad-ad69-4bda-9548-c5d26c6f5fdd.png)

The website is refreshed to give opportunity to share the about.html link.