### PR TITLE
Add InputNodes for all required inputs even if they are bound to null.

### DIFF
--- a/TestCases/compliance-level-3/1161-boxed-list-expression/1161-boxed-list-expression-test-01.xml
+++ b/TestCases/compliance-level-3/1161-boxed-list-expression/1161-boxed-list-expression-test-01.xml
@@ -36,6 +36,15 @@
 
     <testCase id="002">
         <description>null inputs</description>
+        <inputNode name="A">
+            <value xsi:nil="true"/>
+        </inputNode>
+        <inputNode name="B">
+            <value xsi:nil="true"/>
+        </inputNode>
+        <inputNode name="C">
+            <value xsi:nil="true"/>
+        </inputNode>
         <resultNode name="BList" type="decision">
             <expected>
                 <list>


### PR DESCRIPTION
Following our discussion on 18/12/2025, I added InputNodes for all required inputs, even if they are bound to null.

I created the DMN RTF issue here https://issues.omg.org/browse/INBOX-2420


