### PR TITLE
1157 unarytests decisiontable

### DIFF
--- a/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable-test-01.xml
+++ b/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable-test-01.xml
@@ -123,6 +123,17 @@
         </resultNode>
     </testCase>
 
+    <testCase id="008_b">
+        <!-- further to 008, an input expression of boolean "false" will not be satisfied against a rule
+         unary test of that evaluates to true -->
+        <description>input values: boolean expression is weird</description>
+        <resultNode name="decision008_b" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
     <testCase id="009">
         <description>output values: result satisfies output values</description>
         <resultNode name="decision009" type="decision">
@@ -201,6 +212,15 @@
         <resultNode name="decision016" type="decision">
             <expected>
                 <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="017">
+        <description>input values: ? used in expression outside of unary tests expressions</description>
+        <resultNode name="decision017" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable-test-01.xml
+++ b/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable-test-01.xml
@@ -71,7 +71,7 @@
     </testCase>
 
     <testCase id="006_b">
-        <description>input values: input expression is valid against input values - '?' inside literal string</description>
+        <description>input values: "?" symbol alone is not satisfied</description>
         <resultNode name="decision006_b" type="decision">
             <expected>
                 <value xsi:type="xsd:string">success</value>
@@ -80,7 +80,7 @@
     </testCase>
 
     <testCase id="006_c">
-        <description>input values: "?" symbol alone always is a match</description>
+        <description>input values: "?" symbol alone will be satisfied a true value</description>
         <resultNode name="decision006_c" type="decision">
             <expected>
                 <value xsi:type="xsd:string">success</value>
@@ -101,8 +101,8 @@
         <!-- "One of the expressions in the UnaryTests evaluates to true when the implicit value
         is applied to it." -->
         <!-- this test is to exercise the vagueness of 'applied to'.  One of the expressions is simply
-        "true".  Which, as an expression always evaluates to true.  So ... should match.  But, in practice,
-        the value of "false" applied against unary tests "("123", true)" should not match any of them.  My
+        "true".  Which, as an expression always evaluates to true.  So ... should satisfy.  But, in practice,
+        the value of "false" applied against unary tests "("123", true)" should not satisfy any of them.  My
         interpretation is that "applied to" is meant for unary comparisons. -->
         <description>input values: boolean expression is weird</description>
         <resultNode name="decision008" type="decision">
@@ -112,8 +112,19 @@
         </resultNode>
     </testCase>
 
+    <testCase id="008_a">
+        <!-- further to 008, an input expression of boolean "false" will not be satisfied against a rule
+         unary test of boolean constant "true"-->
+        <description>input values: boolean expression is weird</description>
+        <resultNode name="decision008_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
     <testCase id="009">
-        <description>output values: result matches output values</description>
+        <description>output values: result satisfies output values</description>
         <resultNode name="decision009" type="decision">
             <expected>
                 <value xsi:type="xsd:string">success</value>
@@ -122,7 +133,7 @@
     </testCase>
 
     <testCase id="010">
-        <description>output values: result does not matches output values</description>
+        <description>output values: result does not satisfy output values</description>
         <resultNode name="decision010" type="decision" errorResult="true">
             <expected>
                 <value xsi:nil="true"/>
@@ -149,7 +160,7 @@
     </testCase>
 
     <testCase id="013">
-        <description>output values: multiple columns - all match</description>
+        <description>output values: multiple columns - all satisfied</description>
         <resultNode name="decision013" type="decision">
             <expected>
                 <component name="col1">
@@ -163,7 +174,7 @@
     </testCase>
 
     <testCase id="014">
-        <description>output values: multiple columns - column mismatch</description>
+        <description>output values: multiple columns - column not satisfied</description>
         <resultNode name="decision014" type="decision">
             <expected>
                 <component name="col1">
@@ -177,7 +188,7 @@
     </testCase>
 
     <testCase id="015">
-        <description>output values: ? used in tests - match</description>
+        <description>output values: ? used in tests - satisfied</description>
         <resultNode name="decision015" type="decision">
             <expected>
                 <value xsi:type="xsd:string">foo</value>
@@ -186,7 +197,7 @@
     </testCase>
 
     <testCase id="016">
