### PR TITLE
Invalid model.  Variable names must match the decision name.  Fixing …

### DIFF
--- a/TestCases/compliance-level-3/1131-feel-function-invocation/1131-feel-function-invocation.dmn
+++ b/TestCases/compliance-level-3/1131-feel-function-invocation/1131-feel-function-invocation.dmn
@@ -3,56 +3,56 @@
     <description>FEEL function invocation</description>
     <decision name="decision001" id="_decision001">
         <description>Tests invocation of non-existing function</description>
-        <variable name="decision_001"/>
+        <variable name="decision001"/>
         <literalExpression>
             <text>non_existing_function()</text>
         </literalExpression>
     </decision>
     <decision name="decision002" id="_decision002">
         <description>Tests invocation of null</description>
-        <variable name="decision_002"/>
+        <variable name="decision002"/>
         <literalExpression>
             <text>null()</text>
         </literalExpression>
     </decision>
     <decision name="decision003" id="_decision003">
         <description>Tests invocation of string</description>
-        <variable name="decision_003"/>
+        <variable name="decision003"/>
         <literalExpression>
             <text>"some_func"()</text>
         </literalExpression>
     </decision>
     <decision name="decision004" id="_decision004">
         <description>Tests invocation of string (name of function)</description>
-        <variable name="decision_004"/>
+        <variable name="decision004"/>
         <literalExpression>
             <text>"abs"(-1)</text>
         </literalExpression>
     </decision>
     <decision name="decision005" id="_decision005">
         <description>Tests invocation of date</description>
-        <variable name="decision_005"/>
+        <variable name="decision005"/>
         <literalExpression>
             <text>@"2023-11-11"()</text>
         </literalExpression>
     </decision>
     <decision name="decision006" id="_decision006">
         <description>Tests invocation of number</description>
-        <variable name="decision_006"/>
+        <variable name="decision006"/>
         <literalExpression>
             <text>123()</text>
         </literalExpression>
     </decision>
     <decision name="decision007" id="_decision007">
         <description>Tests invocation of true</description>
-        <variable name="decision_007"/>
+        <variable name="decision007"/>
         <literalExpression>
             <text>true()</text>
         </literalExpression>
     </decision>
     <decision name="decision008" id="_decision008">
         <description>Tests invocation of false</description>
-        <variable name="decision_008"/>
+        <variable name="decision008"/>
         <literalExpression>
             <text>false()</text>
         </literalExpression>


### PR DESCRIPTION
just changing the names on the decision variables to match the decision names.  Otherwise, it is not a valid model.