### PR TITLE
Add zeroes before decimal points

### DIFF
--- a/TestCases/compliance-level-3/0014-loan-comparison/0014-loan-comparison-test-01.xml
+++ b/TestCases/compliance-level-3/0014-loan-comparison/0014-loan-comparison-test-01.xml
@@ -29,7 +29,7 @@
 							<value xsi:type="xsd:string">Oceans Capital</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03500</value>
+							<value xsi:type="xsd:decimal">0.03500</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">0</value>
@@ -43,7 +43,7 @@
 							<value xsi:type="xsd:string">eClick Lending</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03200</value>
+							<value xsi:type="xsd:decimal">0.03200</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">1.1</value>
@@ -57,7 +57,7 @@
 							<value xsi:type="xsd:string">eClickLending</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03375</value>
+							<value xsi:type="xsd:decimal">0.03375</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">0.1</value>
@@ -71,7 +71,7 @@
 							<value xsi:type="xsd:string">AimLoan</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03000</value>
+							<value xsi:type="xsd:decimal">0.03000</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">1.1</value>
@@ -85,7 +85,7 @@
 							<value xsi:type="xsd:string">Home Loans Today</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03125</value>
+							<value xsi:type="xsd:decimal">0.03125</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">1.1</value>
@@ -99,7 +99,7 @@
 							<value xsi:type="xsd:string">Sebonic</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03125</value>
+							<value xsi:type="xsd:decimal">0.03125</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">0.1</value>
@@ -113,7 +113,7 @@
 							<value xsi:type="xsd:string">AimLoan</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03125</value>
+							<value xsi:type="xsd:decimal">0.03125</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">0.1</value>
@@ -127,7 +127,7 @@
 							<value xsi:type="xsd:string">eRates Mortgage</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03125</value>
+							<value xsi:type="xsd:decimal">0.03125</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">1.1</value>
@@ -141,7 +141,7 @@
 							<value xsi:type="xsd:string">Home Loans Today</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03250</value>
+							<value xsi:type="xsd:decimal">0.03250</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">0.1</value>
@@ -155,7 +155,7 @@
 							<value xsi:type="xsd:string">AimLoan</value>
 						</component>
 						<component name="rate">
-							<value xsi:type="xsd:decimal">.03250</value>
+							<value xsi:type="xsd:decimal">0.03250</value>
 						</component>
 						<component name="points">
 							<value xsi:type="xsd:decimal">0</value>
@@ -176,7 +176,7 @@
 								<value xsi:type="xsd:string">Oceans Capital</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03500</value>
+								<value xsi:type="xsd:decimal">0.03500</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -202,7 +202,7 @@
 								<value xsi:type="xsd:string">eClick Lending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03200</value>
+								<value xsi:type="xsd:decimal">0.03200</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -228,7 +228,7 @@
 								<value xsi:type="xsd:string">eClickLending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03375</value>
+								<value xsi:type="xsd:decimal">0.03375</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -254,7 +254,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03000</value>
+								<value xsi:type="xsd:decimal">0.03000</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -280,7 +280,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -306,7 +306,7 @@
 								<value xsi:type="xsd:string">Sebonic</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -332,7 +332,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -358,7 +358,7 @@
 								<value xsi:type="xsd:string">eRates Mortgage</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -384,7 +384,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -410,7 +410,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -440,7 +440,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03000</value>
+								<value xsi:type="xsd:decimal">0.03000</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -466,7 +466,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -492,7 +492,7 @@
 								<value xsi:type="xsd:string">Sebonic</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -518,7 +518,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -544,7 +544,7 @@
 								<value xsi:type="xsd:string">eRates Mortgage</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -570,7 +570,7 @@
 								<value xsi:type="xsd:string">eClick Lending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03200</value>
+								<value xsi:type="xsd:decimal">0.03200</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -596,7 +596,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -622,7 +622,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -648,7 +648,7 @@
 								<value xsi:type="xsd:string">eClickLending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03375</value>
+								<value xsi:type="xsd:decimal">0.03375</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -674,7 +674,7 @@
 								<value xsi:type="xsd:string">Oceans Capital</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03500</value>