-        <description>output values: ? used in tests - mismatch</description>
+        <description>output values: ? used in tests - not satisfied</description>
         <resultNode name="decision016" type="decision">
             <expected>
                 <value xsi:nil="true"/>

--- a/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable-test-01.xml
+++ b/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable-test-01.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1157-unarytests-decisiontable.dmn</modelName>
+
+    <testCase id="001">
+        <description>input values: input expression is valid against input values - positive unary tests</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>input values: input expression is valid against input values - range</description>
+        <resultNode name="decision002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>input values: input expression is valid against input values - '-' char</description>
+        <resultNode name="decision003" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004">
+        <description>input values: input expression is valid against input values - negate using not()</description>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="005">
+        <description>input values: input expression is not valid against input values and will become null</description>
+        <resultNode name="decision005" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="006">
+        <description>input values: input expression is valid against input values - '?' symbol with built-in function</description>
+        <!-- also shows input values unary tests can call built-in functions -->
+        <resultNode name="decision006" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="006_a">
+        <description>input values: input expression is valid against input values - '?' inside literal string</description>
+        <resultNode name="decision006_a" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="006_b">
+        <description>input values: input expression is valid against input values - '?' inside literal string</description>
+        <resultNode name="decision006_b" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="006_c">
+        <description>input values: "?" symbol alone always is a match</description>
+        <resultNode name="decision006_c" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="007">
+        <description>input values: input expression is valid against input values - input values has no text</description>
+        <resultNode name="decision007" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="008">
+        <!-- "One of the expressions in the UnaryTests evaluates to true when the implicit value
+        is applied to it." -->
+        <!-- this test is to exercise the vagueness of 'applied to'.  One of the expressions is simply
+        "true".  Which, as an expression always evaluates to true.  So ... should match.  But, in practice,
+        the value of "false" applied against unary tests "("123", true)" should not match any of them.  My
+        interpretation is that "applied to" is meant for unary comparisons. -->
+        <description>input values: boolean expression is weird</description>
+        <resultNode name="decision008" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="009">
+        <description>output values: result matches output values</description>
+        <resultNode name="decision009" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="010">
+        <description>output values: result does not matches output values</description>
+        <resultNode name="decision010" type="decision" errorResult="true">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="011">
+        <description>output values: output values text may be empty</description>
+        <resultNode name="decision011" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="012">
+        <description>output values: output values text may be "-" char</description>
+        <resultNode name="decision012" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">success</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="013">
+        <description>output values: multiple columns - all match</description>
+        <resultNode name="decision013" type="decision">
+            <expected>
+                <component name="col1">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+                <component name="col2">
+                    <value xsi:type="xsd:string">bar</value>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="014">
+        <description>output values: multiple columns - column mismatch</description>
+        <resultNode name="decision014" type="decision">
+            <expected>
+                <component name="col1">
+                    <value xsi:type="xsd:string">foo</value>
+                </component>
+                <component name="col2">
+                    <value xsi:nil="true"/>
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="015">
+        <description>output values: ? used in tests - match</description>
+        <resultNode name="decision015" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">foo</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="016">
+        <description>output values: ? used in tests - mismatch</description>
+        <resultNode name="decision016" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable.dmn
+++ b/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable.dmn
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1157-unarytests-decisiontable"
+             name="1157-unarytests-decisiontable"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <description>UnaryTests for decision tables</description>
+
+    <!--
+        input expression against allow values pos, neg, and '-'
+    -->
+
+    <decision name="decision001" id="_decision001">
+        <!-- input expression is valid against input values - positive unary tests -->
+        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <variable name="decision001"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+                <inputValues>
+                    <text>123,456</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision002" id="_decision002">
+        <!-- input expression is valid against input values - range -->
+        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <variable name="decision002"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+                <inputValues>
+                    <text>[1..1000]</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <!-- input expression is valid against input values - '-' char -->
+        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <variable name="decision003"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+                <inputValues>
+                    <text>-</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision004" id="_decision004">
+        <!-- input expression is valid against input values - negation using not() -->
+        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <variable name="decision004"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+                <inputValues>
+                    <text>not(456,789)</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+
+    <decision name="decision005" id="_decision005">
+        <!-- input expression is not valid against input values and will become null -->
+        <!-- input expression 123 will not match unary tests and thus the rule for null will match -->
+        <variable name="decision005"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+                <inputValues>
+                    <text>not(123)</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>null</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision006" id="_decision006">
+        <!-- input expression is valid against input values - '?' symbol with built-in function-->
+        <!-- input expression "foo" will match unary tests and thus the rule for 123 will match -->
+        <variable name="decision006"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>"foo"</text>
+                </inputExpression>
+                <inputValues>
+                    <text>"bar", string length(?) = 3</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>"foo"</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision006_a" id="_decision006_a">
+        <!-- input expression is not valid against input values - '?' symbol inside literal string -->
+        <!-- in this case, the `string length("?") = 1` does evaluate to true, but, true !== "foo" and the
+        vagueness of "applied to" comes in - the expression "string length("?") = 1" does not use the
+        special char "?", not is it a unary comparison .. so it is a mismatch -->
+        <!-- input expression "foo" will not match unary tests and thus the rule for null will match -->
+        <variable name="decision006_a"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>"foo"</text>
+                </inputExpression>
+                <inputValues>
+                    <text>"bar", string length("?") = 1</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>null</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision006_b" id="_decision006_b">
+        <!-- input expression is not valid against input values - '?' symbol inside literal string -->
+        <!-- in this case, the `string length("?") = 1` does evaluate to true, but, true !== "foo" so
+        it is a mismatch -->
+        <!-- input expression 123 will not match unary tests and thus the rule for null will match -->
+        <variable name="decision006_b"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+                <inputValues>
+                    <text>?</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision006_c" id="_decision006_c">
+        <!-- '?' symbol  -->
+        <!-- input expression "foo" will match "?" and thus the rule for "123"" will match -->
+        <variable name="decision006_c"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>"foo"</text>
+                </inputExpression>
+                <inputValues>
+                    <text>?</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>"foo"</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision007" id="_decision007">
+        <!-- input expression is valid against input values - input value has no text-->
+        <!-- spec says text is optional -->
+        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <variable name="decision007"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+                <inputValues>
+                    <text></text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision008" id="_decision008">
+        <!-- Odd handling for boolean. 'true' is an expression. Unary tests permit expressions but
+         in this case the input expression false will not match unary tests and thus the
+         rule for null will match -->
+        <variable name="decision008"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>false</text>
+                </inputExpression>
+                <inputValues>
+                    <text>("123", true)</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>null</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision009" id="_decision009">
+        <!-- table result matches output values -->
+        <variable name="decision009"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+            </input>
+            <output>
+                <outputValues>
+                    <text>"success","failure"</text>
+                </outputValues>
+            </output>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision010" id="_decision010">
+        <!-- table result "foo" does not match output values "success" or "failure". Result
+        is null coerced -->
+        <variable name="decision010"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+            </input>
+            <output>
+                <outputValues>
+                    <text>"success","failure"</text>
+                </outputValues>
+            </output>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"foo"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision011" id="_decision011">
+        <!-- output values text may be empty -->
+        <variable name="decision011"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+            </input>
+            <output>
+                <outputValues>
+                    <text></text>
+                </outputValues>
+            </output>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision012" id="_decision012">
+        <!-- output values text may be '-' char -->
+        <variable name="decision012"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+            </input>
+            <output>
+                <outputValues>
+                    <text>-</text>
+                </outputValues>
+            </output>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision013" id="_decision013">
+        <!-- multiple output columns all match -->
+        <variable name="decision013"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+            </input>
+            <output name="col1">
+                <outputValues>
+                    <text>"foo", "bar"</text>
+                </outputValues>
+            </output>
+            <output name="col2">
+                <outputValues>
+                    <text>"foo", "bar"</text>
+                </outputValues>
+            </output>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"foo"</text>
+                </outputEntry>
+                <outputEntry>
+                    <text>"bar"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision014" id="_decision014">
+        <!-- multiple output columns - one column mismatch -->
+        <variable name="decision014"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+            </input>
+            <output name="col1">
+                <outputValues>
+                    <text>"foo", "bar"</text>
+                </outputValues>
+            </output>
+            <output name="col2">
+                <outputValues>
+                    <text>"foo", "bar"</text>
+                </outputValues>
+            </output>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"foo"</text>
+                </outputEntry>
+                <outputEntry>
+                    <text>"baz"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision015" id="_decision015">
+        <!-- ? used in output values - match -->
+        <variable name="decision015"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+            </input>
+            <output>
+                <outputValues>
+                    <text>string length(?) >= 3</text>
+                </outputValues>
+            </output>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"foo"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision016" id="_decision016">
+        <!-- ? used in output values - mismatch -->
+        <variable name="decision016"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+            </input>
+            <output>
+                <outputValues>
+                    <text>string length(?) >= 3</text>
+                </outputValues>
+            </output>
+            <rule>
+                <inputEntry>
+                    <text>123</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"a"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable.dmn
+++ b/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable.dmn
@@ -191,8 +191,7 @@
 
     <decision name="decision006_b" id="_decision006_b">
         <!-- '?' symbol  -->
