### PR TITLE
Add 'namespace' attribute to disambiguate the DRGElement references

### DIFF
--- a/TestCases/testCases.xsd
+++ b/TestCases/testCases.xsd
@@ -28,6 +28,7 @@
 									<xs:complexContent>
 										<xs:extension base="valueType">
 											<xs:attribute name="name" use="required"/>
+											<xs:attribute name="namespace" type="xs:string" use="optional"/>
 										</xs:extension>
 									</xs:complexContent>
 								</xs:complexType>
@@ -40,6 +41,7 @@
 									</xs:sequence>
 									<xs:attribute name="errorResult" type="xs:boolean" default="false"/>
 									<xs:attribute name="name" use="required"/>
+									<xs:attribute name="namespace" type="xs:string" use="optional"/>
 									<xs:attribute name="type" type="xs:string"/>
 									<xs:attribute name="cast" type="xs:string"/>
 								</xs:complexType>
@@ -56,10 +58,12 @@
 						<xs:attribute name="type" type="testCaseType" default="decision"/>
 						<xs:attribute name="invocableName" type="xs:string"/> <!-- if type==decisionService, this attribute will point at which DS to invoke. -->
 						<xs:attribute name="name" type="xs:string"/>
+						<xs:attribute name="namespace" type="xs:string" use="optional"/>
 						<xs:anyAttribute namespace="##other" processContents="lax"/>
 					</xs:complexType>
 				</xs:element>
 			</xs:sequence>
+			<xs:attribute name="namespace" type="xs:string" use="optional"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:complexType name="valueType">


### PR DESCRIPTION
The following attributes are added:
- TestCases.namespace - default namespace for all DRGElements referenced in the test file
- TestCase.namespace - default namespace for all DRGElements referenced in the test case
- InputNode.namespace - namespace for the DRGElement  referenced in the InputNode
- ResultNode.namespace - namespace for the DRGElement referenced in the ResultNode

The namespace defined at lower levels (e.g. InputNode) takes precedence over the ones defined at the higher levels (e.g. TestCases)