### PR TITLE
DMN 1.5 - 1156-range-function

### DIFF
--- a/TestCases/compliance-level-3/1156-range-function/1156-range-function-test-01.xml
+++ b/TestCases/compliance-level-3/1156-range-function/1156-range-function-test-01.xml
@@ -469,8 +469,8 @@
     </testCase>
 
     <testCase id="019_a">
-        <!-- 10.3.2.7 Ranges  "endpoints must be of equivalent types" -->
-        <description>date and date and time end points are not equivalent and give null</description>
+        <!-- 10.3.2.7 Ranges "endpoints must be of equivalent types" -->
+        <description>date and date and time end points are not equivalent and gives null</description>
         <resultNode name="decision019_a" type="decision" errorResult="true">
             <expected>
                 <value xsi:nil="true"/>
@@ -480,8 +480,80 @@
 
     <testCase id="019_b">
         <!-- 10.3.2.7 Ranges  "endpoints must be of equivalent types" -->
-        <description>date and date and time end points are not equivalent and give null</description>
+        <description>date and date and time end points are not equivalent and gives null</description>
         <resultNode name="decision019_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="020">
+        <description>descending numeric range gives null</description>
+        <resultNode name="decision020" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="021">
+        <description>descending date range gives null</description>
+        <resultNode name="decision021" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="022">
+        <description>descending date time range gives null</description>
+        <resultNode name="decision022" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="023">
+        <description>descending string range gives null</description>
+        <resultNode name="decision023" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="024">
+        <description>descending date duration range gives null</description>
+        <resultNode name="decision024" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="025">
+        <description>descending year duration range gives null</description>
+        <resultNode name="decision025" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="026">
+        <description>descending time range gives null</description>
+        <resultNode name="decision026" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="027">
+        <description>both null endpoints gives null</description>
+        <resultNode name="decision027" type="decision" errorResult="true">
             <expected>
                 <value xsi:nil="true"/>
             </expected>