-        <!-- input expression "foo" executed against "?" does not return true and thus the rule for null will be satisfied -->
-        <!-- spec states that an expression with "?" must return a boolean "true" for it to be satisfied -->
+        <!-- input expression "foo" executed against "?" does not return true but, does satisfy an equality check -->
         <variable name="decision006_b"/>
         <decisionTable>
             <input>
@@ -206,7 +205,7 @@
             <output/>
             <rule>
                 <inputEntry>
-                    <text>null</text>
+                    <text>"foo"</text>
                 </inputEntry>
                 <outputEntry>
                     <text>"success"</text>
@@ -233,6 +232,32 @@
             <rule>
                 <inputEntry>
                     <text>true</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision006_d" id="_decision006_d">
+        <!-- '?' symbol  -->
+        <!-- input expression `false` executed against "?" returns false and thus an equality check is satisfied -->
+        <!-- spec states that an expression with "?" must return a boolean "true" for it to be satisfied -->
+        <variable name="decision006_d"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>false</text>
+                </inputExpression>
+                <inputValues>
+                    <text>?</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>false</text>
                 </inputEntry>
                 <outputEntry>
                     <text>"success"</text>
@@ -316,6 +341,32 @@
             <rule>
                 <inputEntry>
                     <text>false</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision008_b" id="_decision008_b">
