### PR TITLE
Add tests for imports with no prefix

### DIFF
--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-01-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-01-A.dmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-01-A"
+             name="1158-noname-imports-01-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-01-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <!-- references an informationRequirement from an import  -->
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-01-B#_model_b_decision001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_b_decision001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- references an knowledgeRequirement from an import -->
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="http://www.montera.com.au/spec/DMN/1158-noname-imports-01-B#_model_b_bkm001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>model_b_bkm001()</text>
+        </literalExpression>
+    </decision>
+
+    <!-- references an inputData from an import -->
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <informationRequirement>
+            <requiredInput href="http://www.montera.com.au/spec/DMN/1158-noname-imports-01-B#_model_b_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_b_input001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- uses an imported "string" typeRef - two tests will provide a string and a number
+    as input to assert the correct type is being used (we'll see a null for a number value) -->
+    <decision name="decision004" id="_decision004">
+        <variable name="decision004" typeRef="typeRefA"/>
+        <informationRequirement>
+            <requiredInput href="http://www.montera.com.au/spec/DMN/1158-noname-imports-01-B#_model_b_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_b_input001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-01-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-01-B.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-01-B"
+             name="1158-noname-imports-01-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="typeRefA">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <inputData name="model_b_input001" id="_model_b_input001">
+        <variable name="model_b_input001" typeRef="string"/>
+    </inputData>
+
+    <!-- decision just returns its own name -->
+    <decision name="model_b_decision001" id="_model_b_decision001">
+        <variable name="model_b_decision001" typeRef="string"/>
+        <literalExpression>
+            <text>"model_b_decision001"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- BKM just returns its own name -->
+    <businessKnowledgeModel name="model_b_bkm001" id="_model_b_bkm001">
+        <variable name="model_b_bkm001"/>
+        <encapsulatedLogic>
+            <literalExpression typeRef="string">
+                <text>"model_b_bkm001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-02-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-02-A.dmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-A"
+             name="1158-noname-imports-02-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <!-- references an informationRequirement from an import -->
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-C#_model_a_decision001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_a_decision001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- references an knowledgeRequirement from an import -->
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-C#_model_a_bkm001"/>
+        </knowledgeRequirement>
+        <literalExpression>
+            <text>model_a_bkm001()</text>
+        </literalExpression>
+    </decision>
+
+    <!-- references an inputData from an import -->
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003"/>
+        <informationRequirement>
+            <requiredInput href="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-C#_model_a_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_a_input001</text>
+        </literalExpression>
+    </decision>
+
+    <!-- uses an imported "string" typeRef - two tests will provide a string and a number
+    as input to assert the type is being used (we'll see a null for a number value) -->
+    <decision name="decision004" id="_decision004">
+        <variable name="decision004" typeRef="typeRefA"/>
+        <informationRequirement>
+            <requiredInput href="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-C#_model_a_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>model_a_input001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-02-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-02-B.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-B"
+             name="1158-noname-imports-02-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <!-- does nothing but effectively import, then re-export everything in model C -->
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-02-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-02-C.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-02-C"
+             name="1158-noname-imports-02-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="typeRefA">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <inputData name="model_a_input001" id="_model_a_input001">
+        <variable name="model_a_input001" typeRef="string"/>
+    </inputData>
+
+    <!-- decision just returns its own name -->
+    <decision name="model_a_decision001" id="_model_a_decision001">
+        <variable name="model_a_decision001" typeRef="string"/>
+        <literalExpression>
+            <text>"model_a_decision001"</text>
+        </literalExpression>
+    </decision>
+
+    <!-- BKM just returns its own name -->
+    <businessKnowledgeModel name="model_a_bkm001" id="_model_a_bkm001">
+        <variable name="model_a_bkm001"/>
+        <encapsulatedLogic>
+            <literalExpression typeRef="string">
+                <text>"model_a_bkm001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-03-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-03-A.dmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-03-A"
+             name="1158-noname-imports-03-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-03-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <itemDefinition name="typeRefA">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <inputData name="input001" id="_model_a_input001">
+        <variable name="input001" typeRef="string"/>
+    </inputData>
+
+    <decision name="decision001" id="_model_a_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <literalExpression>
+            <text>"model_a_decision001"</text>
+        </literalExpression>
+    </decision>
+
+    <businessKnowledgeModel name="bkm001" id="_model_a_bkm001">
+        <variable name="bkm001"/>
+        <encapsulatedLogic>
+            <literalExpression typeRef="string">
+                <text>"model_a_bkm001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002"/>
+        <knowledgeRequirement>
+            <requiredKnowledge href="#_model_a_bkm001"/>
+        </knowledgeRequirement>
+        <literalExpression typeRef="string">
+            <text>bkm001()</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003" typeRef="string"/>
+        <informationRequirement>
+            <requiredInput href="#_model_a_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input001</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision004" id="_decision004">
+        <variable name="decision004" typeRef="typeRefA"/>
+        <informationRequirement>
+            <requiredInput href="#_model_a_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input001</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-03-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-03-B.dmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-03-B"
+             name="1158-noname-imports-03-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="typeRefA">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <inputData name="input001" id="_model_b_input001">
+        <variable name="input001" typeRef="string"/>
+    </inputData>
+
+    <decision name="decision001" id="_model_b_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <literalExpression>
+            <text>"model_b_decision001"</text>
+        </literalExpression>
+    </decision>
+
+    <businessKnowledgeModel name="bkm001" id="_model_b_bkm001">
+        <variable name="model_b_bkm001"/>
+        <encapsulatedLogic>
+            <literalExpression typeRef="string">
+                <text>"model_b_bkm001"</text>
+            </literalExpression>
+        </encapsulatedLogic>
+    </businessKnowledgeModel>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-04-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-04-A.dmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-04-A"
+             name="1158-noname-imports-04-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-04-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <!-- decision shares a name with a typeRef - this is permitted  -->
+    <decision name="allowableDuplicateName" id="_decision001">
+        <variable name="allowableDuplicateName" typeRef="allowableDuplicateName"/>
+        <literalExpression>
+            <text>"model_a_decision001"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-04-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-04-B.dmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-04-B"
+             name="1158-noname-imports-04-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="allowableDuplicateName">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-05-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-05-A.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-05-A"
+             name="1158-noname-imports-05-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-05-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-05-B#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-05-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-05-B.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-05-B"
+             name="1158-noname-imports-05-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-05-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_b_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-05-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-05-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-05-C"
+             name="1158-noname-imports-05-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-06-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-06-A.dmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-06-A"
+             name="1158-noname-imports-06-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-06-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-06-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-06-B#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-06-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-06-B.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-06-B"
+             name="1158-noname-imports-06-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_b_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-06-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-06-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-06-C"
+             name="1158-noname-imports-06-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-07-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-07-A.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-07-A"
+             name="1158-noname-imports-07-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-07-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-07-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-07-C#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-07-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-07-B.dmn
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-07-B"
+             name="1158-noname-imports-07-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-07-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-07-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-07-C"
+             name="1158-noname-imports-07-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-08-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-08-A.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-A"
+             name="1158-noname-imports-08-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-C#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-08-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-08-B.dmn
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-B"
+             name="1158-noname-imports-08-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-D"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-08-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-08-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-C"
+             name="1158-noname-imports-08-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-08-D.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-08-D.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-08-D"
+             name="1158-noname-imports-08-D"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_d_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-09-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-09-A.dmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-A"
+             name="1158-noname-imports-09-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-D"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-C#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-09-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-09-B.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-B"
+             name="1158-noname-imports-09-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-09-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-09-C.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-C"
+             name="1158-noname-imports-09-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-09-D.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-09-D.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-09-D"
+             name="1158-noname-imports-09-D"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_d_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-10-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-10-A.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-10-A"
+             name="1158-noname-imports-10-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-10-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-10-D"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-10-D#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-10-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-10-B.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-10-B"
+             name="1158-noname-imports-10-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-10-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-10-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-10-C.dmn
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-10-C"
+             name="1158-noname-imports-10-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-10-D.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-10-D.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-10-D"
+             name="1158-noname-imports-10-D"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_d_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-11-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-11-A.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-11-A"
+             name="1158-noname-imports-11-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+ >
+
+    <!-- definitions element shared a name with a typeRef - this is permitted  -->
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-11-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="allowableDuplicateName"/>
+        <literalExpression>
+            <text>"model_a_decision001"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-11-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-11-B.dmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-11-B"
+             name="1158-noname-imports-11-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <itemDefinition name="allowableDuplicateName">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-12-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-12-A.dmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-12-A"
+             name="1158-noname-imports-12-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+ >
+
+    <!-- definitions element shares a name with an imported decision -->
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-12-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-12-B#_allowableDuplicateName"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>allowableDuplicateName</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-12-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-12-B.dmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-12-B"
+             name="1158-noname-imports-12-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="allowableDuplicateName" id="_allowableDuplicateName">
+        <variable name="allowableDuplicateName" typeRef="string"/>
+        <literalExpression>
+            <text>"allowableDuplicateName"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-13-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-13-A.dmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-13-A"
+             name="1158-noname-imports-13-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-13-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <itemDefinition name="allowableDuplicateName">
+        <typeRef>string</typeRef>
+    </itemDefinition>
+
+    <!-- imported decision shares a name with a typeRef - this is permitted  -->
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="allowableDuplicateName"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-13-B#_allowableDuplicateName"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>allowableDuplicateName</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-13-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-13-B.dmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-13-B"
+             name="1158-noname-imports-13-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="allowableDuplicateName" id="_allowableDuplicateName">
+        <variable name="allowableDuplicateName" typeRef="string"/>
+        <literalExpression>
+            <text>"allowableDuplicateName"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-14-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-14-A.dmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-14-A"
+             name="1158-noname-imports-14-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-14-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-14-B#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003" typeRef="string"/>
+        <literalExpression>
+            <text>"model_a_decision003"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-14-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-14-B.dmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-14-B"
+             name="1158-noname-imports-14-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="#_decision003"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision003</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003" typeRef="string"/>
+        <literalExpression>
+            <text>"model_b_decision003"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-15-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-15-A.dmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-15-A"
+             name="1158-noname-imports-15-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-15-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-15-B#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003" typeRef="string"/>
+        <literalExpression>
+            <text>"model_a_decision003"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-15-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-15-B.dmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-15-B"
+             name="1158-noname-imports-15-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <informationRequirement>
+            <!-- absolute href -->
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-15-B#_decision003"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision003</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision003" id="_decision003">
+        <variable name="decision003" typeRef="string"/>
+        <literalExpression>
+            <text>"model_b_decision003"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-16-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-16-A.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-16-A"
+             name="1158-noname-imports-16-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-16-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-16-B#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-16-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-16-B.dmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-16-B"
+             name="1158-noname-imports-16-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-16-A"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_b_decision002"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-17-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-17-A.dmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-17-A"
+             name="1158-noname-imports-17-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-17-A"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-17-A#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_a_decision002"</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-18-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-18-A.dmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-18-A"
+             name="1158-noname-imports-18-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-18-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-18-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredDecision href="http://www.montera.com.au/spec/DMN/1158-noname-imports-18-C#_decision002"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>decision002</text>
+        </literalExpression>
+    </decision>
+
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-18-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-18-B.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-18-B"
+             name="1158-noname-imports-18-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-18-C"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-18-C.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-18-C.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-18-C"
+             name="1158-noname-imports-18-C"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-18-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+    <decision name="decision002" id="_decision002">
+        <variable name="decision002" typeRef="string"/>
+        <literalExpression>
+            <text>"model_c_decision002"</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-19-A.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-19-A.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-19-A"
+             name="1158-noname-imports-19-A"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+    <import namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-19-B"
+            name=""
+            importType="https://www.omg.org/spec/DMN/20230324/MODEL/"
+    />
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-19-B.dmn
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-19-B.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions namespace="http://www.montera.com.au/spec/DMN/1158-noname-imports-19-B"
+             name="1158-noname-imports-19-B"
+             id="_i9fboPUUEeesLuP4RHs4vA"
+             xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+>
+
+    <inputData name="input001" id="_input001">
+        <variable name="input001" typeRef="string"/>
+    </inputData>
+
+    <decision name="decision001" id="_decision001">
+        <variable name="decision001" typeRef="string"/>
+        <informationRequirement>
+            <requiredInput href="#_input001"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>input001</text>
+        </literalExpression>
+    </decision>
+
+</definitions>
+

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-01.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-01.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-01-A.dmn</modelName>
+
+    <!-- model A uses a number of no-name imports from model B -->
+
+    <testCase id="001">
+        <description>will import a decision</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>will import a BKM</description>
+        <resultNode name="decision002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_bkm001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>will import an inputData</description>
+        <inputNode name="model_b_input001">
+            <value xsi:type="xsd:string">model_b_input001</value>
+        </inputNode>
+        <resultNode name="decision003" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_input001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004">
+        <!-- imported typeRef is a string, we test a string against it -->
+        <description>will import a typeRef</description>
+        <inputNode name="model_b_input001">
+            <value xsi:type="xsd:string">a string</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">a string</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+<!--    <testCase id="004_a">-->
+<!--        &lt;!&ndash; imported typeRef is a string, we test a number against it &ndash;&gt;-->
+<!--        <description>will import a typeRef</description>-->
+<!--        <inputNode name="model_b_input001">-->
+<!--            <value xsi:type="xsd:decimal">1234</value>-->
+<!--        </inputNode>-->
+<!--        <resultNode name="decision004" type="decision">-->
+<!--            <expected>-->
+<!--                <value xsi:nil="true"/>-->
+<!--            </expected>-->
+<!--        </resultNode>-->
+<!--    </testCase>-->
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-02.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-02.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-02-A.dmn</modelName>
+
+    <!-- asserting that imports are recursive in that no-name imports of no-name imports
+    are also considered part of the current model namespace.  Here, the model A imports
+    model B, which subsequently imports stuff from model C.  The things in C
+    are used in A. -->
+
+    <!-- Effectively, Model B imports model C then 'exports' it all again -->
+
+    <testCase id="001">
+        <description>will import a decision</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>will import a BKM</description>
+        <resultNode name="decision002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_bkm001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>will import an inputData</description>
+        <inputNode name="model_a_input001">
+            <value xsi:type="xsd:string">model_a_input001</value>
+        </inputNode>
+        <resultNode name="decision003" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_input001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004">
+        <!-- imported typeRef is a string, we test a string against it -->
+        <description>will import a typeRef</description>
+        <inputNode name="model_a_input001">
+            <value xsi:type="xsd:string">a string</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">a string</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+<!--    <testCase id="004_a">-->
+<!--        &lt;!&ndash; imported typeRef is a string, we test a number against it &ndash;&gt;-->
+<!--        <description>will import a typeRef</description>-->
+<!--        <inputNode name="model_a_input001">-->
+<!--            <value xsi:type="xsd:decimal">1234</value>-->
+<!--        </inputNode>-->
+<!--        <resultNode name="decision004" type="decision">-->
+<!--            <expected>-->
+<!--                <value xsi:nil="true"/>-->
+<!--            </expected>-->
+<!--        </resultNode>-->
+<!--    </testCase>-->
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-03.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-03.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-03-A.dmn</modelName>
+
+    <!-- model A uses a number of no-name imports from model B whose names are already in model A.
+    There are no ID conflicts.   We do not expect anything from model B to override model A.-->
+
+    <testCase id="001">
+        <description>will not import a decision with name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="002">
+        <description>will not import a BKM with name conflict</description>
+        <resultNode name="decision002" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_bkm001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="003">
+        <description>will not import an inputData with name conflict</description>
+        <inputNode name="input001">
+            <value xsi:type="xsd:string">model_a_input001</value>
+        </inputNode>
+        <resultNode name="decision003" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_input001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="004">
+        <!-- imported typeRef is a string, we test a string against it -->
+        <description>will not import a typeRef with name conflict</description>
+        <inputNode name="input001">
+            <value xsi:type="xsd:string">a string</value>
+        </inputNode>
+        <resultNode name="decision004" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">a string</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+<!--    <testCase id="004_a">-->
+<!--        &lt;!&ndash; imported typeRef is a string, we test a number against it &ndash;&gt;-->
+<!--        <description>will not import a typeRef with name conflict</description>-->
+<!--        <inputNode name="input001">-->
+<!--            <value xsi:type="xsd:decimal">1234</value>-->
+<!--        </inputNode>-->
+<!--        <resultNode name="decision004" type="decision">-->
+<!--            <expected>-->
+<!--                <value xsi:nil="true"/>-->
+<!--            </expected>-->
+<!--        </resultNode>-->
+<!--    </testCase>-->
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-04.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-04.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-04-A.dmn</modelName>
+
+    <!-- model A has a decision called "allowableDuplicateName".  From model B, it uses an imported
+    typeRef also called "allowableDuplicateName".  Name clashes between drg elements and
+    import/itemDefinition are permitted by the spec.-->
+
+    <testCase id="001">
+        <description>imported typeRef name may already exist as a DRG name</description>
+        <resultNode name="allowableDuplicateName" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-05.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-05.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-05-A.dmn</modelName>
+
+    <!-- A imports B, B imports C-->
+    <!-- Both B & C define decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from model B to get the gig -->
+
+    <testCase id="001">
+        <description>nested imports - will not import a decision with name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-06.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-06.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-06-A.dmn</modelName>
+
+    <!-- A imports both B & C -->
+    <!-- Both B & C define decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from Model B to be the resolved one -->
+
+<!--    <testCase id="001">-->
+<!--        <description>multiple impoprts - will not import a decision with name conflict</description>-->
+<!--        <resultNode name="decision001" type="decision">-->
+<!--            <expected>-->
+<!--                <value xsi:type="xsd:string">model_b_decision002</value>-->
+<!--            </expected>-->
+<!--        </resultNode>-->
+<!--    </testCase>-->
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-07.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-07.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-07-A.dmn</modelName>
+
+    <!-- A imports both B & C -->
+    <!-- Only C defines decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from Model C to be used -->
+
+    <testCase id="001">
+        <description>multiple imports - will not import a decision with name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_c_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-08.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-08.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-08-A.dmn</modelName>
+
+    <!-- A imports B, B import C & D -->
+    <!-- Both C & D define decision002 -->
+    <!-- Model A uses decision002 -->
+    <!-- We expect the decision002 from Model C to be used -->
+
+    <testCase id="001">
+        <description>nested imports - will go deep</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_c_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-09.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-09.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-09-A.dmn</modelName>
+
+    <!-- A imports B & D, B import C -->
+    <!-- Both C & D define decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from Model C to be used -->
+
+    <testCase id="001">
+        <description>nest imports - will go deep</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_c_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-10.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-10.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-10-A.dmn</modelName>
+
+    <!-- A imports B & D, B import C -->
+    <!-- Only D defines decision002 -->
+    <!-- A uses decision002 -->
+    <!-- We expect the decision002 from Model D to be used -->
+
+    <testCase id="001">
+        <description>will handle multiple imports within an import</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_d_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-11.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-11.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-11-A.dmn</modelName>
+
+    <!--
+    Model A definitions name is "allowableDuplicateName".  From model B, it uses an imported typeRef
+    also called "allowableDuplicateName".  The name clash here is permitted in the spec.
+    -->
+
+    <testCase id="001">
+        <description>imported typeRef name will not conflict with definitions name</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision001</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-12.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-12.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-12-A.dmn</modelName>
+
+    <!--
+
+    Model A definitions name is "allowableDuplicateName".  from model B, it uses an imported
+    decision also called "allowableDuplicateName".  The name clash here is permitted in
+    the spec.
+
+    -->
+
+    <testCase id="001">
+        <description>imported decision name will not conflict with definitions name</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">allowableDuplicateName</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-13.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-13.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-13-A.dmn</modelName>
+
+    <!--
+
+    Model A has a typeRef "allowableDuplicateName".  From model B, it uses an imported decision called
+    "allowableDuplicateName".  The name clash here is permitted in the spec.
+    -->
+
+    <testCase id="001">
+        <description>imported decision name will not conflict with typeRef name</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">allowableDuplicateName</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-14.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-14.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-14-A.dmn</modelName>
+
+    <!--
+    Model A has decision001 and decision003.  Model B has decision002 and decision003
+    Decision001 requires decision002 (in model B).  decision002 requires decision003 (in model B).
+
+    decision003 already exists in model A so, we expect the decision003 requirement in model B
+    to be resolved to the decision in model B
+    -->
+
+    <testCase id="001">
+        <description>requirement of imported decision will be resolved locally when there is a name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision003</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-15.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-15.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-15-A.dmn</modelName>
+
+    <!--
+    Model A has decision001 and decision003.  Model B has decision002 and also decision003.
+
+    Decision001 requires decision002 (in model B).  In model B, decision002 requires
+    decision003 BUT uses an fully qualified href (not just a local one) .
+
+    Decision003 already exists in model A, so, we expect the
+    decision003 requirement in model B to be resolved to the decision in model B
+    -->
+
+    <testCase id="001">
+        <description>fully qualified local requirement href of imported decision will be resolved locally when there is a name conflict</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision003</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-16.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-16.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-16-A.dmn</modelName>
+
+    <!--
+    Model A imports B. B imports A.
+
+    We can't assert on anything real here to make sure a runtime does not go in a loop.  But,
+    consider this a sanity check.  The test should fail if a runtime does go into an infinite loop.
+    -->
+
+    <testCase id="001">
+        <description>dependency loop - a direct import imports the main model - will not crash</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_b_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-17.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-17.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-17-A.dmn</modelName>
+
+    <!--
+    Model A imports itself.
+
+    We can't assert on anything real here to make sure a runtime does not go in a loop.  But,
+    consider this a sanity check.  The test should fail if a runtime does go into an infinite loop.
+    -->
+
+    <testCase id="001">
+        <description>dependency loop - main model imports itself - will not crash</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_a_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-18.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-18.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-18-A.dmn</modelName>
+
+    <!--
+    Model A imports B, B imports C, C imports B.
+
+    We can't assert on anything real here to make sure a runtime does not go in a loop.  But,
+    consider this a sanity check.  The test should fail if a runtime does go into an infinite loop.
+    -->
+
+    <testCase id="001">
+        <description>dependency loop - nested import - will not crash</description>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">model_c_decision002</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>

--- a/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-19.xml
+++ b/TestCases/compliance-level-3/1158-noname-imports/1158-noname-imports-test-19.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Contributed to DMN TCK by StrayAlien -->
+<testCases xmlns="http://www.omg.org/spec/DMN/20160719/testcase"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation=""
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <modelName>1158-noname-imports-19-B.dmn</modelName>
+
+    <!--
+    Model A is empty and imports a decision and input data from model B.  The test case
+    will reference both those items in B
+    -->
+
+    <testCase id="001">
+        <description>imported decision and inputData are also "exported"</description>
+        <inputNode name="input001">
+            <value xsi:type="xsd:string">Foo</value>
+        </inputNode>
+        <resultNode name="decision001" type="decision">
+            <expected>
+                <value xsi:type="xsd:string">Foo</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+</testCases>


### PR DESCRIPTION
This PR contains fixes for https://github.com/dmn-tck/tck/pull/674 as per discussion in the DMN RTF:
- hrefs contain DMN namespaces not locations
- href must contain a namespace when the imported DRG element is not  defined in the current DMN file
- 