### PR TITLE
DMN 15b - no-name imports

### DIFF
--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-001-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-001-A.dmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-001-A"
+             name="1158-noname-imports-001-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-001-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <!-- references an informationRequirement from an import  -->
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_model_b_decision001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_b_decision001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- references an knowledgeRequirement from an import -->
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_model_b_bkm001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>model_b_bkm001()</text>
+        </literalExpression>
+    </decision>
+
+    <!-- references an inputData from an import -->
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <informationRequirement>
+            <requiredInput href="#_model_b_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_b_input001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- uses an imported "string" typeRef - two tests will provide a string and a number
+    as input to assert the correct type is being used (we'll see a null for a number value) -->
+    <decision name="decision004" id="_decision004">
+        <variable name="decision004" typeRef="typeRefA"/>
+        <informationRequirement>
+            <requiredInput href="#_model_b_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_b_input001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-001-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-001-B.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-001-B"
+             name="1158-noname-imports-001-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="typeRefA">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <inputData name="model_b_input001" id="_model_b_input001">
+        <variable name="model_b_input001" typeRef="Any"/>
+    </inputData>
+
+    <!-- decision just returns its own name -->
+    <decision name="model_b_decision001" id="_model_b_decision001">
+        <variable name="model_b_decision001"/>
+        <literalExpression>
+            <text>"model_b_decision001"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- BKM just returns its own name -->
+    <businessKnowledgeModel name="model_b_bkm001" id="_model_b_bkm001">
+        <variable name="model_b_bkm001"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>"model_b_bkm001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-001-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-001-test.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-001-A.dmn</modelName>
+
+    <!-- model A uses a number of no-name imports from model B -->
+
+    <testCase id="001">
+        <description>will import a decision</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>will import a BKM</description>
+        <resultNode name="decision002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_bkm001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>will import an inputData</description>
+        <inputNode name="model_b_input001">
+            <value xsi:type="xsd:string">model_b_input001</value>
+        </inputNode>
+        <resultNode name="decision003" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_input001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004">
+        <!-- imported typeRef is a string, we test a string against it -->
+        <description>will import a typeRef</description>
+        <inputNode name="model_b_input001">
+            <value xsi:type="xsd:string">a string</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">a string</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_a">
+        <!-- imported typeRef is a string, we test a number against it -->
+        <description>will import a typeRef</description>
+        <inputNode name="model_b_input001">
+            <value xsi:type="xsd:decimal">1234</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-002-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-002-A.dmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-002-A"
+             name="1158-noname-imports-002-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-002-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <!-- references an informationRequirement from an import -->
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_model_a_decision001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_a_decision001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- references an knowledgeRequirement from an import -->
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_model_a_bkm001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>model_a_bkm001()</text>
+        </literalExpression>
+    </decision>
+
+    <!-- references an inputData from an import -->
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <informationRequirement>
+            <requiredInput href="#_model_a_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_a_input001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- uses an imported "string" typeRef - two tests will provide a string and a number
+    as input to assert the type is being used (we'll see a null for a number value) -->
+    <decision name="decision004" id="_decision004">
+        <variable name="decision004" typeRef="typeRefA"/>
+        <informationRequirement>
+            <requiredInput href="#_model_a_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_a_input001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-002-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-002-B.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-002-B"
+             name="1158-noname-imports-002-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <!-- does nothing but effectively import, then re-export everything in model C -->
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-002-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-002-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-002-C.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-002-C"
+             name="1158-noname-imports-002-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="typeRefA">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <inputData name="model_a_input001" id="_model_a_input001">
+        <variable name="model_a_input001" typeRef="Any"/>
+    </inputData>
+
+    <!-- decision just returns its own name -->
+    <decision name="model_a_decision001" id="_model_a_decision001">
+        <variable name="model_a_decision001"/>
+        <literalExpression>
+            <text>"model_a_decision001"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- BKM just returns its own name -->
+    <businessKnowledgeModel name="model_a_bkm001" id="_model_a_bkm001">
+        <variable name="model_a_bkm001"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>"model_a_bkm001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-002-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-002-test.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-002-A.dmn</modelName>
+
+    <!-- asserting that imports are recursive in that no-name imports of no-name imports
+    are also considered part of the current model namespace.  Here, the model A imports
+    model B, which subsequently imports stuff from model C.  The things in C
+    are used in A. -->
+
+    <!-- Effectively, Model B imports model C then 'exports' it all again -->
+
+    <testCase id="001">
+        <description>will import a decision</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>will import a BKM</description>
+        <resultNode name="decision002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_bkm001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>will import an inputData</description>
+        <inputNode name="model_a_input001">
+            <value xsi:type="xsd:string">model_a_input001</value>
+        </inputNode>
+        <resultNode name="decision003" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_input001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004">
+        <!-- imported typeRef is a string, we test a string against it -->
+        <description>will import a typeRef</description>
+        <inputNode name="model_a_input001">
+            <value xsi:type="xsd:string">a string</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">a string</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_a">
+        <!-- imported typeRef is a string, we test a number against it -->
+        <description>will import a typeRef</description>
+        <inputNode name="model_a_input001">
+            <value xsi:type="xsd:decimal">1234</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-003-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-003-A.dmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-003-A"
+             name="1158-noname-imports-003-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-003-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <itemDefinition name="typeRefA">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <inputData name="input001" id="_model_a_input001">
+        <variable name="input001" typeRef=""/>
+    </inputData>
+
+    <decision name="decision001" id="_model_a_decision001">
+        <variable name="decision001"/>
+        <literalExpression>
+            <text>"model_a_decision001"</text>
+        </literalExpression>
+    </decision>
+
+    <businessKnowledgeModel name="bkm001" id="_model_a_bkm001">
+        <variable name="bkm001"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>"model_a_bkm001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_model_a_bkm001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>bkm001()</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <informationRequirement>
+            <requiredInput href="#_model_a_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input001</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision004" id="_decision004">
+        <variable name="decision004" typeRef="typeRefA"/>
+        <informationRequirement>
+            <requiredInput href="#_model_a_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-003-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-003-B.dmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-003-B"
+             name="1158-noname-imports-003-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="typeRefA">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <inputData name="input001" id="_model_b_input001">
+        <variable name="input001" typeRef="Any"/>
+    </inputData>
+
+    <decision name="decision001" id="_model_b_decision001">
+        <variable name="decision001"/>
+        <literalExpression>
+            <text>"model_b_decision001"</text>
+        </literalExpression>
+    </decision>
+
+    <businessKnowledgeModel name="bkm001" id="_model_b_bkm001">
+        <variable name="model_b_bkm001"/>
+        <encapsulatedLogic>
+            <literalExpression>
+                <text>"model_b_bkm001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-003-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-003-test.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-003-A.dmn</modelName>
+
+    <!-- model A uses a number of no-name imports from model B whose names are already in model A.
+    There are no ID conflicts.   We do not expect anything from model B to override model A.-->
+
+    <testCase id="001">
+        <description>will not import a decision with name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>will not import a BKM with name conflict</description>
+        <resultNode name="decision002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_bkm001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>will not import an inputData with name conflict</description>
+        <inputNode name="input001">
+            <value xsi:type="xsd:string">model_a_input001</value>
+        </inputNode>
+        <resultNode name="decision003" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_input001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004">
+        <!-- imported typeRef is a string, we test a string against it -->
+        <description>will not import a typeRef with name conflict</description>
+        <inputNode name="input001">
+            <value xsi:type="xsd:string">a string</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">a string</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004_a">
+        <!-- imported typeRef is a string, we test a number against it -->
+        <description>will not import a typeRef with name conflict</description>
+        <inputNode name="input001">
+            <value xsi:type="xsd:decimal">1234</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:nil="true"/>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-004-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-004-A.dmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-004-A"
+             name="1158-noname-imports-004-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-004-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <!-- decision shares a name with a typeRef - this is permitted  -->
+    <decision name="allowableDuplicateName" id="_decision001">
+        <variable name="allowableDuplicateName" typeRef="allowableDuplicateName"/>
+        <literalExpression>
+            <text>"model_a_decision001"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-004-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-004-B.dmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-004-B"
+             name="1158-noname-imports-004-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="allowableDuplicateName">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-004-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-004-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-004-A.dmn</modelName>
+
+    <!-- model A has a decision called "allowableDuplicateName".  From model B, it uses an imported
+    typeRef also called "allowableDuplicateName".  Name clashes between drg elements and
+    import/itemDefinition are permitted by the spec.-->
+
+    <testCase id="001">
+        <description>imported typeRef name may already exist as a DRG name</description>
+        <resultNode name="allowableDuplicateName" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-005-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-005-A.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-005-A"
+             name="1158-noname-imports-005-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-005-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-005-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-005-B.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-005-B"
+             name="1158-noname-imports-005-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-005-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_b_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-005-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-005-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-005-C"
+             name="1158-noname-imports-005-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-005-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-005-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-005-A.dmn</modelName>
+
+    <!-- A imports B, B imports C-->
+    <!-- Both B & C define decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from model B to get the gig -->
+
+    <testCase id="001">
+        <description>nested imports - will not import a decision with name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-006-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-006-A.dmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-006-A"
+             name="1158-noname-imports-006-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-006-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-006-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-006-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-006-B.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-006-B"
+             name="1158-noname-imports-006-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_b_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-006-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-006-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-006-C"
+             name="1158-noname-imports-006-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-006-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-006-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-006-A.dmn</modelName>
+
+    <!-- A imports both B & C -->
+    <!-- Both B & C define decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from Model B to be the resolved one -->
+
+    <testCase id="001">
+        <description>multiple impoprts - will not import a decision with name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-007-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-007-A.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-007-A"
+             name="1158-noname-imports-007-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-007-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-007-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-007-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-007-B.dmn
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-007-B"
+             name="1158-noname-imports-007-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-007-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-007-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-007-C"
+             name="1158-noname-imports-007-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-007-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-007-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-007-A.dmn</modelName>
+
+    <!-- A imports both B & C -->
+    <!-- Only C defines decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from Model C to be used -->
+
+    <testCase id="001">
+        <description>multiple imports - will not import a decision with name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_c_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-A.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-008-A"
+             name="1158-noname-imports-008-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-008-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-B.dmn
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-008-B"
+             name="1158-noname-imports-008-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-008-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-008-D"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-008-C"
+             name="1158-noname-imports-008-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-D.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-D.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-008-D"
+             name="1158-noname-imports-008-D"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_d_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-008-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-008-A.dmn</modelName>
+
+    <!-- A imports B, B import C & D -->
+    <!-- Both C & D define decision002 -->
+    <!-- Model A uses decision002 -->
+    <!-- We expect the decision002 from Model C to be used -->
+
+    <testCase id="001">
+        <description>nested imports - will go deep</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_c_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-A.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-009-A"
+             name="1158-noname-imports-009-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-009-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-009-D"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-B.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-009-B"
+             name="1158-noname-imports-009-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-009-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-009-C"
+             name="1158-noname-imports-009-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-D.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-D.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-009-D"
+             name="1158-noname-imports-009-D"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_d_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-009-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-009-A.dmn</modelName>
+
+    <!-- A imports B & D, B import C -->
+    <!-- Both C & D define decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from Model C to be used -->
+
+    <testCase id="001">
+        <description>nest imports - will go deep</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_c_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-A.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-010-A"
+             name="1158-noname-imports-009-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-010-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-010-D"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-B.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-010-B"
+             name="1158-noname-imports-010-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-010-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-C.dmn
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-010-C"
+             name="1158-noname-imports-010-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-D.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-D.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-010-D"
+             name="1158-noname-imports-010-D"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_d_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-010-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-010-A.dmn</modelName>
+
+    <!-- A imports B & D, B import C -->
+    <!-- Only D defines decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from Model D to be used -->
+
+    <testCase id="001">
+        <description>will handle multiple imports within an import</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_d_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-011-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-011-A.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-011-A"
+             name="allowableDuplicateName"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+ >
+
+    <!-- definitions element shared a name with a typeRef - this is permitted  -->
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-011-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="allowableDuplicateName"/>
+        <literalExpression>
+            <text>"model_a_decision001"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-011-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-011-B.dmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-011-B"
+             name="1158-noname-imports-011-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="allowableDuplicateName">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-011-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-011-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-011-A.dmn</modelName>
+
+    <!--
+    Model A definitions name is "allowableDuplicateName".  From model B, it uses an imported typeRef
+    also called "allowableDuplicateName".  The name clash here is permitted in the spec.
+    -->
+
+    <testCase id="001">
+        <description>imported typeRef name will not conflict with definitions name</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-012-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-012-A.dmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-012-A"
+             name="allowableDuplicateName"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+ >
+
+    <!-- definitions element shares a name with an imported decision -->
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-012-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_allowableDuplicateName"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>allowableDuplicateName</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-012-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-012-B.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-012-B"
+             name="1158-noname-imports-012-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="allowableDuplicateName" id="_allowableDuplicateName">
+        <variable name="allowableDuplicateName"/>
+        <literalExpression>
+            <text>"allowableDuplicateName"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-012-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-012-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-012-A.dmn</modelName>
+
+    <!--
+
+    Model A definitions name is "allowableDuplicateName".  from model B, it uses an imported
+    decision also called "allowableDuplicateName".  The name clash here is permitted in
+    the spec.
+
+    -->
+
+    <testCase id="001">
+        <description>imported decision name will not conflict with definitions name</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">allowableDuplicateName</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-013-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-013-A.dmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-013-A"
+             name="1158-noname-imports-013-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-013-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <itemDefinition name="allowableDuplicateName">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <!-- imported decision shares a name with a typeRef - this is permitted  -->
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="allowableDuplicateName"/>
+        <informationRequirement>
+            <requiredDecision href="#_allowableDuplicateName"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>allowableDuplicateName</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-013-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-013-B.dmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-013-B"
+             name="1158-noname-imports-013-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="allowableDuplicateName" id="_allowableDuplicateName">
+        <variable name="allowableDuplicateName"/>
+        <literalExpression>
+            <text>"allowableDuplicateName"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-013-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-013-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-013-A.dmn</modelName>
+
+    <!--
+
+    Model A has a typeRef "allowableDuplicateName".  From model B, it uses an imported decision called
+    "allowableDuplicateName".  The name clash here is permitted in the spec.
+    -->
+
+    <testCase id="001">
+        <description>imported decision name will not conflict with typeRef name</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">allowableDuplicateName</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-014-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-014-A.dmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-014-A"
+             name="1158-noname-imports-014-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-014-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <literalExpression>
+            <text>"model_a_decision003"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-014-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-014-B.dmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-014-B"
+             name="1158-noname-imports-014-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision003"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision003</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <literalExpression>
+            <text>"model_b_decision003"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-014-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-014-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-014-A.dmn</modelName>
+
+    <!--
+    Model A has decision001 and decision003.  Model B has decision002 and decision003
+    Decision001 requires decision002 (in model B).  decision002 requires decision003 (in model B).
+
+    decision003 already exists in model A so, we expect the decision003 requirement in model B
+    to be resolved to the decision in model A
+    -->
+
+    <testCase id="001">
+        <description>requirement of imported decision will be resolved locally when there is a name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision003</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-015-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-015-A.dmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-015-A"
+             name="1158-noname-imports-015-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-015-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <literalExpression>
+            <text>"model_a_decision003"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-015-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-015-B.dmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-015-B"
+             name="1158-noname-imports-015-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <informationRequirement>
+            <!-- absolute href -->
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-015-B#_decision003"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision003</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <literalExpression>
+            <text>"model_b_decision003"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-015-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-015-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-015-A.dmn</modelName>
+
+    <!--
+    Model A has decision001 and decision003.  Model B has decision002 and also decision003.
+
+    Decision001 requires decision002 (in model B).  In model B, decision002 requires
+    decision003 BUT uses an fully qualified href (not just a local one) .
+
+    Decision003 already exists in model A, so, despite the fully qualified href we expect the
+    decision003 requirement in model B to be resolved to the decision in model A
+    -->
+
+    <testCase id="001">
+        <description>fully qualified local requirement href of imported decision will be resolved locally when there is a name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision003</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-016-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-016-A.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-016-A"
+             name="1158-noname-imports-016-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-016-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-016-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-016-B.dmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-016-B"
+             name="1158-noname-imports-016-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-016-A"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_b_decision002"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-016-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-016-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-016-A.dmn</modelName>
+
+    <!--
+    Model A imports B. B imports A.
+
+    We can't assert on anything real here to make sure a runtime does not go in a loop.  But,
+    consider this a sanity check.  The test should fail if a runtime does go into an infinite loop.
+    -->
+
+    <testCase id="001">
+        <description>dependency loop - a direct import imports the main model - will not crash</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-017-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-017-A.dmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-017-A"
+             name="1158-noname-imports-017-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-017-A"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_a_decision002"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-017-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-017-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-017-A.dmn</modelName>
+
+    <!--
+    Model A imports itself.
+
+    We can't assert on anything real here to make sure a runtime does not go in a loop.  But,
+    consider this a sanity check.  The test should fail if a runtime does go into an infinite loop.
+    -->
+
+    <testCase id="001">
+        <description>dependency loop - main model imports itself - will not crash</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-018-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-018-A.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-018-A"
+             name="1158-noname-imports-018-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-018-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-018-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-018-B.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-018-B"
+             name="1158-noname-imports-018-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-018-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-018-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-018-C.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-018-C"
+             name="1158-noname-imports-018-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-018-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-018-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-018-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-018-A.dmn</modelName>
+
+    <!--
+    Model A imports B, B imports C, C imports B.
+
+    We can't assert on anything real here to make sure a runtime does not go in a loop.  But,
+    consider this a sanity check.  The test should fail if a runtime does go into an infinite loop.
+    -->
+
+    <testCase id="001">
+        <description>dependency loop - nested import - will not crash</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_c_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-019-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-019-A.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-019-A"
+             name="1158-noname-imports-019-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-019-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-019-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-019-B.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-019-B"
+             name="1158-noname-imports-019-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+
+    <inputData name="input001" id="_input001">
+        <variable name="input001"/>
+    </inputData>
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredInput href="#_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input001</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-019-test.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-019-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-019-A.dmn</modelName>
+
+    <!--
+    Model A is empty and imports a decision and input data from model B.  The test case
+    will reference both those items in B
+    -->
+
+    <testCase id="001">
+        <description>imported decision and inputData are also "exported"</description>
+        <inputNode name="input001">
+            <value xsi:type="xsd:string">Foo</value>
+        </inputNode>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">Foo</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>


### PR DESCRIPTION
Hold onto your hats.  Tests for the new "no-name" import feature of DMN 1.5b.

Import tests can be very confusing, so, I have broken these up into lots of small models with an associated test suite comprising of (generally) just one assertion.

Here is the new spec text:

> Multiple imports with empty import names are allowed in the default namespace and their precedence is resolved according to their definition order. When the import name attribute is an empty string, the elements are imported in the default namespace of the model. 

> When a name collision occurs between an element in the default namespace and an imported element, the imported element does not replace the one already in the default namespace while the elements without name collision are imported.

Some things to note:

* "name collision" is not just _any_ name - itemDefinitions/imports can share names with DRG elements.  That has been exercised here.
* I think this should also be "id collision" as ids should be unique within a model AFAIK.  So, if an imported model has an id that conflicts with the importing model then it should also not be imported (IMO).  I wanted to test this, but, in strictness, the spec does not mention it.  I think we should test it ... somehow.
* some test models have "dependency loops" in that a model may directly or indirectly import its own namespace.  We can really test it, but, we can put it in tests as a sanity check for runtimes.
* tests here assert stuff about direct imports as well as imports of imports.

Each test suite has some small notes in it describing the model structure and expectations.

Comments welcome.