+        <!-- Odd handling for boolean. 'true' is an expression. Unary tests permit expressions but
+         in this case the input expression false will not satisfy unary tests and thus the
+         rule for null will be satisfied -->
+        <variable name="decision008_b"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>false</text>
+                </inputExpression>
+                <inputValues>
+                    <text>1==1</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>null</text>
                 </inputEntry>
                 <outputEntry>
                     <text>"success"</text>
@@ -524,18 +575,41 @@
                 <inputExpression>
                     <text>123</text>
                 </inputExpression>
-            </input>
-            <output>
-                <outputValues>
+                <inputValues>
                     <text>string length(?) >= 3</text>
-                </outputValues>
-            </output>
+                </inputValues>
+            </input>
+            <output/>
             <rule>
                 <inputEntry>
                     <text>123</text>
                 </inputEntry>
                 <outputEntry>
                     <text>"a"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision name="decision017" id="_decision017">
+        <!-- ? is used in an expression, but is not one of the unary tests expressions -->
+        <variable name="decision017"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>123</text>
+                </inputExpression>
+                <inputValues>
+                    <text>[345, ? = 123, 456]</text>
+                </inputValues>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>null</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
                 </outputEntry>
             </rule>
         </decisionTable>

--- a/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable.dmn
+++ b/TestCases/compliance-level-3/1157-unarytests-decisiontable/1157-unarytests-decisiontable.dmn
@@ -12,7 +12,7 @@
 
     <decision name="decision001" id="_decision001">
         <!-- input expression is valid against input values - positive unary tests -->
-        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <!-- input expression 123 will satisfy unary tests and thus the rule for 123 will be satisfied -->
         <variable name="decision001"/>
         <decisionTable>
             <input>
@@ -37,7 +37,7 @@
 
     <decision name="decision002" id="_decision002">
         <!-- input expression is valid against input values - range -->