--- a/TestCases/compliance-level-3/1156-range-function/1156-range-function-test-01.xml
+++ b/TestCases/compliance-level-3/1156-range-function/1156-range-function-test-01.xml
@@ -1,0 +1,493 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1156-range-function.dmn</modelName>
+
+    <testCase id="001">
+        <description>Sanity check something is in range</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="001_a">
+        <description>range(number) instance of range&lt;number&gt;</description>
+        <resultNode name="decision001_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="001_b">
+        <description>range(number) instance of range&lt;number&gt;</description>
+        <resultNode name="decision001_b" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="001_c">
+        <description>range(string) instance of range&lt;string&gt;</description>
+        <resultNode name="decision001_c" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="001_d">
+        <description>range(date) instance of range&lt;date&gt;</description>
+        <resultNode name="decision001_d" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="001_e">
+        <description>range(date and time) instance of range&lt;date and time&gt;</description>
+        <resultNode name="decision001_e" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="001_g">
+        <description>range(time) instance of range&lt;time&gt;</description>
+        <resultNode name="decision001_g" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="001_h">
+        <description>range(days and time duration) instance of range&lt;days and time duration&gt;</description>
+        <resultNode name="decision001_h" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="001_i">
+        <description>range(years and months duration) instance of range&lt;years and months duration&gt;</description>
+        <resultNode name="decision001_i" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>Foo</description>
+        <resultNode name="decision002" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003_a">
+        <description>range() function result equals FEEL range: [..]</description>
+        <resultNode name="decision003_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003_b">
+        <description>range() function result equals FEEL range: (..]</description>
+        <resultNode name="decision003_b" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003_c">
+        <description>range() function result equals FEEL range: ]..]</description>
+        <resultNode name="decision003_c" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003_d">
+        <description>range() function result equals FEEL range: [..)</description>
+        <resultNode name="decision003_d" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003_e">
+        <description>range() function result equals FEEL range: [..[</description>
+        <resultNode name="decision003_e" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_a">
+        <description>closed start endpoint with value and open endpoint with no value is valid and is unary GE equivalent </description>
+        <resultNode name="decision004_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_b">
+        <description>open start endpoint with value and open endpoint with no value is valid and is unary GT equivalent</description>
+        <resultNode name="decision004_b" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_c">
+        <description>open start endpoint with no value and closed endpoint with value is valid and is unary LE equivalent</description>
+        <resultNode name="decision004_c" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_d">
+        <description>closed start endpoint with no value and open endpoint with value is valid and is LT equivalent </description>
+        <resultNode name="decision004_d" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_e">
+        <description>closed start endpoint with no value is not valid and gives null</description>
+        <resultNode name="decision004_e" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_f">
+        <description>closed end endpoint with no value is not valid and gives null</description>
+        <resultNode name="decision004_f" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005_a">
+        <description>range(string) function equals a unary FEEL range: string </description>
+        <resultNode name="decision005_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005_b">
+        <description>range(date) function equals a unary FEEL range: date </description>
+        <resultNode name="decision005_b" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005_c">
+        <description>range(date and time) function equals a unary FEEL range: date and time </description>
+        <resultNode name="decision005_c" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005_d">
+        <description>range(time) function equals a unary FEEL range: time </description>
+        <resultNode name="decision005_d" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005_e">
+        <description>range(days and time duration) function equals a unary FEEL range: days and time duration </description>
+        <resultNode name="decision005_e" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005_f">
+        <description>range(years and months duration) function equals a unary FEEL range: years and months duration </description>
+        <resultNode name="decision005_f" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="006">
+        <description>will ignore whitespace when parsing</description>
+        <resultNode name="decision006" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="007_a">
+        <description>use of date() function literal is permitted</description>
+        <resultNode name="decision007_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="007_b">
+        <description>use of date() function as non literal is not permitted and gives null</description>
+        <resultNode name="decision007_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="007_c">
+        <description>use of date() function as non literal is not permitted and gives null</description>
+        <inputNode name="input_001">
+            <value xsi:type="xsd:string">1970-01-01</value>
+        </inputNode>
+        <resultNode name="decision007_c" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="008_a">
+        <description>use of date and time() function literal is permitted</description>
+        <resultNode name="decision008_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="008_b">
+        <description>use of date and time() function as non literal is not permitted and gives null</description>
+        <resultNode name="decision008_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="008_c">
+        <description>use of date and time() function as non literal is not permitted and gives null</description>
+        <inputNode name="input_001">
+            <value xsi:type="xsd:string">1970-01-01T00:00:00</value>
+        </inputNode>
+        <resultNode name="decision008_c" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="009_a">
+        <description>use of time() function literal is permitted</description>
+        <resultNode name="decision009_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="009_b">
+        <description>use of time() function as non literal is not permitted and gives null</description>
+        <resultNode name="decision009_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="009_c">
+        <description>use of time() function as non literal is not permitted and gives null</description>
+        <inputNode name="input_001">
+            <value xsi:type="xsd:string">00:00:00</value>
+        </inputNode>
+        <resultNode name="decision009_c" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="010_a">
+        <description>use of duration() function literal is permitted</description>
+        <resultNode name="decision010_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="010_b">
+        <description>use of duration() function as non literal is not permitted and gives null</description>
+        <resultNode name="decision010_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="010_c">
+        <description>use of duration() function as non literal is not permitted and gives null</description>
+        <inputNode name="input_001">
+            <value xsi:type="xsd:string">P1D</value>
+        </inputNode>
+        <resultNode name="decision010_c" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="011">
+        <description>named argument</description>
+        <resultNode name="decision011" type="decision">
+            <expected>
+                <value xsi:type="xsd:boolean">true</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="012">
+        <description>invalidly named argument gives null</description>
+        <resultNode name="decision012" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="013_a">
+        <description>too many arguments gives null</description>
+        <resultNode name="decision013_a" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="013_b">
+        <description>too few arguments gives null</description>
+        <resultNode name="decision013_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="014">
+        <description>invalid argument type gives null</description>
+        <resultNode name="decision014" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="015_a">
+        <description>empty string gives null</description>
+        <resultNode name="decision015_a" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="015_b">
+        <description>whitespace only gives null</description>
+        <resultNode name="decision015_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="016">
+        <description>non-literal argument providing invalid range string gives null</description>
+        <resultNode name="decision016" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="017">
+        <description>a unary range is not a valid literal range string and gives null</description>
+        <resultNode name="decision017" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="018">
+        <description>mismatching endpoint types gives null</description>
+        <resultNode name="decision018" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="019_a">
+        <!-- 10.3.2.7 Ranges  "endpoints must be of equivalent types" -->
+        <description>date and date and time end points are not equivalent and give null</description>
+        <resultNode name="decision019_a" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="019_b">
+        <!-- 10.3.2.7 Ranges  "endpoints must be of equivalent types" -->
+        <description>date and date and time end points are not equivalent and give null</description>
+        <resultNode name="decision019_b" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1156-range-function/1156-range-function-test-01.xml
+++ b/TestCases/compliance-level-3/1156-range-function/1156-range-function-test-01.xml
@@ -141,42 +141,6 @@
         </resultNode>
     </testCase>
 
-    <testCase id="004_a">
-        <description>closed start endpoint with value and open endpoint with no value is valid and is unary GE equivalent </description>
-        <resultNode name="decision004_a" type="decision">
-            <expected>
-                <value xsi:type="xsd:boolean">true</value>
-            </expected>
-        </resultNode>
-    </testCase>
-
-    <testCase id="004_b">
-        <description>open start endpoint with value and open endpoint with no value is valid and is unary GT equivalent</description>
-        <resultNode name="decision004_b" type="decision">
-            <expected>
-                <value xsi:type="xsd:boolean">true</value>
-            </expected>
-        </resultNode>
-    </testCase>
-
-    <testCase id="004_c">
-        <description>open start endpoint with no value and closed endpoint with value is valid and is unary LE equivalent</description>
-        <resultNode name="decision004_c" type="decision">
-            <expected>
-                <value xsi:type="xsd:boolean">true</value>
-            </expected>
-        </resultNode>
-    </testCase>
-
-    <testCase id="004_d">
-        <description>closed start endpoint with no value and open endpoint with value is valid and is LT equivalent </description>
-        <resultNode name="decision004_d" type="decision">
-            <expected>
-                <value xsi:type="xsd:boolean">true</value>
-            </expected>
-        </resultNode>
-    </testCase>
-
     <testCase id="004_e">
         <description>closed start endpoint with no value is not valid and gives null</description>
         <resultNode name="decision004_e" type="decision" errorResult="true">

--- a/TestCases/compliance-level-3/1156-range-function/1156-range-function-test-01.xml
+++ b/TestCases/compliance-level-3/1156-range-function/1156-range-function-test-01.xml
@@ -88,7 +88,7 @@
     </testCase>
 
     <testCase id="002">
-        <description>Foo</description>
+        <description>sanity check using a non-literal string expression </description>
         <resultNode name="decision002" type="decision">
             <expected>
                 <value xsi:type="xsd:boolean">true</value>

--- a/TestCases/compliance-level-3/1156-range-function/1156-range-function.dmn
+++ b/TestCases/compliance-level-3/1156-range-function/1156-range-function.dmn
@@ -131,38 +131,6 @@
         </literalExpression>
     </decision>
 
-    <decision name="decision004_a" id="_decision004_a">
-        <!-- closed start endpoint with value and open endpoint with no value is valid and is unary GE equivalent -->
-        <variable name="decision004_a"/>
-        <literalExpression>
-            <text>range("[2..)") = >=2</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="decision004_b" id="_decision004_b">
-        <!-- open start endpoint with value and open endpoint with no value is valid and is unary GT equivalent -->
-        <variable name="decision004_b"/>
-        <literalExpression>
-            <text>range("(2..)") = >2</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="decision004_c" id="_decision004_c">
-        <!-- open start endpoint with no value and closed endpoint with value is valid and is unary LE equivalent -->
-        <variable name="decision004_c"/>
-        <literalExpression>
-            <text>range("(..2]") = &lt;=2</text>
-        </literalExpression>
-    </decision>
-
-    <decision name="decision004_d" id="_decision004_d">
-        <!-- closed start endpoint with no value and open endpoint with value is valid and is LT equivalent -->
-        <variable name="decision004_d"/>
-        <literalExpression>
-            <text>range("(..2)") = &lt;2</text>
-        </literalExpression>
-    </decision>
-
     <decision name="decision004_e" id="_decision004_e">
         <!-- closed start endpoint with no value is not valid and gives null -->
         <variable name="decision004_e"/>

--- a/TestCases/compliance-level-3/1156-range-function/1156-range-function.dmn
+++ b/TestCases/compliance-level-3/1156-range-function/1156-range-function.dmn
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1156-range-function"
+             name="1156-range-function"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <description>FEEL built-in function 'range(string)' in category conversion functions</description>
+
+    <inputData name="input_001" id="_input_001">
+        <variable name="input_001" typeRef="string"/>
+    </inputData>
+
+    <decision name="decision001" id="_decision001">
+        <!-- basic sanity check to ensure it is operating as a range -->
+        <variable name="decision001"/>
+        <literalExpression>
+            <text>2 in range("[1..3]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision001_a" id="_decision001_a">
+        <!-- will parse and have the correct type for number -->
+        <variable name="decision001_a"/>
+        <literalExpression>
+            <text>range("[1..3]") instance of range&lt;number&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision001_b" id="_decision001_b">
+        <!-- will parse and have the correct type for number (using non-literal) -->
+        <variable name="decision001_b"/>
+        <literalExpression>
+            <text>range(string("[1..3]")) instance of range&lt;number&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision001_c" id="_decision001_c">
+        <!-- will parse and have the correct type for string -->
+        <variable name="decision001_c"/>
+        <literalExpression>
+            <text>range("[\"a\"..\"c\"]") instance of range&lt;string&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision001_d" id="_decision001_d">
+        <!-- will parse and have the correct type for date -->
+        <variable name="decision001_d"/>
+        <literalExpression>
+            <text>range("[@\"1970-01-01\"..@\"1970-01-02\"]") instance of range&lt;date&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision001_e" id="_decision001_e">
+        <!-- will parse and have the correct type for date and time -->
+        <variable name="decision001_e"/>
+        <literalExpression>
+            <text>range("[@\"1970-01-01T00:00:00\"..@\"1970-01-02T00:00:00\"]") instance of range&lt;date and time&gt;
+            </text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision001_g" id="_decision001_g">
+        <!-- will parse and have the correct type for time -->
+        <variable name="decision001_g"/>
+        <literalExpression>
+            <text>range("[@\"00:00:00\"..@\"00:00:00\"]") instance of range&lt;time&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision001_h" id="_decision001_h">
+        <!-- will parse and have the correct type for days and time duration -->
+        <variable name="decision001_h"/>
+        <literalExpression>
+            <text>range("[@\"P1D\"..@\"P2D\"]") instance of range&lt;days and time duration&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision001_i" id="_decision001_i">
+        <!-- will parse and have the correct type for years and months duration -->
+        <variable name="decision001_i"/>
+        <literalExpression>
+            <text>range("[@\"P1Y\"..@\"P2Y\"]") instance of range&lt;years and months duration&gt;</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision002" id="_decision002">
+        <!-- basic sanity check to ensure it is operating as a range using non-literal-->
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>2 in range(string("[1..3]"))</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003_a" id="_decision003_a">
+        <!-- parsed range is equal to literal range -->
+        <variable name="decision003_a"/>
+        <literalExpression>
+            <text>range("[18..21]") = [18..21]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003_b" id="_decision003_b">
+        <!-- parsed range endpoint inclusivity is equal to literal range -->
+        <variable name="decision003_b"/>
+        <literalExpression>
+            <text>range("(18..21]") = (18..21]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003_c" id="_decision003_c">
+        <!-- parsed range endpoint inclusivity is equal to literal range -->
+        <variable name="decision003_c"/>
+        <literalExpression>
+            <text>range("]18..21]") = ]18..21]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003_d" id="_decision003_d">
+        <!-- parsed range endpoint inclusivity is equal to literal range -->
+        <variable name="decision003_d"/>
+        <literalExpression>
+            <text>range("[18..21)") = [18..21)</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003_e" id="_decision003_e">
+        <!-- parsed range endpoint inclusivity is equal to literal range -->
+        <variable name="decision003_e"/>
+        <literalExpression>
+            <text>range("[18..21[") = [18..21[</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision004_a" id="_decision004_a">
+        <!-- closed start endpoint with value and open endpoint with no value is valid and is unary GE equivalent -->
+        <variable name="decision004_a"/>
+        <literalExpression>
+            <text>range("[2..)") = >=2</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision004_b" id="_decision004_b">
+        <!-- open start endpoint with value and open endpoint with no value is valid and is unary GT equivalent -->
+        <variable name="decision004_b"/>
+        <literalExpression>
+            <text>range("(2..)") = >2</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision004_c" id="_decision004_c">
+        <!-- open start endpoint with no value and closed endpoint with value is valid and is unary LE equivalent -->
+        <variable name="decision004_c"/>
+        <literalExpression>
+            <text>range("(..2]") = &lt;=2</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision004_d" id="_decision004_d">
+        <!-- closed start endpoint with no value and open endpoint with value is valid and is LT equivalent -->
+        <variable name="decision004_d"/>
+        <literalExpression>
+            <text>range("(..2)") = &lt;2</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision004_e" id="_decision004_e">
+        <!-- closed start endpoint with no value is not valid and gives null -->
+        <variable name="decision004_e"/>
+        <literalExpression>
+            <text>range("[..2]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision004_f" id="_decision004_f">
+        <!-- closed end endpoint with no value is not valid and gives null -->
+        <variable name="decision004_f"/>
+        <literalExpression>
+            <text>range("[1..]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision005_a" id="_decision005_a">
+        <!-- parsed string range is equal to literal range -->
+        <variable name="decision005_a"/>
+        <literalExpression>
+            <text>range("[\"a\"..\"c\"]") = ["a".."c"]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision005_b" id="_decision005_b">
+        <!-- parsed date range is equal to literal range -->
+        <variable name="decision005_b"/>
+        <literalExpression>
+            <text>range("[@\"1970-01-01\"..@\"1970-01-02\"]") = [@"1970-01-01"..@"1970-01-02"]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision005_c" id="_decision005_c">
+        <!-- parsed date and time range is equal to literal range -->
+        <variable name="decision005_c"/>
+        <literalExpression>
+            <text>range("[@\"1970-01-01T00:00:00\"..@\"1970-01-02T00:00:00\"]") =
+                [@"1970-01-01T00:00:00"..@"1970-01-02T00:00:00"]
+            </text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision005_d" id="_decision005_d">
+        <!-- parsed time range is equal to literal range -->
+        <variable name="decision005_d"/>
+        <literalExpression>
+            <text>range("[@\"00:00:00\"..@\"00:00:00\"]") = [@"00:00:00"..@"00:00:00"]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision005_e" id="_decision005_e">
+        <!-- parsed days/weeks duration range is equal to literal range -->
+        <variable name="decision005_e"/>
+        <literalExpression>
+            <text>range("[@\"P1D\"..@\"P2D\"]") = [@"P1D"..@"P2D"]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision005_f" id="_decision005_f">
+        <!-- parsed years/month duration range is equal to literal range -->
+        <variable name="decision005_f"/>
+        <literalExpression>
+            <text>range("[@\"P1Y\"..@\"P2Y\"]") = [@"P1Y"..@"P2Y"]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision006" id="_decision006">
+        <!-- will ignore whitespace when parsing -->
+        <variable name="decision006"/>
+        <literalExpression>
+            <text>range(" [ 1 .. 3 ] ") = [1..3]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision007_a" id="_decision007_a">
+        <!-- use of date() function literal is permitted -->
+        <variable name="decision007_a"/>
+        <literalExpression>
+            <text>range("[date(\"1970-01-01\")..date(\"1970-01-02\")]") = [date("1970-01-01")..date("1970-01-02")]
+            </text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision007_b" id="_decision007_b">
+        <!-- use of date() function as non literal is not permitted and gives null -->
+        <!-- the usage of string() here causes start endPoint to be non-literal -->
+        <variable name="decision007_b"/>
+        <literalExpression>
+            <text>range("[date(string(\"1970-01-01\"))..date(\"1970-01-02\")]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision007_c" id="_decision007_c">
+        <!-- use of date() function as non literal is not permitted and gives null -->
+        <!-- shows range literal using input data as argument to date() -->
+        <variable name="decision007_c"/>
+        <informationRequirement>
+            <requiredInput href="#_input_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>range("[date(input_001)..date(\"1970-01-02\")]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision008_a" id="_decision008_a">
+        <!-- use of date and time() function literal is permitted -->
+        <variable name="decision008_a"/>
+        <literalExpression>
+            <text>range("[date and time(\"1970-01-01T00:00:00\")..@\"1970-01-02T00:00:00\"]") =
+                [@"1970-01-01T00:00:00"..@"1970-01-02T00:00:00"]
+            </text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision008_b" id="_decision008_b">
+        <!-- use of date and time() function as non literal is not permitted and gives null -->
+        <!-- the usage of string() here causes start endPoint to be non-literal -->
+        <variable name="decision008_b"/>
+        <literalExpression>
+            <text>range("[date and time(string(\"1970-01-01T00:00:00\"))..@\"1970-01-02T00:00:00\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision008_c" id="_decision008_c">
+        <!-- use of date and time() function as non literal is not permitted and gives null -->
+        <!-- shows range literal using input data as argument to date and time() -->
+        <variable name="decision008_c"/>
+        <informationRequirement>
+            <requiredInput href="#_input_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>range("[date and time(input_001)..@\"1970-01-02T00:00:00\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision009_a" id="_decision009_a">
+        <!-- use of time() function literal is permitted -->
+        <variable name="decision009_a"/>
+        <literalExpression>
+            <text>range("[time(\"00:00:00\")..@\"00:00:00\"]") = [@"00:00:00"..@"00:00:00"]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision009_b" id="_decision009_b">
+        <!-- use of time() function as non literal is not permitted and gives null -->
+        <!-- the usage of string() here causes start endPoint to be non-literal -->
+        <variable name="decision009_b"/>
+        <literalExpression>
+            <text>range("[time(string(\"00:00:00\"))..@\"00:00:00\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision009_c" id="_decision009_c">
+        <!-- use of time() function as non literal is not permitted and gives null -->
+        <!-- shows range literal using input data as argument to time() -->
+        <variable name="decision009_c"/>
+        <informationRequirement>
+            <requiredInput href="#_input_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>range("[time(input_001)..@\"00:00:00\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision010_a" id="_decision010_a">
+        <!-- use of duration() function literal is permitted -->
+        <variable name="decision010_a"/>
+        <literalExpression>
+            <text>range("[duration(\"P1D\")..@\"P2D\"]") = [@"P1D"..@"P2D"]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision010_b" id="_decision010_b">
+        <!-- use of duration() function as non literal is not permitted and gives null-->
+        <!-- the usage of string() here causes start endPoint to be non-literal -->
+        <variable name="decision010_b"/>
+        <literalExpression>
+            <text>range("[duration(string(\"P1D\"))..@\"P2D\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision010_c" id="_decision010_c">
+        <!-- use of duration() function as non literal is not permitted and gives null-->
+        <!-- shows range literal using input data as argument to duration() -->
+        <variable name="decision010_c"/>
+        <informationRequirement>
+            <requiredInput href="#_input_001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>range("[duration(input_001)..@\"P2D\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision011" id="_decision011">
+        <!-- named argument -->
+        <variable name="decision011"/>
+        <literalExpression>
+            <text>range(from: "[1..3]") = [1..3]</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision012" id="_decision012">
+        <!-- invalidly named argument 'fron' gives null  -->
+        <variable name="decision012"/>
+        <literalExpression>
+            <text>range(fron: "[1..3]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision013_a" id="_decision013_a">
+        <!-- too many arguments gives null -->
+        <variable name="decision013_a"/>
+        <literalExpression>
+            <text>range("[1..3]", "foo")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision013_b" id="_decision013_b">
+        <!-- too few arguments gives null -->
+        <variable name="decision013_b"/>
+        <literalExpression>
+            <text>range()</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision014" id="_decision014">
+        <!-- invalid type gives null -->
+        <variable name="decision014"/>
+        <literalExpression>
+            <text>range([1..3])</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision015_a" id="_decision015_a">
+        <!-- empty string gives null -->
+        <variable name="decision015_a"/>
+        <literalExpression>
+            <text>range("")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision015_b" id="_decision015_b">
+        <!-- whitespace only gives null -->
+        <variable name="decision015_b"/>
+        <literalExpression>
+            <text>range(" ")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision016" id="_decision016">
+        <!-- non-literal argument provides invalid range string gives null -->
+        <variable name="decision016"/>
+        <literalExpression>
+            <text>range(string(""))</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision017" id="_decision017">
+        <!-- a unary range is not a valid literal range string -->
+        <variable name="decision017"/>
+        <literalExpression>
+            <text>range(">=10")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision018" id="_decision018">
+        <!-- mismatching endpoint types gives null -->
+        <variable name="decision018"/>
+        <literalExpression>
+            <text>range("[1..\"b\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision019_a" id="_decision019_sa">
+        <!-- date, and date and time end points are not equivalent and gives null -->
+        <variable name="decision019_a"/>
+        <literalExpression>
+            <text>range("[@\"1970-01-01\"..@\"1970-01-02T00:00:00\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision019_b" id="_decision019_b">
+        <!-- date, and date and time end points are not equivalent and gives null -->
+        <variable name="decision019_b"/>
+        <literalExpression>
+            <text>range("[@\"1970-01-01T00:00:00\"..@\"1970-01-02\"]")</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1156-range-function/1156-range-function.dmn
+++ b/TestCases/compliance-level-3/1156-range-function/1156-range-function.dmn
@@ -452,6 +452,71 @@
         </literalExpression>
     </decision>
 
+    <decision name="decision020" id="_decision020">
+        <!-- a descending numeric range gives null -->
+        <variable name="decision020"/>
+        <literalExpression>
+            <text>range("[3..1]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision021" id="_decision021">
+        <!-- a descending date range gives null -->
+        <variable name="decision021"/>
+        <literalExpression>
+            <text>range("[@\"1970-01-02\"..@\"1970-01-01\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision022" id="_decision022">
+        <!-- a descending date time range gives null -->
+        <variable name="decision022"/>
+        <literalExpression>
+            <text>range("[@\"1970-01-02T00:00:00\"..@\"1970-01-01T00:00:00\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision023" id="_decision023">
+        <!-- a descending string range gives null -->
+        <variable name="decision023"/>
+        <literalExpression>
+            <text>range("[\"z\"..\"a\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision024" id="_decision024">
+        <!-- a descending date duration range gives null -->
+        <variable name="decision024"/>
+        <literalExpression>
+            <text>range("[@\"P2D\"..@\"P1D\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision025" id="_decision025">
+        <!-- a descending years duration range gives null -->
+        <variable name="decision025"/>
+        <literalExpression>
+            <text>range("[@\"P2Y\"..@\"P1Y\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision026" id="_decision026">
+        <!-- a descending time range gives null -->
+        <variable name="decision026"/>
+        <literalExpression>
+            <text>range("[@\"02:00:00\"..@\"01:00:00\"]")</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision027" id="_decision027">
+        <!-- both null endpoints gives null -->
+        <variable name="decision027"/>
+        <literalExpression>
+            <text>range("[null..null]")</text>
+        </literalExpression>
+    </decision>
+
+
 
 </definitions>
 


### PR DESCRIPTION
The new range function gets exercised.  The spec is very specific about what can be passed to this function as a string.  These tests seek to cover all that.

Like:

* the grammar only permits literal as endpoints.  If permits function calls if they are the date/time literal functions.  Nothing else.  No build in functions, not any other function the returns a string/number/date/time/duration value.  Just literals and literal functions.

* The grammar only permits range expressions with a '..' in them .. so no unary style range like range("<10").  All grammar optional have a range start character, and a range end character.  But, under some circumstances either the start or the end endPoint may be omitted.

I understand there is a PR in already for the range function but (apols @SimonRinguette) I am throwing in these tests as they delve deeper into the permitted grammar, plus error conditions and named params and types.  

These tests only do some basic sanity checking on ranges and do not test range operation.  We have other tests for asserting range correctness.  Many of the tests here use equivalence to determine correctness - that is, if the parsed range is equal to a literal range with the same endpoints and inclusivity then it is the same so no range checking required.
