### PR TITLE
Change 'for loop' tests to match semantics in Section 10.3.2.14

### DIFF
--- a/TestCases/compliance-level-3/0084-feel-for-loops/0084-feel-for-loops-test-01.xml
+++ b/TestCases/compliance-level-3/0084-feel-for-loops/0084-feel-for-loops-test-01.xml
@@ -291,26 +291,19 @@
     </testCase>
 
     <testCase id="decision_023">
-        <description>a valid numeric range is permitted as iteration context</description>
+        <description>numeric range is not permitted as iteration domain</description>
         <resultNode name="decision_023" type="decision">
             <expected>
-                <list>
-                    <item><value xsi:type="xsd:decimal">1</value></item>
-                    <item><value xsi:type="xsd:decimal">2</value></item>
-                </list>
+                <value xsi:nil="true"/>
             </expected>
         </resultNode>
     </testCase>
 
     <testCase id="decision_024">
-        <description>a valid date range is permitted as iteration context</description>
+        <description>date range is not permitted as iteration domain</description>
         <resultNode name="decision_024" type="decision">
             <expected>
-                <list>
-                    <item><value xsi:type="xsd:date">1980-01-01</value></item>
-                    <item><value xsi:type="xsd:date">1980-01-02</value></item>
-                    <item><value xsi:type="xsd:date">1980-01-03</value></item>
-                </list>
+                <value xsi:nil="true"/>
             </expected>
         </resultNode>
     </testCase>

--- a/TestCases/compliance-level-3/0084-feel-for-loops/0084-feel-for-loops-test-01.xml
+++ b/TestCases/compliance-level-3/0084-feel-for-loops/0084-feel-for-loops-test-01.xml
@@ -290,6 +290,7 @@
         </resultNode>
     </testCase>
 
+<!--
     <testCase id="decision_023">
         <description>numeric range is not permitted as iteration domain</description>
         <resultNode name="decision_023" type="decision">
@@ -307,6 +308,7 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
     <testCase id="decision_025">
         <description>invalid (descending) range gives null</description>

--- a/TestCases/compliance-level-3/0084-feel-for-loops/0084-feel-for-loops.dmn
+++ b/TestCases/compliance-level-3/0084-feel-for-loops/0084-feel-for-loops.dmn
@@ -185,8 +185,9 @@
         </literalExpression>
     </decision>
 
+<!--
     <decision name="decision_023" id="_decision_023">
-        <!-- numeric range is not permitted as iteration domain -->
+        &lt;!&ndash; numeric range is not permitted as iteration domain &ndash;&gt;
         <variable name="decision_023"/>
         <literalExpression>
             <text>for i in [1..2] return i</text>
@@ -194,12 +195,13 @@
     </decision>
 
     <decision name="decision_024" id="_decision_024">
-        <!-- date range is not permitted as iteration domain -->
+        &lt;!&ndash; date range is not permitted as iteration domain &ndash;&gt;
         <variable name="decision_024"/>
         <literalExpression>
             <text>for i in [@"1980-01-01"..@"1980-01-03"] return i</text>
         </literalExpression>
     </decision>
+-->
 
     <decision name="decision_025" id="_decision_025">
         <!-- invalid range gives null (ranges may be descending) -->

--- a/TestCases/compliance-level-3/0084-feel-for-loops/0084-feel-for-loops.dmn
+++ b/TestCases/compliance-level-3/0084-feel-for-loops/0084-feel-for-loops.dmn
@@ -186,7 +186,7 @@
     </decision>
 
     <decision name="decision_023" id="_decision_023">
-        <!-- a valid numeric range is permitted as iteration context -->
+        <!-- numeric range is not permitted as iteration domain -->
         <variable name="decision_023"/>
         <literalExpression>
             <text>for i in [1..2] return i</text>
@@ -194,7 +194,7 @@
     </decision>
 
     <decision name="decision_024" id="_decision_024">
-        <!-- a valid date range is permitted as iteration context -->
+        <!-- date range is not permitted as iteration domain -->
         <variable name="decision_024"/>
         <literalExpression>
             <text>for i in [@"1980-01-01"..@"1980-01-03"] return i</text>


### PR DESCRIPTION
This is related to https://github.com/dmn-tck/tck/issues/681

According to Section 10.3.2.14, range expressions are not allowed as iteration context. For example, 1..2 is supported but not (1..2]

> An iteration context may either be an expression that returns a list of elements, or two expressions that return integers connected by “..”.