-        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <!-- input expression 123 will satisfy unary tests and thus the rule for 123 will be satisfied -->
         <variable name="decision002"/>
         <decisionTable>
             <input>
@@ -62,7 +62,7 @@
 
     <decision name="decision003" id="_decision003">
         <!-- input expression is valid against input values - '-' char -->
-        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <!-- input expression 123 will satisfy unary tests and thus the rule for 123 will be satisfied -->
         <variable name="decision003"/>
         <decisionTable>
             <input>
@@ -87,7 +87,7 @@
 
     <decision name="decision004" id="_decision004">
         <!-- input expression is valid against input values - negation using not() -->
-        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <!-- input expression 123 will satisfy unary tests and thus the rule for 123 will be satisfied -->
         <variable name="decision004"/>
         <decisionTable>
             <input>
@@ -113,7 +113,7 @@
 
     <decision name="decision005" id="_decision005">
         <!-- input expression is not valid against input values and will become null -->
-        <!-- input expression 123 will not match unary tests and thus the rule for null will match -->
+        <!-- input expression 123 will not satisfy unary tests and thus the rule for null will be satisfied -->
         <variable name="decision005"/>
         <decisionTable>
             <input>
@@ -138,7 +138,7 @@
 
     <decision name="decision006" id="_decision006">
         <!-- input expression is valid against input values - '?' symbol with built-in function-->
-        <!-- input expression "foo" will match unary tests and thus the rule for 123 will match -->
+        <!-- input expression "foo" will satisfy unary tests and thus the rule for 123 will be satisfied -->
         <variable name="decision006"/>
         <decisionTable>
             <input>
@@ -165,8 +165,8 @@
         <!-- input expression is not valid against input values - '?' symbol inside literal string -->
         <!-- in this case, the `string length("?") = 1` does evaluate to true, but, true !== "foo" and the
         vagueness of "applied to" comes in - the expression "string length("?") = 1" does not use the
-        special char "?", not is it a unary comparison .. so it is a mismatch -->
-        <!-- input expression "foo" will not match unary tests and thus the rule for null will match -->
+        special char "?", not is it a unary comparison .. so it is not satisfied -->
+        <!-- input expression "foo" will not satisfy unary tests and thus the rule for null will be satisfied -->
         <variable name="decision006_a"/>
         <decisionTable>
             <input>
@@ -190,15 +190,14 @@
     </decision>
 
     <decision name="decision006_b" id="_decision006_b">
-        <!-- input expression is not valid against input values - '?' symbol inside literal string -->
-        <!-- in this case, the `string length("?") = 1` does evaluate to true, but, true !== "foo" so
-        it is a mismatch -->
-        <!-- input expression 123 will not match unary tests and thus the rule for null will match -->
+        <!-- '?' symbol  -->
+        <!-- input expression "foo" executed against "?" does not return true and thus the rule for null will be satisfied -->
+        <!-- spec states that an expression with "?" must return a boolean "true" for it to be satisfied -->
         <variable name="decision006_b"/>
         <decisionTable>
             <input>
                 <inputExpression>
-                    <text>123</text>
+                    <text>"foo"</text>
                 </inputExpression>
                 <inputValues>
                     <text>?</text>
@@ -207,7 +206,7 @@
             <output/>
             <rule>
                 <inputEntry>
-                    <text>123</text>
+                    <text>null</text>
                 </inputEntry>
                 <outputEntry>
                     <text>"success"</text>
@@ -218,12 +217,13 @@
 
     <decision name="decision006_c" id="_decision006_c">
         <!-- '?' symbol  -->
-        <!-- input expression "foo" will match "?" and thus the rule for "123"" will match -->
+        <!-- input expression `true` executed against "?" returns true and thus the rule for true will be satisfied -->
+        <!-- spec states that an expression with "?" must return a boolean "true" for it to be satisfied -->
         <variable name="decision006_c"/>
         <decisionTable>
             <input>
                 <inputExpression>
-                    <text>"foo"</text>
+                    <text>true</text>
                 </inputExpression>
                 <inputValues>
                     <text>?</text>
@@ -232,7 +232,7 @@
             <output/>
             <rule>
                 <inputEntry>
