### PR TITLE
[DMN 1.6] Change test case to match DMN16-50

### DIFF
--- a/TestCases/compliance-level-3/0089-nested-inputdata-imports/0089-nested-inputdata-imports-test-01.xml
+++ b/TestCases/compliance-level-3/0089-nested-inputdata-imports/0089-nested-inputdata-imports-test-01.xml
@@ -11,23 +11,12 @@
 
   <testCase id="001" invocableName="Evaluation DS" type="decision">
     <description>Nested imports of InputData following GITHUB DMN TCK 274</description>
-    <inputNode name="Model B">
-      <component name="modelA">
-        <component name="Person name">
+    <inputNode name="Person name" namespace="http://www.trisotech.com/definitions/_ae5b3c17-1ac3-4e1d-b4f9-2cf861aec6d9">
           <value xsi:type="xsd:string">B.A.John</value>
-        </component>
-      </component>
-    </inputNode>
-    <inputNode name="Model B2">
-      <component name="modelA">
-        <component name="Person name">
-          <value xsi:type="xsd:string">B2.A.John2</value>
-        </component>
-      </component>
     </inputNode>
     <resultNode name="Model C Decision based on Bs">
       <expected>
-        <value xsi:type="xsd:string">B: Evaluating Say Hello to: Hello, B.A.John; B2: Evaluating Say Hello to: Hello, B2.A.John2</value>
+        <value xsi:type="xsd:string">B: Evaluating Say Hello to: Hello, B.A.John; B2: Evaluating Say Hello to: Hello, B.A.John</value>
       </expected>
     </resultNode>
   </testCase>


### PR DESCRIPTION
The semantics of bindings for multiple imports has been clarified:

`An InformationItem element contained in an InputData is assigned a value by an external data source that is attached at runtime. When an InputData is imported several times via transitive imports, the contained InformationItem is assigned only once and holds the same value.`

