### PR TITLE
test(feel): verify non-existing member access

### DIFF
--- a/TestCases/compliance-level-3/0057-feel-context/0057-feel-context-test-01.xml
+++ b/TestCases/compliance-level-3/0057-feel-context/0057-feel-context-test-01.xml
@@ -127,4 +127,13 @@
         </resultNode>
     </testCase>
 
+    <testCase id="009">
+        <description>non-existing member access results in null</description>
+        <resultNode name="decision009" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
 </testCases>

--- a/TestCases/compliance-level-3/0057-feel-context/0057-feel-context-test-01.xml
+++ b/TestCases/compliance-level-3/0057-feel-context/0057-feel-context-test-01.xml
@@ -136,4 +136,13 @@
         </resultNode>
     </testCase>
 
+    <testCase id="010">
+        <description>non-existing member access (on null)</description>
+        <resultNode errorResult="true" name="decision010" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
 </testCases>

--- a/TestCases/compliance-level-3/0057-feel-context/0057-feel-context.dmn
+++ b/TestCases/compliance-level-3/0057-feel-context/0057-feel-context.dmn
@@ -72,5 +72,12 @@
         </literalExpression>
     </decision>
 
+    <decision name="decision010" id="_decision010">
+        <variable name="decision010"/>
+        <literalExpression>
+            <text>null.b</text>
+        </literalExpression>
+    </decision>
+
 </definitions>
 

--- a/TestCases/compliance-level-3/0057-feel-context/0057-feel-context.dmn
+++ b/TestCases/compliance-level-3/0057-feel-context/0057-feel-context.dmn
@@ -65,5 +65,12 @@
         </literalExpression>
     </decision>
 
+    <decision name="decision009" id="_decision009">
+        <variable name="decision009"/>
+        <literalExpression>
+            <text>{ a: 1 }.b</text>
+        </literalExpression>
+    </decision>
+
 </definitions>
 


### PR DESCRIPTION
Ensures the following is true:

```
{ a: 1 }.b = null

null.b = null
```

Related to https://github.com/dmn-tck/tck/issues/537