-                    <text>"foo"</text>
+                    <text>true</text>
                 </inputEntry>
                 <outputEntry>
                     <text>"success"</text>
@@ -244,7 +244,7 @@
     <decision name="decision007" id="_decision007">
         <!-- input expression is valid against input values - input value has no text-->
         <!-- spec says text is optional -->
-        <!-- input expression 123 will match unary tests and thus the rule for 123 will match -->
+        <!-- input expression 123 will satisfy unary tests and thus the rule for 123 will be satisfied -->
         <variable name="decision007"/>
         <decisionTable>
             <input>
@@ -269,8 +269,8 @@
 
     <decision name="decision008" id="_decision008">
         <!-- Odd handling for boolean. 'true' is an expression. Unary tests permit expressions but
-         in this case the input expression false will not match unary tests and thus the
-         rule for null will match -->
+         in this case the input expression false will not satisfy unary tests and thus the
+         rule for null will be satisfied -->
         <variable name="decision008"/>
         <decisionTable>
             <input>
@@ -293,8 +293,39 @@
         </decisionTable>
     </decision>
 
+    <decision name="decision008_a" id="_decision008_a">
+        <!-- Odd handling for boolean. 'true' is an expression. Unary tests permit expressions but
+         in this case the input expression false will not satisfy unary tests and thus the
+         rule for null will be satisfied -->
+        <variable name="decision008_a"/>
+        <decisionTable>
+            <input>
+                <inputExpression>
+                    <text>false</text>
+                </inputExpression>
+            </input>
+            <output/>
+            <rule>
+                <inputEntry>
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"fail"</text>
+                </outputEntry>
+            </rule>
+            <rule>
+                <inputEntry>
+                    <text>false</text>
+                </inputEntry>
+                <outputEntry>
+                    <text>"success"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
     <decision name="decision009" id="_decision009">
-        <!-- table result matches output values -->
+        <!-- table result satisfies output values -->
         <variable name="decision009"/>
         <decisionTable>
             <input>
@@ -319,7 +350,7 @@
     </decision>
 
     <decision name="decision010" id="_decision010">
-        <!-- table result "foo" does not match output values "success" or "failure". Result
+        <!-- table result "foo" does not satisfy output values "success" or "failure". Result
         is null coerced -->
         <variable name="decision010"/>
         <decisionTable>
@@ -395,7 +426,7 @@
     </decision>
 
     <decision name="decision013" id="_decision013">
-        <!-- multiple output columns all match -->
+        <!-- multiple output columns all satisfied -->
         <variable name="decision013"/>
         <decisionTable>
             <input>
@@ -428,7 +459,7 @@
     </decision>
 
     <decision name="decision014" id="_decision014">
-        <!-- multiple output columns - one column mismatch -->
+        <!-- multiple output columns - one column not satisfied -->
         <variable name="decision014"/>
         <decisionTable>
             <input>
@@ -461,7 +492,7 @@
     </decision>
 
     <decision name="decision015" id="_decision015">
-        <!-- ? used in output values - match -->
+        <!-- ? used in output values - satisfied -->
         <variable name="decision015"/>
         <decisionTable>
             <input>
@@ -486,7 +517,7 @@
     </decision>
 
     <decision name="decision016" id="_decision016">
-        <!-- ? used in output values - mismatch -->
+        <!-- ? used in output values - not satisfied -->
         <variable name="decision016"/>
         <decisionTable>
             <input>


### PR DESCRIPTION
This may surprise you all, but we actually do not yet assert anywhere on the usage of unary tests for input and output values in decisions tables.  Given the recent changes to the spec regarding unary tests I thought I'd revisit the tests for decision tables unary tests.  There are none.  So ... here are some ...

There are some interesting things to note in here - specifically around the vagueness of the "applied to" part of the spec in alternative c. and booleans.  Please (please!) tell me if this is not correct.

Here is the new spec text:

```
A UnaryTests is satisfied if and only if one of the following alternatives is true: 

a) One of the expressions in the UnaryTests evaluates to a value, and the implicit value is equal to that value. 
b) One of the expressions in the UnaryTests evaluates to a list of values, and the implicit value is equal to at least one of the values in that list. 
c) One of the expressions in the UnaryTests evaluates to true when the implicit value is applied to it. 
d) One of the expressions in the UnaryTests is a boolean expression using the special ‘?’ variable and that expression evaluates to true when the implicit value is assigned to ‘?’.
```

