### PR TITLE
Add new test cases for decision services

### DIFF
--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
@@ -18,6 +18,7 @@
         </resultNode>
     </testCase>
 
+<!--
     <testCase id="001a">
         <description>Test DS without using invocableName and type (equivalent to test 001)</description>
         <resultNode name="decisionService_001">
@@ -26,6 +27,7 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
     <testCase id="002" invocableName="decisionService_002" type="decisionService">
         <description>Direct invocation: with an input decision</description>
@@ -254,6 +256,7 @@
         </resultNode>
     </testCase>
 
+<!--
     <testCase id="015_a">
         <description>Direct invocation: with no params</description>
         <resultNode name="decisionService_015">
@@ -267,5 +270,6 @@
             </expected>
         </resultNode>
     </testCase>
+-->
 
 </testCases>

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services-test-01.xml
@@ -18,6 +18,15 @@
         </resultNode>
     </testCase>
 
+    <testCase id="001a">
+        <description>Test DS without using invocableName and type (equivalent to test 001)</description>
+        <resultNode name="decisionService_001">
+            <expected>
+                <value xsi:type="xsd:string">foo</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
     <testCase id="002" invocableName="decisionService_002" type="decisionService">
         <description>Direct invocation: with an input decision</description>
         <!-- we expect the input param value to 'override' the actual impl of 'decision_002_input' -->
@@ -225,6 +234,35 @@
                 </component>
                 <component name="decisionService_014">
                     <value xsi:type="xsd:string">A B</value> <!-- DMN13-163 Decision Service output value in the case of single output Decision -->
+                </component>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <!-- DS with multiple output decisions -->
+    <testCase id="015" invocableName="decisionService_015" type="decisionService">
+        <description>Direct invocation: with no params</description>
+        <resultNode name="decision_015_1">
+            <expected>
+                <value xsi:type="xsd:string">15_1</value>
+            </expected>
+        </resultNode>
+        <resultNode name="decision_015_2">
+            <expected>
+                <value xsi:type="xsd:string">15_2</value>
+            </expected>
+        </resultNode>
+    </testCase>
+
+    <testCase id="015_a">
+        <description>Direct invocation: with no params</description>
+        <resultNode name="decisionService_015">
+            <expected>
+                <component name="decision_015_1">
+                    <value xsi:type="xsd:string">15_1</value>
+                </component>
+                <component name="decision_015_2">
+                    <value xsi:type="xsd:string">15_2</value>
                 </component>
             </expected>
         </resultNode>

--- a/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
+++ b/TestCases/compliance-level-3/0085-decision-services/0085-decision-services.dmn
@@ -593,5 +593,25 @@
         <variable name="inputData_014_1" typeRef="string"/>
     </inputData>
 
+    <!-- DS with multiple output decisions: no params -->
+    <decisionService name="decisionService_015" id="_decisionService_015">
+        <variable name="decisionService_015"/>
+        <outputDecision href="#_decision_015_1"/>
+        <outputDecision href="#_decision_015_2"/>
+    </decisionService>
+
+    <decision name="decision_015_1" id="_decision_015_1">
+        <variable name="decision_015_1"/>
+        <literalExpression>
+            <text>"15_1"</text>
+        </literalExpression>
+    </decision>
+
+    <decision name="decision_015_2" id="_decision_015_2">
+        <variable name="decision_015_2"/>
+        <literalExpression>
+            <text>"15_2"</text>
+        </literalExpression>
+    </decision>
 
 </definitions>


### PR DESCRIPTION
The purpose of the PR is:
- add test cases for DSs with multiple output decisions
- add test cases for DSs expressed in a much simpler way, without using the invocableName and type. IMO it is more user-friendly.