### PR TITLE
Add new name attribute for TestCases

### DIFF
--- a/TestCases/testCases.xsd
+++ b/TestCases/testCases.xsd
@@ -11,6 +11,7 @@
 	<xs:element name="testCases">
 		<xs:complexType>
 			<xs:sequence>
+				<xs:element name="testCasesName" type="xs:string" minOccurs="0"/>
 				<xs:element name="modelName" type="xs:string" minOccurs="0"/>
 				<xs:element name="labels" minOccurs="0">
 					<xs:complexType>


### PR DESCRIPTION
We have a use case where the TestCases need to have a name, it cannot be inferred from the name of the TCK file.