+								<value xsi:type="xsd:decimal">0.03500</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -704,7 +704,7 @@
 								<value xsi:type="xsd:string">Oceans Capital</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03500</value>
+								<value xsi:type="xsd:decimal">0.03500</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -730,7 +730,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -756,7 +756,7 @@
 								<value xsi:type="xsd:string">eClickLending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03375</value>
+								<value xsi:type="xsd:decimal">0.03375</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -782,7 +782,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -808,7 +808,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -834,7 +834,7 @@
 								<value xsi:type="xsd:string">Sebonic</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -860,7 +860,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -886,7 +886,7 @@
 								<value xsi:type="xsd:string">eRates Mortgage</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -912,7 +912,7 @@
 								<value xsi:type="xsd:string">eClick Lending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03200</value>
+								<value xsi:type="xsd:decimal">0.03200</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -938,7 +938,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03000</value>
+								<value xsi:type="xsd:decimal">0.03000</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -968,7 +968,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03000</value>
+								<value xsi:type="xsd:decimal">0.03000</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -994,7 +994,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -1020,7 +1020,7 @@
 								<value xsi:type="xsd:string">Sebonic</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -1046,7 +1046,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -1072,7 +1072,7 @@
 								<value xsi:type="xsd:string">eRates Mortgage</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -1098,7 +1098,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -1124,7 +1124,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -1150,7 +1150,7 @@
 								<value xsi:type="xsd:string">eClick Lending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03200</value>
+								<value xsi:type="xsd:decimal">0.03200</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -1176,7 +1176,7 @@
 								<value xsi:type="xsd:string">eClickLending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03375</value>
+								<value xsi:type="xsd:decimal">0.03375</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -1202,7 +1202,7 @@
 								<value xsi:type="xsd:string">Oceans Capital</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03500</value>
+								<value xsi:type="xsd:decimal">0.03500</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -1232,7 +1232,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -1258,7 +1258,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03250</value>
+								<value xsi:type="xsd:decimal">0.03250</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -1284,7 +1284,7 @@
 								<value xsi:type="xsd:string">Oceans Capital</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03500</value>
+								<value xsi:type="xsd:decimal">0.03500</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0</value>
@@ -1310,7 +1310,7 @@
 								<value xsi:type="xsd:string">eClickLending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03375</value>
+								<value xsi:type="xsd:decimal">0.03375</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -1336,7 +1336,7 @@
 								<value xsi:type="xsd:string">Home Loans Today</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -1362,7 +1362,7 @@
 								<value xsi:type="xsd:string">Sebonic</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -1388,7 +1388,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">0.1</value>
@@ -1414,7 +1414,7 @@
 								<value xsi:type="xsd:string">eRates Mortgage</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03125</value>
+								<value xsi:type="xsd:decimal">0.03125</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -1440,7 +1440,7 @@
 								<value xsi:type="xsd:string">AimLoan</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03000</value>
+								<value xsi:type="xsd:decimal">0.03000</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>
@@ -1466,7 +1466,7 @@
 								<value xsi:type="xsd:string">eClick Lending</value>
 							</component>
 							<component name="rate">
-								<value xsi:type="xsd:decimal">.03200</value>
+								<value xsi:type="xsd:decimal">0.03200</value>
 							</component>
 							<component name="points">
 								<value xsi:type="xsd:decimal">1.1</value>


### PR DESCRIPTION
# Add zero before decimal point

## Motivation for a change

### Reason 1 (general)
Omitting leading zeros for type **xsd:decimal** is correct, but not for FEEL **number** when converted to string.

### Reason 2 (DMNTK specific)
Test runner for DMNTK validates both, the returned value **and** the string representation of this value, so this test file must be tweaked after each update from master TCK repository to make the test passing.

## Change proposal
Add leading zeroes to expected decimal values for rates in test file.

## Change risks
I guess that other runners validate only the value, so nothing should change for them. When loading decimal value without leading zero in Java works, then loading the same value with a leading zero should make no harm.

Please share your thoughts ;-), comments welcome!