What about all the stuff in table 55 for testing inclusion?  Like a list of ranges?  (we'll discuss in a moment).

here we go:

*Booleans* 

If I test boolean constant `false` against the unary tests with a boolean constant `true` - what do you expect?  At this time, we seem to be expecting that the unary test is not satisfied.

But, the constant value `true` _is_ an expression - and according to the "c" option above, if it evaluates to `true` then it is satisfied.  But ... in practice, that is not what people are expecting - I tried it and some existing tests failed (as I recall).  And this is where the kind of vague "applied to" thing comes in.  I _think_ the spec is assuming here that an "expression" is really a unary type comparison and not just any expression ... and 'applied to" really means that the expression takes into account the tested-for value.

So, if I tested `false` against (say) `=false`, the unary test is satisfied, and I think this is what option "c" is anticipating.  

Likewise, if I tested `false` against any non-unary expression that evaluates to `true` like (say) `1=1` then implicitly, I think we might expect it to be satisfied, but, this is simply an extension of the boolean constant `true` situation and it is not satisfied.

This applies to DT rules as well.  Here is a simple illustration.  An input expression of constant `false` with two rules.  The first to match against constant `true`, the second to match against constant `false`.  The first rule will not be satisfied, the second will.  So, an expression that simply evaluates to true is a bit weird.

```
    <decision name="decision" id="_decision">
        <variable name="decision"/>
        <decisionTable>
            <input>
                <inputExpression>
                    <text>false</text>
                </inputExpression>
            </input>
            <output/>
            <rule>
                <inputEntry>
                    <text>true</text>
                </inputEntry>
                <outputEntry>
                    <text>"fail"</text>
                </outputEntry>
            </rule>
            <rule>
                <inputEntry>
                    <text>false</text>
                </inputEntry>
                <outputEntry>
                    <text>"success"</text>
                </outputEntry>
            </rule>
        </decisionTable>
    </decision>
```

*A list of results*

This is option (b) is the new unary tests text.  "One of the expressions in the UnaryTests evaluates to a list of values, and the implicit value is equal to at least one of the values in that list."

This excludes the possibility that the list may contain ranges.  We have 'in' tests that assert that a list may contain ranges, and those ranges are tested against for inclusion, not equality.

In "Table 55: Semantics of decision table syntax"  we see reference to grammar rule 49.c.  Now, I'm a bit confused about what this table us really telling us, but I _think_ it dovetails with the syntax for unary tests.  Tell me if I am wrong.  The third row says that a list may have ranges and they are checked for inclusion, not equality. 

The new unary test text says that if a result is a list, then check for equality in the elements.  

Should the new text be ""One of the expressions in the UnaryTests evaluates to a list of values, and the implicit value is equal to at least one of the values in that list, or if the list item value is a range, then the implicit value is checked for inclusion in that range".

*usage of the '?' special char*

Now this can get a little weird.

The spec option (d) says the "One of the expressions in the UnaryTests is a boolean expression using the special ‘?’ variable and that expression evaluates to true when the implicit value is assigned to ‘?’."

So, if the expression does _not_ evaluate to boolean true .... ?  Like ... if I test (say) "foo" against the unary test "?" ... (with just the "?" special char nothing else) .... the expression will result in "foo" .. not `true` .... will this mean option (a), the equality check is satisfied instead?

Also ... (here we go), what if I test boolean constant `false` against "?", it it is a boolean expression but does not evaluate to `true` ....

Here I have assumed that even if it does not return `true`, and equality check as per option (a) can apply.

*usage of the '?' special char inside list results*

If I test (say) `123` against a unary test that has a list expression like `[345, ? = 123, 456]` then, this is testing against `[345, true, 456]` and, according to the spec, values inside lists are checked for equality and this would not be satisfied as the "?" char is not used as per option (d).

... or is it?  

Apols for the long PR description, but, sometimes when you lift the lid on something to try to understand it explicitly, you just kind of end up wondering what the spec is trying to say, not what it actually says ..





